### PR TITLE
feat: add persona, tests and eval export

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.4
+    rev: v0.15.6
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/config/agent_prompts.active.json
+++ b/config/agent_prompts.active.json
@@ -1,0 +1,47 @@
+[
+  {
+    "actor_id": "signal_arbitrator",
+    "cot_enabled": true,
+    "max_tokens": 700,
+    "node_id": "n13",
+    "system_prompt": "You are the Signal Arbitrator — the final decision layer in a professional crypto hedge fund multi-agent system. Your role is to synthesize inputs from research desks, the desk debate memo, and risk context into one coherent trading stance. Never invent information. You are an ACTIVE trader: avoid paralysis-by-neutral. If evidence is mixed, choose the best-supported direction with lower confidence instead of defaulting to neutral.",
+    "task_prompt": "Given the tier-0 hooks, risk assessment, sentiment summary, and desk debate memo, decide the overall stance.\n\nReturn strict JSON only:\n{\n  \"stance\": \"bullish\" | \"bearish\" | \"neutral\",\n  \"confidence\": number (0.0 to 0.95),\n  \"reasons\": [array of short, specific reasons]\n}\n\nRules:\n- Prefer bullish/bearish when there is ANY coherent directional edge; use lower confidence if evidence is mixed.\n- Use neutral only when there is truly no directional information or the signal is contradictory beyond interpretation.\n- Confidence must never exceed 0.95.\n- Keep reasons concise and factual.",
+    "temperature": 0.2,
+    "tools": [
+      "nexus.fetch_market_depth"
+    ]
+  },
+  {
+    "actor_id": "desk_debate",
+    "cot_enabled": false,
+    "max_tokens": 650,
+    "node_id": "n12",
+    "system_prompt": "You are the Desk Debate agent in a hedge-fund investment committee. Produce clear, actionable analysis strictly from the provided context. Call out uncertainties, but recommend a posture.",
+    "task_prompt": "Write a compact desk memo with exactly these sections:\n\n- Thesis (1-2 sentences)\n- Key Risks (2-4 bullets)\n- What Would Change Your Mind (1-2 bullets)\n- Recommended Posture Right Now (1 sentence)\n\nConstraints:\n- Reference the specific ticker/universe explicitly.\n- Be concrete and specific. Avoid vague statements.\n- If tools are available and needed to verify liquidity or depth, call at most ONE tool.\n- Total output must stay under 450 words.",
+    "temperature": 0.15,
+    "tools": [
+      "nexus.fetch_market_depth"
+    ]
+  },
+  {
+    "actor_id": "portfolio_proposal",
+    "cot_enabled": true,
+    "max_tokens": 800,
+    "node_id": "n14",
+    "system_prompt": "You are the Portfolio Proposal desk of an ACTIVE crypto fund. Translate the current signal into a tradeable portfolio with moderate turnover. Use HOLD only when genuinely unsure. Keep risk bounded, but express the edge.",
+    "task_prompt": "Convert the current signal and context into a portfolio proposal.\n\nReturn strict JSON only:\n{\n  \"trades\": {\n    \"SYMBOL\": {\n      \"action\": \"buy\" | \"sell\" | \"hold\",\n      \"portfolio_weight\": number (0.0 - 1.0)\n    }\n  }\n}\n\nRules:\n- Only include symbols that are in the current universe.\n- Sum of all portfolio_weight must be ≤ 1.0.\n- If stance is bullish, prefer buys; if bearish, prefer sells (or holds if shorting is not allowed).\n- Avoid over-concentration (no single position > 0.35).\n- Use smaller weights when confidence is low; increase weights when confidence is high.",
+    "temperature": 0.2,
+    "tools": []
+  },
+  {
+    "actor_id": "portfolio_execute",
+    "cot_enabled": false,
+    "max_tokens": 650,
+    "node_id": "n16",
+    "system_prompt": "You are the Execution desk. Your goal is to produce a compliant execution plan that respects the portfolio proposal and Risk Guard decision. Be ACTIVE but safe: if Risk Guard is APPROVED and trade_intent.action is BUY or SELL, you should produce at least one small order sized for the paper account. Never invent balances.",
+    "task_prompt": "Create an execution plan.\n\nReturn strict JSON only:\n{\n  \"smart_orders\": [\n    {\n      \"symbol\": string,\n      \"side\": \"buy\" | \"sell\",\n      \"qty\": number\n    }\n  ]\n}\n\nRules:\n- Only include symbols from universe.\n- If trade_intent.action is BUY or SELL and Risk Guard is APPROVED, include at least one small order.\n- Use paper.cash_usdt and paper.positions to keep sizing realistic.\n- If trade_intent is HOLD, return {\"smart_orders\": []}.",
+    "temperature": 0.1,
+    "tools": []
+  }
+]
+

--- a/config/agent_prompts.buffett.json
+++ b/config/agent_prompts.buffett.json
@@ -1,0 +1,35 @@
+[
+  {
+    "actor_id": "signal_arbitrator",
+    "cot_enabled": true,
+    "max_tokens": 700,
+    "node_id": "n13",
+    "system_prompt": "You are the Signal Arbitrator for a long-horizon value investor persona (\"Buffett-like\") running a crypto hedge fund sleeve. You prioritize capital preservation, only act on high-conviction opportunities, and avoid churn. Never invent information.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"stance\": \"bullish\" | \"bearish\" | \"neutral\",\n  \"confidence\": number (0.0 to 0.95),\n  \"reasons\": [array of short, specific reasons]\n}\n\nRules:\n- Default to NEUTRAL unless there is strong, consistent evidence.\n- Prefer fewer, higher quality signals; do not overreact to short-term noise.\n- Confidence should be conservative; avoid >0.8 unless evidence is overwhelming.",
+    "temperature": 0.05,
+    "tools": [
+      "nexus.fetch_market_depth"
+    ]
+  },
+  {
+    "actor_id": "portfolio_proposal",
+    "cot_enabled": true,
+    "max_tokens": 800,
+    "node_id": "n14",
+    "system_prompt": "You are the Portfolio Proposal desk for a long-horizon, low-turnover value investor persona. You avoid frequent trading and keep allocations concentrated only when conviction is very high.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"trades\": {\n    \"SYMBOL\": {\n      \"action\": \"buy\" | \"sell\" | \"hold\",\n      \"portfolio_weight\": number (0.0 - 1.0)\n    }\n  }\n}\n\nRules:\n- Default to hold.\n- Avoid frequent changes; only buy/sell when stance is directional with high confidence.\n- No single position > 0.25 unless confidence is very high.",
+    "temperature": 0.05,
+    "tools": []
+  },
+  {
+    "actor_id": "portfolio_execute",
+    "cot_enabled": false,
+    "max_tokens": 600,
+    "node_id": "n16",
+    "system_prompt": "You are the Execution desk for a long-horizon persona. If trade_intent is HOLD, do nothing. If BUY/SELL and Risk Guard is APPROVED, place minimal, safe orders sized for the paper account.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"smart_orders\": [\n    {\"symbol\": string, \"side\": \"buy\"|\"sell\", \"qty\": number}\n  ]\n}\n\nRules:\n- Prefer 0 or 1 order.\n- Never oversize; use paper cash and constraints.\n- If anything is unclear, return {\"smart_orders\": []}.",
+    "temperature": 0.0,
+    "tools": []
+  }
+]
+

--- a/config/agent_prompts.daytrade.json
+++ b/config/agent_prompts.daytrade.json
@@ -1,0 +1,35 @@
+[
+  {
+    "actor_id": "signal_arbitrator",
+    "cot_enabled": true,
+    "max_tokens": 700,
+    "node_id": "n13",
+    "system_prompt": "You are the Signal Arbitrator for a day trader persona. You trade intraday swings, value momentum + liquidity, and avoid holding when conditions are unclear. Never invent information.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"stance\": \"bullish\" | \"bearish\" | \"neutral\",\n  \"confidence\": number (0.0 to 0.95),\n  \"reasons\": [array of short, specific reasons]\n}\n\nRules:\n- Prefer bullish/bearish when there is a clear intraday edge.\n- Use neutral when evidence is weak.\n- Keep confidence calibrated to evidence quality.",
+    "temperature": 0.18,
+    "tools": [
+      "nexus.fetch_market_depth"
+    ]
+  },
+  {
+    "actor_id": "portfolio_proposal",
+    "cot_enabled": true,
+    "max_tokens": 800,
+    "node_id": "n14",
+    "system_prompt": "You are the Portfolio Proposal desk for a day trader persona. You accept moderate turnover and keep positions tactical.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"trades\": {\n    \"SYMBOL\": {\n      \"action\": \"buy\" | \"sell\" | \"hold\",\n      \"portfolio_weight\": number (0.0 - 1.0)\n    }\n  }\n}\n\nRules:\n- Align actions with stance.\n- Keep weights moderate and diversified.\n- Use hold when uncertain.",
+    "temperature": 0.2,
+    "tools": []
+  },
+  {
+    "actor_id": "portfolio_execute",
+    "cot_enabled": false,
+    "max_tokens": 650,
+    "node_id": "n16",
+    "system_prompt": "You are the Execution desk for a day trader persona. If Risk Guard is APPROVED and trade_intent is BUY/SELL, produce at least one small order sized for the paper account.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"smart_orders\": [\n    {\"symbol\": string, \"side\": \"buy\"|\"sell\", \"qty\": number}\n  ]\n}\n\nRules:\n- Prefer 1-4 orders.\n- Size within constraints.\n- If trade_intent is HOLD, return {\"smart_orders\": []}.",
+    "temperature": 0.12,
+    "tools": []
+  }
+]
+

--- a/config/agent_prompts.scalp.json
+++ b/config/agent_prompts.scalp.json
@@ -1,0 +1,35 @@
+[
+  {
+    "actor_id": "signal_arbitrator",
+    "cot_enabled": true,
+    "max_tokens": 700,
+    "node_id": "n13",
+    "system_prompt": "You are the Signal Arbitrator for a scalper persona. You prioritize short-term momentum/mean-reversion edges, act quickly, and accept higher turnover. Never invent information.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"stance\": \"bullish\" | \"bearish\" | \"neutral\",\n  \"confidence\": number (0.0 to 0.95),\n  \"reasons\": [array of short, specific reasons]\n}\n\nRules:\n- Prefer a directional stance when there is any short-term edge; use lower confidence when evidence is mixed.\n- Use neutral only when signals are contradictory or unusable.\n- Keep reasons short and execution-oriented.",
+    "temperature": 0.22,
+    "tools": [
+      "nexus.fetch_market_depth"
+    ]
+  },
+  {
+    "actor_id": "portfolio_proposal",
+    "cot_enabled": true,
+    "max_tokens": 800,
+    "node_id": "n14",
+    "system_prompt": "You are the Portfolio Proposal desk for a scalper persona. You accept high turnover and prefer small tactical positions aligned to the current edge.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"trades\": {\n    \"SYMBOL\": {\n      \"action\": \"buy\" | \"sell\" | \"hold\",\n      \"portfolio_weight\": number (0.0 - 1.0)\n    }\n  }\n}\n\nRules:\n- When stance is bullish/bearish, prefer buy/sell rather than hold.\n- Keep weights small and spread risk.\n- Avoid over-concentration (>0.25).",
+    "temperature": 0.25,
+    "tools": []
+  },
+  {
+    "actor_id": "portfolio_execute",
+    "cot_enabled": false,
+    "max_tokens": 650,
+    "node_id": "n16",
+    "system_prompt": "You are the Execution desk for a scalper persona. If Risk Guard is APPROVED and trade_intent is BUY/SELL, output at least one small order. Respect paper cash, constraints, and min notional.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"smart_orders\": [\n    {\"symbol\": string, \"side\": \"buy\"|\"sell\", \"qty\": number}\n  ]\n}\n\nRules:\n- Prefer 1-5 small orders.\n- Keep qty small.\n- If trade_intent is HOLD, return {\"smart_orders\": []}.",
+    "temperature": 0.15,
+    "tools": []
+  }
+]
+

--- a/config/agent_prompts.swing.json
+++ b/config/agent_prompts.swing.json
@@ -1,0 +1,35 @@
+[
+  {
+    "actor_id": "signal_arbitrator",
+    "cot_enabled": true,
+    "max_tokens": 700,
+    "node_id": "n13",
+    "system_prompt": "You are the Signal Arbitrator for a swing trader persona. You target multi-day moves, prefer trend + regime alignment, and avoid over-trading. Never invent information.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"stance\": \"bullish\" | \"bearish\" | \"neutral\",\n  \"confidence\": number (0.0 to 0.95),\n  \"reasons\": [array of short, specific reasons]\n}\n\nRules:\n- Prefer bullish/bearish when evidence supports a multi-day move.\n- Use neutral when regime is unclear.\n- Calibrate confidence: mixed evidence => lower confidence, not neutral by default.",
+    "temperature": 0.12,
+    "tools": [
+      "nexus.fetch_market_depth"
+    ]
+  },
+  {
+    "actor_id": "portfolio_proposal",
+    "cot_enabled": true,
+    "max_tokens": 800,
+    "node_id": "n14",
+    "system_prompt": "You are the Portfolio Proposal desk for a swing trader persona. You accept moderate turnover, rotate into stronger trends, and reduce exposure when signals fade.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"trades\": {\n    \"SYMBOL\": {\n      \"action\": \"buy\" | \"sell\" | \"hold\",\n      \"portfolio_weight\": number (0.0 - 1.0)\n    }\n  }\n}\n\nRules:\n- Use hold for weak signals.\n- Increase weights with confidence; reduce with uncertainty.\n- Avoid over-concentration (>0.35).",
+    "temperature": 0.15,
+    "tools": []
+  },
+  {
+    "actor_id": "portfolio_execute",
+    "cot_enabled": false,
+    "max_tokens": 650,
+    "node_id": "n16",
+    "system_prompt": "You are the Execution desk for a swing trader persona. If Risk Guard is APPROVED and trade_intent is BUY/SELL, produce at least one safe order sized for the paper account and constraints.",
+    "task_prompt": "Return strict JSON only:\n{\n  \"smart_orders\": [\n    {\"symbol\": string, \"side\": \"buy\"|\"sell\", \"qty\": number}\n  ]\n}\n\nRules:\n- Use paper.cash_usdt and constraints.max_notional_usd.\n- Prefer 1-3 orders.\n- If trade_intent is HOLD, return {\"smart_orders\": []}.",
+    "temperature": 0.1,
+    "tools": []
+  }
+]
+

--- a/config/policy.buffett.json
+++ b/config/policy.buffett.json
@@ -1,0 +1,22 @@
+{
+  "policy": {
+    "portfolio_budget_usd": 10000,
+    "stop_loss_pct": 0.04,
+    "take_profit_pct": 0.12,
+    "max_leverage": 1,
+    "min_confidence_directional": 0.65,
+    "trade_cooldown_bars": 96,
+    "allows_short": false,
+    "order_max_add_btc": 0.03,
+    "order_max_add_notional_usd": 1200,
+    "intent_notional_fraction": 0.08,
+    "rule_sentiment_buy_min": 60,
+    "rule_sentiment_sell_below": 35,
+    "bull_exposure_floor": 0.35,
+    "bear_exposure_cap": 0.1,
+    "risk_max_drawdown_stop": 0.12,
+    "risk_kill_switch_cooldown_bars": 240,
+    "risk_position_cap_usd": 1500
+  }
+}
+

--- a/config/policy.daytrade.json
+++ b/config/policy.daytrade.json
@@ -1,0 +1,22 @@
+{
+  "policy": {
+    "portfolio_budget_usd": 10000,
+    "stop_loss_pct": 0.02,
+    "take_profit_pct": 0.04,
+    "max_leverage": 3,
+    "min_confidence_directional": 0.4,
+    "trade_cooldown_bars": 6,
+    "allows_short": true,
+    "order_max_add_btc": 0.12,
+    "order_max_add_notional_usd": 3000,
+    "intent_notional_fraction": 0.22,
+    "rule_sentiment_buy_min": 47,
+    "rule_sentiment_sell_below": 39,
+    "bull_exposure_floor": 0.7,
+    "bear_exposure_cap": 0.3,
+    "risk_max_drawdown_stop": 0.2,
+    "risk_kill_switch_cooldown_bars": 100,
+    "risk_position_cap_usd": 2800
+  }
+}
+

--- a/config/policy.scalp.json
+++ b/config/policy.scalp.json
@@ -1,0 +1,22 @@
+{
+  "policy": {
+    "portfolio_budget_usd": 10000,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.02,
+    "max_leverage": 3,
+    "min_confidence_directional": 0.35,
+    "trade_cooldown_bars": 2,
+    "allows_short": true,
+    "order_max_add_btc": 0.15,
+    "order_max_add_notional_usd": 3500,
+    "intent_notional_fraction": 0.25,
+    "rule_sentiment_buy_min": 45,
+    "rule_sentiment_sell_below": 40,
+    "bull_exposure_floor": 0.75,
+    "bear_exposure_cap": 0.35,
+    "risk_max_drawdown_stop": 0.22,
+    "risk_kill_switch_cooldown_bars": 80,
+    "risk_position_cap_usd": 3000
+  }
+}
+

--- a/config/policy.swing.json
+++ b/config/policy.swing.json
@@ -1,0 +1,22 @@
+{
+  "policy": {
+    "portfolio_budget_usd": 10000,
+    "stop_loss_pct": 0.03,
+    "take_profit_pct": 0.08,
+    "max_leverage": 2,
+    "min_confidence_directional": 0.45,
+    "trade_cooldown_bars": 24,
+    "allows_short": true,
+    "order_max_add_btc": 0.08,
+    "order_max_add_notional_usd": 2500,
+    "intent_notional_fraction": 0.18,
+    "rule_sentiment_buy_min": 48,
+    "rule_sentiment_sell_below": 38,
+    "bull_exposure_floor": 0.6,
+    "bear_exposure_cap": 0.25,
+    "risk_max_drawdown_stop": 0.18,
+    "risk_kill_switch_cooldown_bars": 160,
+    "risk_position_cap_usd": 2500
+  }
+}
+

--- a/src/api/flow_stream_server.py
+++ b/src/api/flow_stream_server.py
@@ -21,10 +21,8 @@ from .pm_routes import router as pm_router
 from .runtime_settings_routes import router as runtime_settings_router
 from .schema_validation import validate_nexus_payload
 
-# Same as `src/main.py`: repo-root `.env` applies to the Flow API when started via uvicorn.
-# Be explicit about the repo root so reloaders / alternate CWDs still load the correct file.
 _REPO_ROOT_DOTENV = Path(__file__).resolve().parents[2] / ".env"
-load_dotenv(dotenv_path=_REPO_ROOT_DOTENV, override=True)
+load_dotenv(dotenv_path=_REPO_ROOT_DOTENV)
 
 RUNS_DIR = Path(".runs")
 LATEST_RUN_FILE = RUNS_DIR / "latest_run.txt"

--- a/src/backtest/run_demo.py
+++ b/src/backtest/run_demo.py
@@ -475,8 +475,7 @@ def execute_run_demo(args: argparse.Namespace, parser: argparse.ArgumentParser) 
 
 
 def main(argv: list[str] | None = None) -> dict[str, Any]:
-    # Always let `.env` win over inherited shell env (including empty values).
-    load_dotenv(override=True)
+    load_dotenv()
     parser = build_run_demo_parser()
     args = parser.parse_args(argv)
     if args.llm:

--- a/src/config/agent_prompts.py
+++ b/src/config/agent_prompts.py
@@ -18,8 +18,24 @@ from typing import Any
 
 
 def _default_prompts_path() -> Path:
-    p = (os.getenv("AIMM_AGENT_PROMPTS_PATH") or "config/agent_prompts.json").strip()
-    return Path(p)
+    p = (os.getenv("AIMM_AGENT_PROMPTS_PATH") or "").strip()
+    if p:
+        return Path(p)
+
+    # Persona bundle: `config/agent_prompts.<profile>.json`
+    profile = (os.getenv("AIMM_TRADER_PROFILE") or "").strip()
+    if profile:
+        cand = Path(f"config/agent_prompts.{profile}.json")
+        if cand.is_file():
+            return cand
+
+    style = (os.getenv("AIMM_TRADING_STYLE") or "").strip()
+    if style:
+        cand = Path(f"config/agent_prompts.{style}.json")
+        if cand.is_file():
+            return cand
+
+    return Path("config/agent_prompts.json")
 
 
 @dataclass(frozen=True)

--- a/src/config/policy_loader.py
+++ b/src/config/policy_loader.py
@@ -9,6 +9,7 @@ deployment policy lives in `config/policy.default.json`.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -167,6 +168,11 @@ def load_fund_policy(*, path: Path | None = None) -> FundPolicy:
 
     This is intentionally strict: missing/invalid policy should fail fast.
     """
+    if path is None:
+        # Optional env override for CI/operators/persona selection.
+        env_path = (os.getenv("AIMM_CONFIG_PATH") or os.getenv("AIMM_POLICY_CONFIG_PATH") or "").strip()
+        if env_path:
+            path = Path(env_path)
     p = path or Path("config/policy.default.json")
     obj = _load_policy_config_from_json(str(p))
     return _policy_from_mapping(obj)

--- a/src/config/policy_loader.py
+++ b/src/config/policy_loader.py
@@ -170,7 +170,9 @@ def load_fund_policy(*, path: Path | None = None) -> FundPolicy:
     """
     if path is None:
         # Optional env override for CI/operators/persona selection.
-        env_path = (os.getenv("AIMM_CONFIG_PATH") or os.getenv("AIMM_POLICY_CONFIG_PATH") or "").strip()
+        env_path = (
+            os.getenv("AIMM_CONFIG_PATH") or os.getenv("AIMM_POLICY_CONFIG_PATH") or ""
+        ).strip()
         if env_path:
             path = Path(env_path)
     p = path or Path("config/policy.default.json")

--- a/src/eval_export.py
+++ b/src/eval_export.py
@@ -1,0 +1,183 @@
+"""Export run evaluation data for analysis and external benchmarking.
+
+Reads:
+
+- ``.runs/index.jsonl`` — compact per-run ledger (paper/live outcomes)
+- ``.runs/backtests/<run_id>/summary.json`` — backtest metrics (when present)
+
+Writes CSV and/or Parquet tables with a ``record_kind`` column (``index`` vs ``backtest``).
+
+Usage::
+
+    uv run python -m eval_export --runs-dir .runs -o exports/evaluation --format both
+    uv run aimm-export-eval -o exports/evaluation.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def read_index_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def read_backtest_summaries(backtests_dir: Path) -> list[dict[str, Any]]:
+    if not backtests_dir.is_dir():
+        return []
+    out: list[dict[str, Any]] = []
+    for d in sorted(backtests_dir.iterdir()):
+        if not d.is_dir():
+            continue
+        sp = d / "summary.json"
+        if not sp.exists():
+            continue
+        try:
+            data = json.loads(sp.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(data, dict):
+            data = dict(data)
+            data["_backtest_dir"] = str(d)
+            out.append(data)
+    return out
+
+
+def build_evaluation_frame(
+    *,
+    runs_dir: Path,
+    include_backtests: bool = True,
+) -> pd.DataFrame:
+    """Return one dataframe: index rows and optional flattened backtest summaries."""
+    idx_path = runs_dir / "index.jsonl"
+    index_rows = read_index_jsonl(idx_path)
+    frames: list[pd.DataFrame] = []
+
+    if index_rows:
+        df_i = pd.json_normalize(index_rows, sep=".")
+        df_i.insert(0, "record_kind", "index")
+        frames.append(df_i)
+
+    if include_backtests:
+        bt = read_backtest_summaries(runs_dir / "backtests")
+        if bt:
+            df_b = pd.json_normalize(bt, sep=".")
+            df_b.insert(0, "record_kind", "backtest")
+            frames.append(df_b)
+
+    if not frames:
+        return pd.DataFrame()
+
+    return pd.concat(frames, ignore_index=True, sort=False)
+
+
+def _write_parquet(df: pd.DataFrame, path: Path) -> None:
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError as e:
+        raise SystemExit(
+            "Parquet export requires the 'pyarrow' package. Install with:\n"
+            "  uv add pyarrow\n"
+            "or: pip install pyarrow"
+        ) from e
+    df.to_parquet(path, index=False)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Export .runs/index.jsonl and backtest summaries to CSV/Parquet.",
+    )
+    p.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=Path(".runs"),
+        help="Directory containing index.jsonl and backtests/ (default: .runs)",
+    )
+    p.add_argument(
+        "--no-backtests",
+        action="store_true",
+        help="Only export index.jsonl; skip .runs/backtests/*/summary.json",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("exports/evaluation"),
+        help="Output base path (adds .csv / .parquet) or a path ending in .csv/.parquet",
+    )
+    p.add_argument(
+        "-f",
+        "--format",
+        choices=("csv", "parquet", "both"),
+        default="csv",
+        help="Output format (default: csv). Parquet requires pyarrow.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    df = build_evaluation_frame(
+        runs_dir=args.runs_dir,
+        include_backtests=not args.no_backtests,
+    )
+    if df.empty:
+        print(
+            f"No data found under {args.runs_dir} "
+            "(missing or empty index.jsonl and no backtest summaries).",
+            file=sys.stderr,
+        )
+        return 1
+
+    out = args.output
+    suf = out.suffix.lower()
+    written: list[Path] = []
+
+    if suf == ".csv":
+        out.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(out, index=False)
+        written = [out]
+    elif suf == ".parquet":
+        out.parent.mkdir(parents=True, exist_ok=True)
+        _write_parquet(df, out)
+        written = [out]
+    else:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        if args.format in ("csv", "both"):
+            p = out.with_suffix(".csv")
+            df.to_csv(p, index=False)
+            written.append(p)
+        if args.format in ("parquet", "both"):
+            p = out.with_suffix(".parquet")
+            _write_parquet(df, p)
+            written.append(p)
+
+    for path in written:
+        print(path)
+    print(f"rows={len(df)} cols={len(df.columns)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/run_index.py
+++ b/src/run_index.py
@@ -1,0 +1,82 @@
+"""Small durable run ledger for evaluation.
+
+Raw `.runs/<run_id>.events.jsonl` logs are valuable but can be large. This module writes a tiny
+append-only index under `.runs/index.jsonl` so you can evaluate outcomes over time even with retention.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from config.app_settings import load_app_settings
+from schemas.state import HedgeFundState
+
+
+def _prune_index_file(idx: Path, *, keep_last: int, max_bytes: int) -> None:
+    try:
+        if not idx.exists():
+            return
+        st = idx.stat()
+        if st.st_size <= max_bytes and st.st_size <= max(1, max_bytes):
+            return
+        # Keep only the last N lines. This is fast enough for our intended size caps.
+        lines = idx.read_text(encoding="utf-8").splitlines()
+        if keep_last > 0 and len(lines) > keep_last:
+            lines = lines[-keep_last:]
+        out = "\n".join(lines).rstrip() + "\n" if lines else ""
+        # If still too big (single huge lines), hard trim by bytes.
+        if len(out.encode("utf-8")) > max_bytes:
+            b = out.encode("utf-8")[-max_bytes:]
+            # ensure valid utf-8 by dropping leading partials
+            out = b.decode("utf-8", errors="ignore")
+            if out and not out.endswith("\n"):
+                out += "\n"
+        idx.write_text(out, encoding="utf-8")
+    except OSError:
+        return
+
+
+def append_run_index(
+    *,
+    run_id: str,
+    state: HedgeFundState,
+    events_path: Path | None = None,
+    runs_dir: Path | None = None,
+) -> None:
+    base = runs_dir or Path(".runs")
+    base.mkdir(parents=True, exist_ok=True)
+    idx = base / "index.jsonl"
+    rec: dict[str, Any] = {
+        "ts": int(time.time()),
+        "run_id": run_id,
+        "ticker": state.get("ticker"),
+        "run_mode": state.get("run_mode"),
+        "is_vetoed": state.get("is_vetoed"),
+        "veto_reason": state.get("veto_reason"),
+        "risk_status": (state.get("risk_report") or {}).get("status"),
+        "risk_score": (state.get("risk_guard") or {}).get("risk_score"),
+        "proposal_status": (state.get("proposal") or {}).get("status"),
+        "execution_status": (state.get("execution_result") or {}).get("status"),
+        "trade_intent": state.get("trade_intent"),
+    }
+    if events_path is not None:
+        rec["events_path"] = str(events_path)
+    idx.write_text("", encoding="utf-8") if not idx.exists() else None
+    with idx.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec, default=str) + "\n")
+
+    # Prune after append so the latest run is always retained.
+    try:
+        s = load_app_settings()
+        keep_last = int(s.runs.index_keep_last)
+        max_mb = int(s.runs.index_max_mb)
+        _prune_index_file(idx, keep_last=keep_last, max_bytes=max(1, max_mb) * 1024 * 1024)
+    except Exception:
+        # Never fail the run due to index housekeeping.
+        return
+
+
+__all__ = ["append_run_index"]

--- a/src/runs_retention.py
+++ b/src/runs_retention.py
@@ -1,0 +1,226 @@
+"""Retention policy for `.runs/` artifacts.
+
+Backtests and live runs can accumulate quickly (events.jsonl, iterations, bundles, evaluations).
+This module enforces a simple safety policy:
+
+- keep at least the most recent N artifacts (by mtime)
+- cap total disk usage under `.runs/`
+
+This is config-first (config/app.default.json) with env overrides for emergencies.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from config.app_settings import load_app_settings
+
+
+@dataclass(frozen=True)
+class RunsRetention:
+    max_total_mb: int
+    keep_last: int
+    backtests_max_total_mb: int
+    backtests_keep_last: int
+
+
+def _env_int(name: str) -> int | None:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def load_runs_retention() -> RunsRetention:
+    s = load_app_settings()
+    max_total_mb = int(s.runs.max_total_mb)
+    keep_last = int(s.runs.keep_last)
+    backtests_max_total_mb = int(s.runs.backtests_max_total_mb)
+    backtests_keep_last = int(s.runs.backtests_keep_last)
+    # Optional env overrides
+    v = _env_int("AIMM_RUNS_MAX_TOTAL_MB")
+    if v is not None:
+        max_total_mb = v
+    v = _env_int("AIMM_RUNS_KEEP_LAST")
+    if v is not None:
+        keep_last = v
+    v = _env_int("AIMM_RUNS_BACKTESTS_MAX_TOTAL_MB")
+    if v is not None:
+        backtests_max_total_mb = v
+    v = _env_int("AIMM_RUNS_BACKTESTS_KEEP_LAST")
+    if v is not None:
+        backtests_keep_last = v
+    max_total_mb = max(50, min(100_000, int(max_total_mb)))
+    keep_last = max(10, min(100_000, int(keep_last)))
+    backtests_max_total_mb = max(50, min(100_000, int(backtests_max_total_mb)))
+    backtests_keep_last = max(5, min(100_000, int(backtests_keep_last)))
+    return RunsRetention(
+        max_total_mb=max_total_mb,
+        keep_last=keep_last,
+        backtests_max_total_mb=backtests_max_total_mb,
+        backtests_keep_last=backtests_keep_last,
+    )
+
+
+def enforce_runs_retention(
+    *, runs_dir: Path | None = None, keep_run_id: str | None = None
+) -> dict[str, int]:
+    """Enforce retention under `.runs/`.
+
+    Returns a small stats dict for logging.
+    """
+
+    base = (runs_dir or Path(".runs")).resolve()
+    if not base.exists() or not base.is_dir():
+        return {"deleted_files": 0, "deleted_dirs": 0, "bytes_freed": 0}
+
+    policy = load_runs_retention()
+    max_bytes = int(policy.max_total_mb) * 1024 * 1024
+
+    # Always preserve these root files.
+    preserve_names = {"latest_run.txt", "policy_memory.jsonl", "index.jsonl"}
+
+    # Collect deletable candidates (files + dirs) with mtime + size.
+    files: list[tuple[float, int, Path]] = []
+    dirs: list[tuple[float, int, Path]] = []
+    for p in base.iterdir():
+        if p.name in preserve_names:
+            continue
+        # Backtests are retained separately.
+        if p.name == "backtests" and p.is_dir():
+            continue
+        if keep_run_id and p.name.startswith(keep_run_id):
+            continue
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        if p.is_file():
+            files.append((st.st_mtime, st.st_size, p))
+        elif p.is_dir():
+            # Approximate dir size by summing contained files (bounded; okay for retention).
+            sz = 0
+            try:
+                for f in p.rglob("*"):
+                    if f.is_file():
+                        try:
+                            sz += f.stat().st_size
+                        except OSError:
+                            pass
+            except OSError:
+                sz = 0
+            dirs.append((st.st_mtime, sz, p))
+
+    # Current usage (recursive).
+    total = 0
+    for f in base.rglob("*"):
+        if f.is_file():
+            try:
+                total += f.stat().st_size
+            except OSError:
+                pass
+
+    # Keep last N by mtime across both files and dirs.
+    candidates: list[tuple[float, int, Path, str]] = [
+        (mt, sz, p, "file") for mt, sz, p in files
+    ] + [(mt, sz, p, "dir") for mt, sz, p in dirs]
+    candidates.sort(key=lambda r: r[0], reverse=True)  # newest first
+    to_consider = candidates[policy.keep_last :]
+    # Oldest first for deletion.
+    to_consider.sort(key=lambda r: r[0])
+
+    deleted_files = deleted_dirs = 0
+    bytes_freed = 0
+    for _mt, sz, p, kind in to_consider:
+        if total <= max_bytes:
+            break
+        try:
+            if kind == "file" and p.is_file():
+                p.unlink(missing_ok=True)
+                deleted_files += 1
+                bytes_freed += int(sz)
+                total -= int(sz)
+            elif kind == "dir" and p.is_dir():
+                shutil.rmtree(p, ignore_errors=True)
+                deleted_dirs += 1
+                bytes_freed += int(sz)
+                total -= int(sz)
+        except OSError:
+            continue
+
+    return {
+        "deleted_files": deleted_files,
+        "deleted_dirs": deleted_dirs,
+        "bytes_freed": bytes_freed,
+    }
+
+
+def _dir_size_bytes(p: Path) -> int:
+    sz = 0
+    for f in p.rglob("*"):
+        if f.is_file():
+            try:
+                sz += f.stat().st_size
+            except OSError:
+                pass
+    return sz
+
+
+def enforce_backtests_retention(*, runs_dir: Path | None = None) -> dict[str, int]:
+    """Enforce retention within `.runs/backtests/` by deleting oldest run directories."""
+
+    base = (runs_dir or Path(".runs")).resolve()
+    bt = base / "backtests"
+    if not bt.exists() or not bt.is_dir():
+        return {"deleted_dirs": 0, "bytes_freed": 0}
+
+    policy = load_runs_retention()
+    try:
+        if not load_app_settings().runs.backtests_retention_enabled:
+            return {"deleted_dirs": 0, "bytes_freed": 0}
+    except Exception:
+        # If settings can't be loaded, default to non-destructive behavior.
+        return {"deleted_dirs": 0, "bytes_freed": 0}
+    max_bytes = int(policy.backtests_max_total_mb) * 1024 * 1024
+
+    run_dirs = []
+    for d in bt.iterdir():
+        if d.is_dir():
+            try:
+                st = d.stat()
+            except OSError:
+                continue
+            run_dirs.append((st.st_mtime, _dir_size_bytes(d), d))
+    run_dirs.sort(key=lambda r: r[0], reverse=True)  # newest first
+
+    # Total usage
+    total = sum(sz for _mt, sz, _d in run_dirs)
+
+    # Never delete newest keep_last
+    to_consider = run_dirs[policy.backtests_keep_last :]
+    to_consider.sort(key=lambda r: r[0])  # oldest first
+
+    deleted = 0
+    freed = 0
+    for _mt, sz, d in to_consider:
+        if total <= max_bytes:
+            break
+        shutil.rmtree(d, ignore_errors=True)
+        deleted += 1
+        freed += int(sz)
+        total -= int(sz)
+    return {"deleted_dirs": deleted, "bytes_freed": freed}
+
+
+__all__ = [
+    "RunsRetention",
+    "enforce_backtests_retention",
+    "enforce_runs_retention",
+    "load_runs_retention",
+]

--- a/tests/test_eval_export.py
+++ b/tests/test_eval_export.py
@@ -1,0 +1,117 @@
+"""Tests for evaluation export (index.jsonl + backtest summaries)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from eval_export import build_evaluation_frame, read_backtest_summaries, read_index_jsonl
+
+
+def test_read_index_jsonl_skips_bad_lines(tmp_path: Path):
+    p = tmp_path / "index.jsonl"
+    p.write_text(
+        '{"run_id":"a","ticker":"BTC/USDT"}\nnot json\n{"run_id":"b"}\n',
+        encoding="utf-8",
+    )
+    rows = read_index_jsonl(p)
+    assert len(rows) == 2
+    assert rows[0]["run_id"] == "a"
+    assert rows[1]["run_id"] == "b"
+
+
+def test_read_backtest_summaries(tmp_path: Path):
+    bt = tmp_path / "backtests" / "bt_1"
+    bt.mkdir(parents=True)
+    summary = {
+        "run_id": "bt_1",
+        "steps": 10,
+        "trade_count": 2,
+        "metrics": {"sharpe": 1.5},
+        "benchmark": {"excess_return_pct": 3.0},
+    }
+    (bt / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    rows = read_backtest_summaries(tmp_path / "backtests")
+    assert len(rows) == 1
+    assert rows[0]["run_id"] == "bt_1"
+    assert "_backtest_dir" in rows[0]
+
+
+def test_build_evaluation_frame_merges(tmp_path: Path):
+    runs = tmp_path / ".runs"
+    runs.mkdir()
+    (runs / "index.jsonl").write_text(
+        json.dumps({"run_id": "live1", "ticker": "ETH/USDT", "is_vetoed": False}) + "\n",
+        encoding="utf-8",
+    )
+    bt = runs / "backtests" / "bt_x"
+    bt.mkdir(parents=True)
+    (bt / "summary.json").write_text(
+        json.dumps({"run_id": "bt_x", "steps": 5, "trade_count": 1, "metrics": {}}),
+        encoding="utf-8",
+    )
+    df = build_evaluation_frame(runs_dir=runs, include_backtests=True)
+    assert len(df) == 2
+    kinds = set(df["record_kind"].tolist())
+    assert kinds == {"index", "backtest"}
+
+
+def test_build_evaluation_frame_index_only(tmp_path: Path):
+    runs = tmp_path / ".runs"
+    runs.mkdir()
+    (runs / "index.jsonl").write_text(
+        json.dumps({"run_id": "x"}) + "\n",
+        encoding="utf-8",
+    )
+    df = build_evaluation_frame(runs_dir=runs, include_backtests=False)
+    assert len(df) == 1
+    assert df["record_kind"].iloc[0] == "index"
+
+
+def test_json_normalize_nested_metrics(tmp_path: Path):
+    runs = tmp_path / ".runs"
+    runs.mkdir()
+    bt = runs / "backtests" / "bt_y"
+    bt.mkdir(parents=True)
+    (bt / "summary.json").write_text(
+        json.dumps(
+            {
+                "run_id": "bt_y",
+                "metrics": {"sharpe": 0.5, "max_drawdown_pct": 12.0},
+            }
+        ),
+        encoding="utf-8",
+    )
+    df = build_evaluation_frame(runs_dir=runs, include_backtests=True)
+    assert "metrics.sharpe" in df.columns
+    assert float(df["metrics.sharpe"].iloc[0]) == 0.5
+
+
+def test_main_writes_csv(tmp_path: Path, monkeypatch, capsys):
+    runs = tmp_path / ".runs"
+    runs.mkdir()
+    (runs / "index.jsonl").write_text(
+        json.dumps({"run_id": "m1", "ticker": "BTC/USDT"}) + "\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.csv"
+    from eval_export import main
+
+    monkeypatch.chdir(tmp_path)
+    code = main(
+        [
+            "--runs-dir",
+            str(runs),
+            "-o",
+            str(out),
+            "-f",
+            "csv",
+        ]
+    )
+    assert code == 0
+    assert out.exists()
+    df = pd.read_csv(out)
+    assert len(df) == 1
+    assert df["record_kind"].iloc[0] == "index"

--- a/tests/test_llm_json_parse.py
+++ b/tests/test_llm_json_parse.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from llm.json_parse import parse_json_object
+
+
+def test_parse_json_object_plain() -> None:
+    assert parse_json_object('{"a": 1, "b": "x"}') == {"a": 1, "b": "x"}
+
+
+def test_parse_json_object_fenced() -> None:
+    txt = 'Here you go:\n```json\n{"stance":"neutral","confidence":0.5,"reasons":["x"]}\n```'
+    assert parse_json_object(txt) == {
+        "stance": "neutral",
+        "confidence": 0.5,
+        "reasons": ["x"],
+    }
+
+
+def test_parse_json_object_preamble_and_trailing_text() -> None:
+    txt = 'Preamble...\n{ "a": 1 }\nThanks!'
+    assert parse_json_object(txt) == {"a": 1}
+
+
+def test_parse_json_object_non_object_returns_none() -> None:
+    assert parse_json_object("[1,2,3]") is None
+    assert parse_json_object("null") is None
+    assert parse_json_object("") is None

--- a/tests/test_mock_depth_is_labeled.py
+++ b/tests/test_mock_depth_is_labeled.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from adapters.nexus_adapter import NexusAdapter
+
+
+def test_mock_depth_is_explicitly_labeled() -> None:
+    out = NexusAdapter().fetch_market_depth(symbol="BTC/USDT", limit=3)
+    assert out.get("is_mock") is True
+    assert out.get("source") == "mock"
+    assert isinstance(out.get("note"), str) and out["note"]

--- a/tests/test_trader_profile_selection.py
+++ b/tests/test_trader_profile_selection.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_agent_prompts_profile_selects_preset_when_present(monkeypatch) -> None:
+    from config import agent_prompts
+
+    monkeypatch.delenv("AIMM_AGENT_PROMPTS_PATH", raising=False)
+    monkeypatch.delenv("AIMM_TRADING_STYLE", raising=False)
+    monkeypatch.setenv("AIMM_TRADER_PROFILE", "buffett")
+
+    p = agent_prompts._default_prompts_path()
+    assert str(p).endswith("config/agent_prompts.buffett.json")
+    assert p.is_file()
+
+
+def test_agent_prompts_explicit_path_wins(monkeypatch, tmp_path: Path) -> None:
+    from config import agent_prompts
+
+    f = tmp_path / "agent_prompts.json"
+    f.write_text("[]\n", encoding="utf-8")
+    monkeypatch.setenv("AIMM_AGENT_PROMPTS_PATH", str(f))
+    monkeypatch.setenv("AIMM_TRADER_PROFILE", "buffett")
+    monkeypatch.setenv("AIMM_TRADING_STYLE", "active")
+
+    p = agent_prompts._default_prompts_path()
+    assert p == f
+
+
+def test_load_fund_policy_uses_env_config_path(monkeypatch, tmp_path: Path) -> None:
+    cfg = tmp_path / "policy.json"
+    cfg.write_text(
+        """
+{
+  "policy": {
+    "stop_loss_pct": 0.12,
+    "take_profit_pct": 0.25,
+    "max_leverage": 3,
+    "min_confidence_directional": 0.55,
+    "trade_cooldown_bars": 96,
+    "allows_short": true,
+    "order_max_add_btc": 0.02,
+    "order_max_add_notional_usd": null,
+    "intent_notional_fraction": 0.1,
+    "rule_sentiment_buy_min": 55,
+    "rule_sentiment_sell_below": 40,
+    "bull_exposure_floor": 0.5,
+    "bear_exposure_cap": 0.2,
+    "risk_max_drawdown_stop": 0.25,
+    "risk_kill_switch_cooldown_bars": 120,
+    "portfolio_budget_usd": 6000,
+    "risk_position_cap_usd": 1500
+  }
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("AIMM_CONFIG_PATH", str(cfg))
+    from config.fund_policy import load_fund_policy
+
+    p = load_fund_policy()
+    assert p.stop_loss_pct == 0.12
+    assert p.max_leverage == 3


### PR DESCRIPTION
## Summary

feat: add persona + eval export
test: persona + json parsing + export

## Motivation

add more templates for trading strategy

## How to Test

add more tests

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (add `--runslow` if you touched slow tests)
- [x] Documentation updated if behavior or public API changed
- [x] No API keys or secrets committed