### PR TITLE
feat: data loader registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27.0",
     "ccxt>=4.4.85",
+    "yfinance>=0.2.0",
+    "futu-api>=9.0.0",
     "fastapi>=0.117.0",
     "jsonschema>=4.25.1",
     "langgraph>=0.4.7",

--- a/src/backtest/loaders/__init__.py
+++ b/src/backtest/loaders/__init__.py
@@ -1,0 +1,1 @@
+"""Data loaders for OHLCV market data."""

--- a/src/backtest/loaders/base.py
+++ b/src/backtest/loaders/base.py
@@ -1,0 +1,65 @@
+"""DataLoader protocol and shared exceptions for all data source loaders."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import pandas as pd
+
+
+class NoAvailableSourceError(Exception):
+    """Raised when no data source is available for a given market."""
+
+
+def validate_date_range(start_date: str, end_date: str) -> None:
+    """Validate that start_date <= end_date."""
+    try:
+        start = pd.Timestamp(start_date)
+        end = pd.Timestamp(end_date)
+    except Exception as exc:
+        raise ValueError(f"Invalid date format: start={start_date!r}, end={end_date!r}") from exc
+    if start > end:
+        raise ValueError(f"start_date ({start_date}) > end_date ({end_date})")
+
+
+@runtime_checkable
+class DataLoaderProtocol(Protocol):
+    """Interface every data source loader must satisfy."""
+
+    name: str
+    markets: set[str]
+    requires_auth: bool
+
+    def is_available(self) -> bool: ...
+
+    def fetch(
+        self,
+        codes: list[str],
+        start_date: str,
+        end_date: str,
+        *,
+        interval: str = "1D",
+        fields: list[str] | None = None,
+    ) -> dict[str, pd.DataFrame]: ...
+
+
+class BaseLoader:
+    """Optional base class with common defaults."""
+
+    name: str = ""
+    markets: set[str] = set()
+    requires_auth: bool = False
+
+    def is_available(self) -> bool:
+        return False
+
+    def fetch(
+        self,
+        codes: list[str],
+        start_date: str,
+        end_date: str,
+        *,
+        interval: str = "1D",
+        fields: list[str] | None = None,
+    ) -> dict[str, pd.DataFrame]:
+        raise NotImplementedError

--- a/src/backtest/loaders/ccxt_loader.py
+++ b/src/backtest/loaders/ccxt_loader.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import os
 from typing import Dict, List, Optional
 
+import ccxt
 import pandas as pd
 
-from .base import NoAvailableSourceError, validate_date_range
+from .base import validate_date_range
 from .registry import register
 
 _OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
@@ -36,15 +37,6 @@ class CCXTLoader:
     def __init__(self) -> None:
         self._exchange_id = os.environ.get("CCXT_EXCHANGE", "binance")
 
-    def is_available(self) -> bool:
-        try:
-            import ccxt  # noqa: PLC0415
-
-            ex_class = getattr(ccxt, self._exchange_id, None)
-            return ex_class is not None
-        except ImportError:
-            return False
-
     def fetch(
         self,
         codes: list[str],
@@ -59,11 +51,9 @@ class CCXTLoader:
             return {}
         validate_date_range(start_date, end_date)
 
-        import ccxt  # noqa: PLC0415
-
         ex_class = getattr(ccxt, self._exchange_id, None)
         if ex_class is None:
-            raise NoAvailableSourceError(f"Unknown exchange: {self._exchange_id}")
+            raise ValueError(f"Unknown exchange: {self._exchange_id}")
         exchange = ex_class({"enableRateLimit": True})
         exchange.load_markets()
 
@@ -75,13 +65,8 @@ class CCXTLoader:
         for code in codes:
             resolved = self._resolve_symbol(exchange, code)
             if resolved not in exchange.symbols:
-                print(f"[WARN] Symbol {code} not on {self._exchange_id}, skipping")
                 continue
-            try:
-                raw = self._fetch_range(exchange, resolved, timeframe, since_ms, until_ms)
-            except Exception as exc:
-                print(f"[WARN] Failed to fetch {code}: {exc}")
-                continue
+            raw = self._fetch_range(exchange, resolved, timeframe, since_ms, until_ms)
             if not raw:
                 continue
             results[code] = self._to_dataframe(raw)
@@ -108,17 +93,13 @@ class CCXTLoader:
                 break
             for row in batch:
                 ts = int(row[0])
-                if ts < since_ms:
-                    continue
-                if ts > until_ms:
+                if ts < since_ms or ts > until_ms:
                     continue
                 out.append([float(v) for v in row])
             last_ts = int(batch[-1][0])
-            if last_ts <= cursor:
+            if last_ts <= cursor or len(batch) < 1000:
                 break
             cursor = last_ts + 1
-            if len(batch) < 1000:
-                break
         out.sort(key=lambda r: r[0])
         return out
 

--- a/src/backtest/loaders/ccxt_loader.py
+++ b/src/backtest/loaders/ccxt_loader.py
@@ -1,0 +1,131 @@
+"""CCXT-backed loader for crypto OHLCV data."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .base import NoAvailableSourceError, validate_date_range
+from .registry import register
+
+_OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
+_INTERVAL_MAP = {
+    "1m": "1m",
+    "3m": "3m",
+    "5m": "5m",
+    "15m": "15m",
+    "30m": "30m",
+    "1H": "1h",
+    "4H": "4h",
+    "1D": "1d",
+    "1W": "1w",
+    "1M": "1M",
+}
+
+
+@register
+class CCXTLoader:
+    """Fetch crypto OHLCV bars via CCXT (public, no API key needed)."""
+
+    name = "ccxt"
+    markets = {"crypto"}
+    requires_auth = False
+
+    def __init__(self) -> None:
+        self._exchange_id = os.environ.get("CCXT_EXCHANGE", "binance")
+
+    def is_available(self) -> bool:
+        try:
+            import ccxt  # noqa: PLC0415
+
+            ex_class = getattr(ccxt, self._exchange_id, None)
+            return ex_class is not None
+        except ImportError:
+            return False
+
+    def fetch(
+        self,
+        codes: list[str],
+        start_date: str,
+        end_date: str,
+        *,
+        interval: str = "1D",
+        fields: Optional[List[str]] = None,
+    ) -> Dict[str, pd.DataFrame]:
+        del fields
+        if not codes:
+            return {}
+        validate_date_range(start_date, end_date)
+
+        import ccxt  # noqa: PLC0415
+
+        ex_class = getattr(ccxt, self._exchange_id, None)
+        if ex_class is None:
+            raise NoAvailableSourceError(f"Unknown exchange: {self._exchange_id}")
+        exchange = ex_class({"enableRateLimit": True})
+        exchange.load_markets()
+
+        timeframe = _INTERVAL_MAP.get(interval.strip(), "1d")
+        since_ms = int(pd.Timestamp(start_date).timestamp() * 1000)
+        until_ms = int(pd.Timestamp(end_date).timestamp() * 1000)
+
+        results: Dict[str, pd.DataFrame] = {}
+        for code in codes:
+            resolved = self._resolve_symbol(exchange, code)
+            if resolved not in exchange.symbols:
+                print(f"[WARN] Symbol {code} not on {self._exchange_id}, skipping")
+                continue
+            try:
+                raw = self._fetch_range(exchange, resolved, timeframe, since_ms, until_ms)
+            except Exception as exc:
+                print(f"[WARN] Failed to fetch {code}: {exc}")
+                continue
+            if not raw:
+                continue
+            results[code] = self._to_dataframe(raw)
+        return results
+
+    @staticmethod
+    def _resolve_symbol(exchange, symbol: str) -> str:
+        if symbol in exchange.symbols:
+            return symbol
+        s = symbol.strip()
+        if s.endswith("/USDT") and f"{s}:USDT" in exchange.symbols:
+            return f"{s}:USDT"
+        return symbol
+
+    @staticmethod
+    def _fetch_range(
+        exchange, symbol: str, timeframe: str, since_ms: int, until_ms: int
+    ) -> list[list[float]]:
+        out: list[list[float]] = []
+        cursor = since_ms
+        while cursor < until_ms:
+            batch = exchange.fetch_ohlcv(symbol, timeframe=timeframe, since=cursor, limit=1000)
+            if not batch:
+                break
+            for row in batch:
+                ts = int(row[0])
+                if ts < since_ms:
+                    continue
+                if ts > until_ms:
+                    continue
+                out.append([float(v) for v in row])
+            last_ts = int(batch[-1][0])
+            if last_ts <= cursor:
+                break
+            cursor = last_ts + 1
+            if len(batch) < 1000:
+                break
+        out.sort(key=lambda r: r[0])
+        return out
+
+    @staticmethod
+    def _to_dataframe(raw: list[list[float]]) -> pd.DataFrame:
+        df = pd.DataFrame(raw, columns=["timestamp", "open", "high", "low", "close", "volume"])
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+        df = df.set_index("timestamp")
+        df.index.name = "trade_date"
+        return df[_OHLCV_COLUMNS]

--- a/src/backtest/loaders/ccxt_loader.py
+++ b/src/backtest/loaders/ccxt_loader.py
@@ -9,7 +9,6 @@ import ccxt
 import pandas as pd
 
 from .base import validate_date_range
-from .registry import register
 
 _OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
 _INTERVAL_MAP = {
@@ -26,7 +25,6 @@ _INTERVAL_MAP = {
 }
 
 
-@register
 class CCXTLoader:
     """Fetch crypto OHLCV bars via CCXT (public, no API key needed)."""
 

--- a/src/backtest/loaders/futu_loader.py
+++ b/src/backtest/loaders/futu_loader.py
@@ -5,30 +5,23 @@ from __future__ import annotations
 import os
 from typing import Dict, List, Optional
 
+import futu
 import pandas as pd
 
-from .base import NoAvailableSourceError, validate_date_range
+from .base import validate_date_range
 from .registry import register
 
 _OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
 _INTERVAL_MAP: dict[str, str] = {
     "1D": "K_DAY",
     "1H": "K_60M",
-    "4H": "K_240M",
+    "4H": "K_DAY",
     "1W": "K_WEEK",
     "1M": "K_MON",
 }
 
 
 def _to_futu_symbol(code: str) -> str:
-    """Convert project symbol to Futu OpenAPI format.
-
-    Examples:
-        700.HK    -> HK.00700
-        5.HK      -> HK.00005
-        000001.SZ -> SZ.000001
-        600519.SH -> SH.600519
-    """
     upper = code.strip().upper()
     if upper.endswith(".HK"):
         return f"HK.{upper[:-3].zfill(5)}"
@@ -39,17 +32,13 @@ def _to_futu_symbol(code: str) -> str:
     return upper
 
 
-def _to_futu_ktype(interval: str):
-    from futu import KLType  # noqa: PLC0415
-
-    return getattr(KLType, _INTERVAL_MAP.get(interval.strip(), "K_DAY"))
+def _to_futu_ktype(interval: str) -> str:
+    return getattr(futu.KLType, _INTERVAL_MAP.get(interval.strip(), "K_DAY"))
 
 
 def _normalize_frame(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalise a Futu kline DataFrame to the standard OHLCV schema."""
     if df.empty:
         return pd.DataFrame(columns=_OHLCV_COLUMNS)
-
     result = df.copy()
     result.index = pd.to_datetime(result["time_key"])
     result.index.name = "trade_date"
@@ -64,8 +53,7 @@ def _normalize_frame(df: pd.DataFrame) -> pd.DataFrame:
 class FutuLoader:
     """Fetch HK and China A-share bars from Futu OpenAPI.
 
-    Requires FutuOpenD running locally (https://www.futunn.com/download/openAPI)
-    and the env vars ``FUTU_HOST`` / ``FUTU_PORT`` to be set.
+    Requires FutuOpenD running locally (https://www.futunn.com/download/openAPI).
     """
 
     name = "futu"
@@ -76,18 +64,6 @@ class FutuLoader:
         self._host = os.environ.get("FUTU_HOST", "127.0.0.1")
         self._port = int(os.environ.get("FUTU_PORT", "11111"))
 
-    def is_available(self) -> bool:
-        if not os.environ.get("FUTU_HOST") or not os.environ.get("FUTU_PORT"):
-            return False
-        try:
-            import futu  # noqa: PLC0415
-
-            ctx = futu.OpenQuoteContext(host=self._host, port=self._port)
-            ctx.close()
-            return True
-        except Exception:
-            return False
-
     def fetch(
         self,
         codes: List[str],
@@ -97,31 +73,13 @@ class FutuLoader:
         interval: str = "1D",
         fields: Optional[List[str]] = None,
     ) -> Dict[str, pd.DataFrame]:
-        """Fetch OHLCV history from Futu OpenAPI.
-
-        Args:
-            codes: Project symbols such as ``700.HK`` or ``000001.SZ``.
-            start_date: Start date in ``YYYY-MM-DD`` format.
-            end_date: End date in ``YYYY-MM-DD`` format.
-            interval: Backtest interval — ``1D``, ``1H``, or ``4H``.
-
-        Returns:
-            Mapping of input symbol to normalised OHLCV dataframe.
-        """
         del fields
         if not codes:
             return {}
         validate_date_range(start_date, end_date)
 
-        try:
-            import futu  # noqa: PLC0415
-
-            ktype = _to_futu_ktype(interval)
-            ctx = futu.OpenQuoteContext(host=self._host, port=self._port)
-        except Exception as exc:
-            raise NoAvailableSourceError(
-                f"Cannot connect to FutuOpenD at {self._host}:{self._port}: {exc}"
-            ) from exc
+        ktype = _to_futu_ktype(interval)
+        ctx = futu.OpenQuoteContext(host=self._host, port=self._port)
 
         results: Dict[str, pd.DataFrame] = {}
         try:
@@ -135,7 +93,6 @@ class FutuLoader:
                     max_count=10_000,
                 )
                 if ret != futu.RET_OK:
-                    print(f"[WARN] Futu returned error for {futu_code}: {data}")
                     continue
                 results[code] = _normalize_frame(data)
         finally:

--- a/src/backtest/loaders/futu_loader.py
+++ b/src/backtest/loaders/futu_loader.py
@@ -1,0 +1,144 @@
+"""Futu OpenAPI-backed loader for HK and China A-share OHLCV data."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .base import NoAvailableSourceError, validate_date_range
+from .registry import register
+
+_OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
+_INTERVAL_MAP: dict[str, str] = {
+    "1D": "K_DAY",
+    "1H": "K_60M",
+    "4H": "K_240M",
+    "1W": "K_WEEK",
+    "1M": "K_MON",
+}
+
+
+def _to_futu_symbol(code: str) -> str:
+    """Convert project symbol to Futu OpenAPI format.
+
+    Examples:
+        700.HK    -> HK.00700
+        5.HK      -> HK.00005
+        000001.SZ -> SZ.000001
+        600519.SH -> SH.600519
+    """
+    upper = code.strip().upper()
+    if upper.endswith(".HK"):
+        return f"HK.{upper[:-3].zfill(5)}"
+    if upper.endswith(".SZ"):
+        return f"SZ.{upper[:-3].zfill(6)}"
+    if upper.endswith(".SH"):
+        return f"SH.{upper[:-3].zfill(6)}"
+    return upper
+
+
+def _to_futu_ktype(interval: str):
+    from futu import KLType  # noqa: PLC0415
+
+    return getattr(KLType, _INTERVAL_MAP.get(interval.strip(), "K_DAY"))
+
+
+def _normalize_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise a Futu kline DataFrame to the standard OHLCV schema."""
+    if df.empty:
+        return pd.DataFrame(columns=_OHLCV_COLUMNS)
+
+    result = df.copy()
+    result.index = pd.to_datetime(result["time_key"])
+    result.index.name = "trade_date"
+    result = result[_OHLCV_COLUMNS].copy()
+    result = result.apply(pd.to_numeric, errors="coerce")
+    result["volume"] = result["volume"].fillna(0.0)
+    result = result.dropna(subset=["open", "high", "low", "close"])
+    return result.sort_index()
+
+
+@register
+class FutuLoader:
+    """Fetch HK and China A-share bars from Futu OpenAPI.
+
+    Requires FutuOpenD running locally (https://www.futunn.com/download/openAPI)
+    and the env vars ``FUTU_HOST`` / ``FUTU_PORT`` to be set.
+    """
+
+    name = "futu"
+    markets = {"hk_equity", "a_share", "us_equity"}
+    requires_auth = True
+
+    def __init__(self) -> None:
+        self._host = os.environ.get("FUTU_HOST", "127.0.0.1")
+        self._port = int(os.environ.get("FUTU_PORT", "11111"))
+
+    def is_available(self) -> bool:
+        if not os.environ.get("FUTU_HOST") or not os.environ.get("FUTU_PORT"):
+            return False
+        try:
+            import futu  # noqa: PLC0415
+
+            ctx = futu.OpenQuoteContext(host=self._host, port=self._port)
+            ctx.close()
+            return True
+        except Exception:
+            return False
+
+    def fetch(
+        self,
+        codes: List[str],
+        start_date: str,
+        end_date: str,
+        *,
+        interval: str = "1D",
+        fields: Optional[List[str]] = None,
+    ) -> Dict[str, pd.DataFrame]:
+        """Fetch OHLCV history from Futu OpenAPI.
+
+        Args:
+            codes: Project symbols such as ``700.HK`` or ``000001.SZ``.
+            start_date: Start date in ``YYYY-MM-DD`` format.
+            end_date: End date in ``YYYY-MM-DD`` format.
+            interval: Backtest interval — ``1D``, ``1H``, or ``4H``.
+
+        Returns:
+            Mapping of input symbol to normalised OHLCV dataframe.
+        """
+        del fields
+        if not codes:
+            return {}
+        validate_date_range(start_date, end_date)
+
+        try:
+            import futu  # noqa: PLC0415
+
+            ktype = _to_futu_ktype(interval)
+            ctx = futu.OpenQuoteContext(host=self._host, port=self._port)
+        except Exception as exc:
+            raise NoAvailableSourceError(
+                f"Cannot connect to FutuOpenD at {self._host}:{self._port}: {exc}"
+            ) from exc
+
+        results: Dict[str, pd.DataFrame] = {}
+        try:
+            for code in codes:
+                futu_code = _to_futu_symbol(code)
+                ret, data = ctx.request_history_kline(
+                    futu_code,
+                    start=start_date,
+                    end=end_date,
+                    ktype=ktype,
+                    max_count=10_000,
+                )
+                if ret != futu.RET_OK:
+                    print(f"[WARN] Futu returned error for {futu_code}: {data}")
+                    continue
+                results[code] = _normalize_frame(data)
+        finally:
+            ctx.close()
+
+        return results

--- a/src/backtest/loaders/futu_loader.py
+++ b/src/backtest/loaders/futu_loader.py
@@ -9,7 +9,6 @@ import futu
 import pandas as pd
 
 from .base import validate_date_range
-from .registry import register
 
 _OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
 _INTERVAL_MAP: dict[str, str] = {
@@ -49,7 +48,6 @@ def _normalize_frame(df: pd.DataFrame) -> pd.DataFrame:
     return result.sort_index()
 
 
-@register
 class FutuLoader:
     """Fetch HK and China A-share bars from Futu OpenAPI.
 

--- a/src/backtest/loaders/registry.py
+++ b/src/backtest/loaders/registry.py
@@ -1,21 +1,17 @@
-"""Loader registry with market-level fallback chains.
+"""Loader registry with direct module-level registration.
 
 Loaders self-register via the ``@register`` decorator when their module is
-first imported.  ``_ensure_registered()`` lazily imports every known loader
-module so the registry is always populated.
+imported.  Every known loader module is imported eagerly since dependencies
+are declared in ``pyproject.toml``.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import Any, Type
 
 from .base import NoAvailableSourceError
 
-logger = logging.getLogger(__name__)
-
 LOADER_REGISTRY: dict[str, Type[Any]] = {}
-_registered = False
 
 
 def register(cls: Type[Any]) -> Type[Any]:
@@ -25,23 +21,9 @@ def register(cls: Type[Any]) -> Type[Any]:
 
 
 def _ensure_registered() -> None:
-    global _registered
-    if _registered:
-        return
-    _registered = True
-
-    _loader_modules = [
-        "backtest.loaders.ccxt_loader",
-        "backtest.loaders.futu_loader",
-        "backtest.loaders.yfinance_loader",
-    ]
-    import importlib
-
-    for mod in _loader_modules:
-        try:
-            importlib.import_module(mod)
-        except Exception:
-            pass
+    import backtest.loaders.ccxt_loader  # noqa: F401
+    import backtest.loaders.futu_loader  # noqa: F401
+    import backtest.loaders.yfinance_loader  # noqa: F401
 
 
 FALLBACK_CHAINS: dict[str, list[str]] = {
@@ -55,11 +37,7 @@ FALLBACK_CHAINS: dict[str, list[str]] = {
 
 
 def resolve_loader(market: str) -> Any:
-    """Return the first *available* loader instance for *market*.
-
-    Walks the fallback chain and returns the first loader whose
-    ``is_available()`` returns ``True``.
-    """
+    """Return the first loader instance for *market* following the fallback chain."""
     _ensure_registered()
     chain = FALLBACK_CHAINS.get(market, [])
     tried: list[str] = []
@@ -68,36 +46,7 @@ def resolve_loader(market: str) -> Any:
             continue
         loader = LOADER_REGISTRY[name]()
         tried.append(name)
-        if loader.is_available():
-            return loader
+        return loader
     raise NoAvailableSourceError(
-        f"No available data source for market '{market}'. "
-        f"Tried: {tried or chain}. Check network and API token config."
+        f"No available data source for market '{market}'. Tried: {tried or chain}."
     )
-
-
-def get_loader_cls_with_fallback(source: str) -> Type[Any]:
-    """Return a loader *class* for *source*, falling back if unavailable."""
-    _ensure_registered()
-    if source not in LOADER_REGISTRY:
-        raise NoAvailableSourceError(f"Unknown data source: {source}")
-
-    loader_cls = LOADER_REGISTRY[source]
-    instance = loader_cls()
-    if instance.is_available():
-        return loader_cls
-
-    for market in loader_cls.markets:
-        try:
-            fallback = resolve_loader(market)
-            logger.warning(
-                "%s is unavailable, falling back to %s for market %s",
-                source,
-                fallback.name,
-                market,
-            )
-            return type(fallback)
-        except NoAvailableSourceError:
-            continue
-
-    raise NoAvailableSourceError(f"Data source '{source}' is unavailable and no fallback found.")

--- a/src/backtest/loaders/registry.py
+++ b/src/backtest/loaders/registry.py
@@ -1,0 +1,103 @@
+"""Loader registry with market-level fallback chains.
+
+Loaders self-register via the ``@register`` decorator when their module is
+first imported.  ``_ensure_registered()`` lazily imports every known loader
+module so the registry is always populated.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Type
+
+from .base import NoAvailableSourceError
+
+logger = logging.getLogger(__name__)
+
+LOADER_REGISTRY: dict[str, Type[Any]] = {}
+_registered = False
+
+
+def register(cls: Type[Any]) -> Type[Any]:
+    """Class decorator: register a loader into the global registry."""
+    LOADER_REGISTRY[cls.name] = cls
+    return cls
+
+
+def _ensure_registered() -> None:
+    global _registered
+    if _registered:
+        return
+    _registered = True
+
+    _loader_modules = [
+        "backtest.loaders.ccxt_loader",
+        "backtest.loaders.futu_loader",
+        "backtest.loaders.yfinance_loader",
+    ]
+    import importlib
+
+    for mod in _loader_modules:
+        try:
+            importlib.import_module(mod)
+        except Exception:
+            pass
+
+
+FALLBACK_CHAINS: dict[str, list[str]] = {
+    "crypto": ["ccxt"],
+    "hk_equity": ["futu", "yfinance", "ccxt"],
+    "a_share": ["futu", "yfinance", "ccxt"],
+    "us_equity": ["yfinance", "futu", "ccxt"],
+    "futures": ["yfinance"],
+    "forex": ["yfinance"],
+}
+
+
+def resolve_loader(market: str) -> Any:
+    """Return the first *available* loader instance for *market*.
+
+    Walks the fallback chain and returns the first loader whose
+    ``is_available()`` returns ``True``.
+    """
+    _ensure_registered()
+    chain = FALLBACK_CHAINS.get(market, [])
+    tried: list[str] = []
+    for name in chain:
+        if name not in LOADER_REGISTRY:
+            continue
+        loader = LOADER_REGISTRY[name]()
+        tried.append(name)
+        if loader.is_available():
+            return loader
+    raise NoAvailableSourceError(
+        f"No available data source for market '{market}'. "
+        f"Tried: {tried or chain}. Check network and API token config."
+    )
+
+
+def get_loader_cls_with_fallback(source: str) -> Type[Any]:
+    """Return a loader *class* for *source*, falling back if unavailable."""
+    _ensure_registered()
+    if source not in LOADER_REGISTRY:
+        raise NoAvailableSourceError(f"Unknown data source: {source}")
+
+    loader_cls = LOADER_REGISTRY[source]
+    instance = loader_cls()
+    if instance.is_available():
+        return loader_cls
+
+    for market in loader_cls.markets:
+        try:
+            fallback = resolve_loader(market)
+            logger.warning(
+                "%s is unavailable, falling back to %s for market %s",
+                source,
+                fallback.name,
+                market,
+            )
+            return type(fallback)
+        except NoAvailableSourceError:
+            continue
+
+    raise NoAvailableSourceError(f"Data source '{source}' is unavailable and no fallback found.")

--- a/src/backtest/loaders/registry.py
+++ b/src/backtest/loaders/registry.py
@@ -1,8 +1,7 @@
 """Loader registry with direct module-level registration.
 
 Loaders self-register via the ``@register`` decorator when their module is
-imported.  Every known loader module is imported eagerly since dependencies
-are declared in ``pyproject.toml``.
+imported.
 """
 
 from __future__ import annotations
@@ -20,12 +19,6 @@ def register(cls: Type[Any]) -> Type[Any]:
     return cls
 
 
-def _ensure_registered() -> None:
-    import backtest.loaders.ccxt_loader  # noqa: F401
-    import backtest.loaders.futu_loader  # noqa: F401
-    import backtest.loaders.yfinance_loader  # noqa: F401
-
-
 FALLBACK_CHAINS: dict[str, list[str]] = {
     "crypto": ["ccxt"],
     "hk_equity": ["futu", "yfinance", "ccxt"],
@@ -38,7 +31,6 @@ FALLBACK_CHAINS: dict[str, list[str]] = {
 
 def resolve_loader(market: str) -> Any:
     """Return the first loader instance for *market* following the fallback chain."""
-    _ensure_registered()
     chain = FALLBACK_CHAINS.get(market, [])
     tried: list[str] = []
     for name in chain:
@@ -50,3 +42,9 @@ def resolve_loader(market: str) -> Any:
     raise NoAvailableSourceError(
         f"No available data source for market '{market}'. Tried: {tried or chain}."
     )
+
+
+# Import loaders at module bottom so @register fires after LOADER_REGISTRY exists.
+import backtest.loaders.ccxt_loader  # noqa: F401 E402
+import backtest.loaders.futu_loader  # noqa: F401 E402
+import backtest.loaders.yfinance_loader  # noqa: F401 E402

--- a/src/backtest/loaders/registry.py
+++ b/src/backtest/loaders/registry.py
@@ -1,7 +1,6 @@
-"""Loader registry with direct module-level registration.
+"""Loader registry with market-level fallback chains.
 
-Loaders self-register via the ``@register`` decorator when their module is
-imported.
+Loaders are registered explicitly — no decorators, no automatic imports.
 """
 
 from __future__ import annotations
@@ -9,16 +8,11 @@ from __future__ import annotations
 from typing import Any, Type
 
 from .base import NoAvailableSourceError
+from .ccxt_loader import CCXTLoader
+from .futu_loader import FutuLoader
+from .yfinance_loader import YFinanceLoader
 
 LOADER_REGISTRY: dict[str, Type[Any]] = {}
-
-
-def register(cls: Type[Any]) -> Type[Any]:
-    """Class decorator: register a loader into the global registry."""
-    LOADER_REGISTRY[cls.name] = cls
-    return cls
-
-
 FALLBACK_CHAINS: dict[str, list[str]] = {
     "crypto": ["ccxt"],
     "hk_equity": ["futu", "yfinance", "ccxt"],
@@ -29,6 +23,16 @@ FALLBACK_CHAINS: dict[str, list[str]] = {
 }
 
 
+def register_loader(cls: Type[Any]) -> Type[Any]:
+    LOADER_REGISTRY[cls.name] = cls
+    return cls
+
+
+register_loader(CCXTLoader)
+register_loader(FutuLoader)
+register_loader(YFinanceLoader)
+
+
 def resolve_loader(market: str) -> Any:
     """Return the first loader instance for *market* following the fallback chain."""
     chain = FALLBACK_CHAINS.get(market, [])
@@ -36,15 +40,8 @@ def resolve_loader(market: str) -> Any:
     for name in chain:
         if name not in LOADER_REGISTRY:
             continue
-        loader = LOADER_REGISTRY[name]()
         tried.append(name)
-        return loader
+        return LOADER_REGISTRY[name]()
     raise NoAvailableSourceError(
         f"No available data source for market '{market}'. Tried: {tried or chain}."
     )
-
-
-# Import loaders at module bottom so @register fires after LOADER_REGISTRY exists.
-import backtest.loaders.ccxt_loader  # noqa: F401 E402
-import backtest.loaders.futu_loader  # noqa: F401 E402
-import backtest.loaders.yfinance_loader  # noqa: F401 E402

--- a/src/backtest/loaders/yfinance_loader.py
+++ b/src/backtest/loaders/yfinance_loader.py
@@ -8,12 +8,10 @@ import pandas as pd
 import yfinance as yf
 
 from .base import validate_date_range
-from .registry import register
 
 _OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
 
 
-@register
 class YFinanceLoader:
     """Fetch global equity bars via yfinance (free, no API key needed)."""
 

--- a/src/backtest/loaders/yfinance_loader.py
+++ b/src/backtest/loaders/yfinance_loader.py
@@ -1,0 +1,84 @@
+"""Yahoo Finance-backed loader for global equity OHLCV data."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .base import NoAvailableSourceError, validate_date_range
+from .registry import register
+
+_OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
+
+
+@register
+class YFinanceLoader:
+    """Fetch global equity bars via yfinance (free, no API key needed)."""
+
+    name = "yfinance"
+    markets = {"hk_equity", "us_equity", "a_share"}
+    requires_auth = False
+
+    def is_available(self) -> bool:
+        import importlib.util
+
+        return importlib.util.find_spec("yfinance") is not None
+
+    def fetch(
+        self,
+        codes: list[str],
+        start_date: str,
+        end_date: str,
+        *,
+        interval: str = "1D",
+        fields: Optional[List[str]] = None,
+    ) -> Dict[str, pd.DataFrame]:
+        """Fetch OHLCV history from Yahoo Finance.
+
+        Args:
+            codes: Yahoo ticker symbols e.g. ``0700.HK``, ``0005.HK``, ``AAPL``.
+            start_date: Start date ``YYYY-MM-DD``.
+            end_date: End date ``YYYY-MM-DD``.
+            interval: Supported: ``1D``, ``1H``.
+
+        Returns:
+            {symbol: DataFrame[trade_date, open, high, low, close, volume]}
+        """
+        del fields
+        if not codes:
+            return {}
+        validate_date_range(start_date, end_date)
+
+        try:
+            import yfinance as yf  # noqa: PLC0415
+        except ImportError as exc:
+            raise NoAvailableSourceError("yfinance not installed") from exc
+
+        _interval_map = {"1D": "1d", "1H": "60m", "4H": "1d"}
+        yf_interval = _interval_map.get(interval.strip(), "1d")
+
+        results: Dict[str, pd.DataFrame] = {}
+        for code in codes:
+            try:
+                ticker = yf.Ticker(code)
+                hist = ticker.history(
+                    start=start_date,
+                    end=end_date,
+                    interval=yf_interval,
+                    auto_adjust=True,
+                )
+            except Exception as exc:
+                print(f"[WARN] yfinance failed for {code}: {exc}")
+                continue
+
+            if hist.empty:
+                continue
+
+            df = hist[["Open", "High", "Low", "Close", "Volume"]].copy()
+            df.columns = _OHLCV_COLUMNS
+            df.index.name = "trade_date"
+            df["volume"] = df["volume"].fillna(0.0)
+            results[code] = df
+
+        return results

--- a/src/backtest/loaders/yfinance_loader.py
+++ b/src/backtest/loaders/yfinance_loader.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 
 import pandas as pd
+import yfinance as yf
 
-from .base import NoAvailableSourceError, validate_date_range
+from .base import validate_date_range
 from .registry import register
 
 _OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
@@ -20,11 +21,6 @@ class YFinanceLoader:
     markets = {"hk_equity", "us_equity", "a_share"}
     requires_auth = False
 
-    def is_available(self) -> bool:
-        import importlib.util
-
-        return importlib.util.find_spec("yfinance") is not None
-
     def fetch(
         self,
         codes: list[str],
@@ -34,47 +30,25 @@ class YFinanceLoader:
         interval: str = "1D",
         fields: Optional[List[str]] = None,
     ) -> Dict[str, pd.DataFrame]:
-        """Fetch OHLCV history from Yahoo Finance.
-
-        Args:
-            codes: Yahoo ticker symbols e.g. ``0700.HK``, ``0005.HK``, ``AAPL``.
-            start_date: Start date ``YYYY-MM-DD``.
-            end_date: End date ``YYYY-MM-DD``.
-            interval: Supported: ``1D``, ``1H``.
-
-        Returns:
-            {symbol: DataFrame[trade_date, open, high, low, close, volume]}
-        """
         del fields
         if not codes:
             return {}
         validate_date_range(start_date, end_date)
-
-        try:
-            import yfinance as yf  # noqa: PLC0415
-        except ImportError as exc:
-            raise NoAvailableSourceError("yfinance not installed") from exc
 
         _interval_map = {"1D": "1d", "1H": "60m", "4H": "1d"}
         yf_interval = _interval_map.get(interval.strip(), "1d")
 
         results: Dict[str, pd.DataFrame] = {}
         for code in codes:
-            try:
-                ticker = yf.Ticker(code)
-                hist = ticker.history(
-                    start=start_date,
-                    end=end_date,
-                    interval=yf_interval,
-                    auto_adjust=True,
-                )
-            except Exception as exc:
-                print(f"[WARN] yfinance failed for {code}: {exc}")
-                continue
-
+            ticker = yf.Ticker(code)
+            hist = ticker.history(
+                start=start_date,
+                end=end_date,
+                interval=yf_interval,
+                auto_adjust=True,
+            )
             if hist.empty:
                 continue
-
             df = hist[["Open", "High", "Low", "Close", "Volume"]].copy()
             df.columns = _OHLCV_COLUMNS
             df.index.name = "trade_date"

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -1,0 +1,194 @@
+"""Tests for Loader Registry and CCXT loader."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from backtest.loaders.base import DataLoaderProtocol, NoAvailableSourceError, validate_date_range
+from backtest.loaders.registry import (
+    FALLBACK_CHAINS,
+    LOADER_REGISTRY,
+    _ensure_registered,
+    register,
+    resolve_loader,
+)
+
+
+class TestValidateDateRange:
+    def test_valid_range(self):
+        validate_date_range("2024-01-01", "2024-01-31")
+
+    def test_invalid_order_raises(self):
+        with pytest.raises(ValueError, match="start_date"):
+            validate_date_range("2024-02-01", "2024-01-01")
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Invalid date format"):
+            validate_date_range("not-a-date", "2024-01-31")
+
+    def test_same_date_is_valid(self):
+        validate_date_range("2024-01-01", "2024-01-01")
+
+
+class TestProtocol:
+    def test_protocol_runtime_checkable(self):
+        class FakeLoader:
+            name = "test"
+            markets = {"crypto"}
+            requires_auth = False
+
+            def is_available(self):
+                return True
+
+            def fetch(self, codes, start, end, *, interval="1D", fields=None):
+                return {}
+
+        assert isinstance(FakeLoader(), DataLoaderProtocol)
+
+
+class TestRegistry:
+    def test_register_decorator(self):
+        @register
+        class _TestLoader:
+            name = "_unittest_test"
+            markets = {"crypto"}
+            requires_auth = False
+
+            def is_available(self):
+                return False
+
+            def fetch(self, codes, start, end, *, interval="1D", fields=None):
+                return {}
+
+        assert "_unittest_test" in LOADER_REGISTRY
+        assert LOADER_REGISTRY["_unittest_test"] is _TestLoader
+
+    def test_registry_has_ccxt(self):
+        _ensure_registered()
+        assert "ccxt" in LOADER_REGISTRY
+
+    def test_fallback_chains_defined(self):
+        assert "crypto" in FALLBACK_CHAINS
+        assert "hk_equity" in FALLBACK_CHAINS
+
+    def test_resolve_crypto_tries_ccxt(self):
+        _ensure_registered()
+        loader = resolve_loader("crypto")
+        assert loader.name == "ccxt"
+
+    def test_resolve_unknown_raises(self):
+        with pytest.raises(NoAvailableSourceError):
+            resolve_loader("nonexistent_market_xyz")
+
+
+class TestCCXTLoader:
+    def test_imports(self):
+        from backtest.loaders.ccxt_loader import CCXTLoader
+
+        assert CCXTLoader.name == "ccxt"
+        assert "crypto" in CCXTLoader.markets
+
+    def test_is_available_returns_bool(self):
+        from backtest.loaders.ccxt_loader import CCXTLoader
+
+        result = CCXTLoader().is_available()
+        assert isinstance(result, bool)
+
+
+class TestFutuLoader:
+    def test_imports(self):
+        from backtest.loaders.futu_loader import (
+            FutuLoader,
+        )
+
+        assert FutuLoader.name == "futu"
+        assert "hk_equity" in FutuLoader.markets
+
+    def test_symbol_hk(self):
+        from backtest.loaders.futu_loader import _to_futu_symbol
+
+        assert _to_futu_symbol("700.HK") == "HK.00700"
+
+    def test_symbol_hk_short_padded(self):
+        from backtest.loaders.futu_loader import _to_futu_symbol
+
+        assert _to_futu_symbol("5.HK") == "HK.00005"
+
+    def test_symbol_sz(self):
+        from backtest.loaders.futu_loader import _to_futu_symbol
+
+        assert _to_futu_symbol("000001.SZ") == "SZ.000001"
+
+    def test_symbol_sh(self):
+        from backtest.loaders.futu_loader import _to_futu_symbol
+
+        assert _to_futu_symbol("600519.SH") == "SH.600519"
+
+    def test_symbol_case_insensitive(self):
+        from backtest.loaders.futu_loader import _to_futu_symbol
+
+        assert _to_futu_symbol("700.hk") == "HK.00700"
+
+    def test_ktype_daily(self):
+        import sys
+        from unittest.mock import MagicMock
+
+        from backtest.loaders.futu_loader import _to_futu_ktype
+
+        futu_stub = MagicMock()
+        futu_stub.KLType.K_DAY = "K_DAY"
+        futu_stub.KLType.K_60M = "K_60M"
+        futu_stub.KLType.K_240M = "K_240M"
+        futu_stub.KLType.K_WEEK = "K_WEEK"
+        futu_stub.KLType.K_MON = "K_MON"
+        sys.modules["futu"] = futu_stub
+
+        assert _to_futu_ktype("1D") == "K_DAY"
+        assert _to_futu_ktype("1H") == "K_60M"
+        assert _to_futu_ktype("unknown") == "K_DAY"
+
+    def test_normalize_frame_empty(self):
+        from backtest.loaders.futu_loader import _normalize_frame
+
+        result = _normalize_frame(pd.DataFrame())
+        assert result.empty
+        assert list(result.columns) == ["open", "high", "low", "close", "volume"]
+
+    def test_normalize_frame_columns(self):
+        from backtest.loaders.futu_loader import _normalize_frame
+
+        df = pd.DataFrame(
+            {
+                "code": ["HK.00700", "HK.00700"],
+                "time_key": ["2024-01-02 00:00:00", "2024-01-03 00:00:00"],
+                "open": [350.0, 355.0],
+                "high": [360.0, 358.0],
+                "low": [345.0, 352.0],
+                "close": [355.0, 356.0],
+                "volume": [1_000_000, 900_000],
+                "turnover": [350_000_000.0, 320_000_000.0],
+            }
+        )
+        result = _normalize_frame(df)
+        assert list(result.columns) == ["open", "high", "low", "close", "volume"]
+        assert result.index.name == "trade_date"
+        assert len(result) == 2
+
+    def test_normalize_frame_drops_nan_ohlc(self):
+        from backtest.loaders.futu_loader import _normalize_frame
+
+        df = pd.DataFrame(
+            {
+                "code": ["HK.00700", "HK.00700"],
+                "time_key": ["2024-01-02 00:00:00", "2024-01-03 00:00:00"],
+                "open": [350.0, None],
+                "high": [360.0, None],
+                "low": [345.0, None],
+                "close": [355.0, None],
+                "volume": [1_000_000, 900_000],
+                "turnover": [350_000_000.0, 320_000_000.0],
+            }
+        )
+        result = _normalize_frame(df)
+        assert len(result) == 1

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -12,7 +12,7 @@ from backtest.loaders.base import NoAvailableSourceError, validate_date_range
 from backtest.loaders.registry import (
     FALLBACK_CHAINS,
     LOADER_REGISTRY,
-    register,
+    register_loader,
     resolve_loader,
 )
 
@@ -34,9 +34,8 @@ class TestValidateDateRange:
 
 
 class TestRegistry:
-    def test_register_decorator(self):
-        @register
-        class _TestLoader:
+    def test_register_loader(self):
+        class _MockLoader:
             name = "_unittest_test"
             markets = {"crypto"}
             requires_auth = False
@@ -44,8 +43,9 @@ class TestRegistry:
             def fetch(self, codes, start, end, **kw):
                 return {}
 
+        register_loader(_MockLoader)
         assert "_unittest_test" in LOADER_REGISTRY
-        assert LOADER_REGISTRY["_unittest_test"] is _TestLoader
+        assert LOADER_REGISTRY["_unittest_test"] is _MockLoader
 
     def test_registry_has_all_loaders(self):
         assert "ccxt" in LOADER_REGISTRY

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -1,11 +1,14 @@
-"""Tests for Loader Registry and CCXT loader."""
+"""Tests for data loader registry and individual loaders."""
 
 from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
-from backtest.loaders.base import DataLoaderProtocol, NoAvailableSourceError, validate_date_range
+from backtest.loaders.base import NoAvailableSourceError, validate_date_range
 from backtest.loaders.registry import (
     FALLBACK_CHAINS,
     LOADER_REGISTRY,
@@ -31,22 +34,6 @@ class TestValidateDateRange:
         validate_date_range("2024-01-01", "2024-01-01")
 
 
-class TestProtocol:
-    def test_protocol_runtime_checkable(self):
-        class FakeLoader:
-            name = "test"
-            markets = {"crypto"}
-            requires_auth = False
-
-            def is_available(self):
-                return True
-
-            def fetch(self, codes, start, end, *, interval="1D", fields=None):
-                return {}
-
-        assert isinstance(FakeLoader(), DataLoaderProtocol)
-
-
 class TestRegistry:
     def test_register_decorator(self):
         @register
@@ -55,24 +42,25 @@ class TestRegistry:
             markets = {"crypto"}
             requires_auth = False
 
-            def is_available(self):
-                return False
-
-            def fetch(self, codes, start, end, *, interval="1D", fields=None):
+            def fetch(self, codes, start, end, **kw):
                 return {}
 
         assert "_unittest_test" in LOADER_REGISTRY
         assert LOADER_REGISTRY["_unittest_test"] is _TestLoader
 
-    def test_registry_has_ccxt(self):
+    def test_registry_has_all_loaders(self):
         _ensure_registered()
         assert "ccxt" in LOADER_REGISTRY
+        assert "futu" in LOADER_REGISTRY
+        assert "yfinance" in LOADER_REGISTRY
 
     def test_fallback_chains_defined(self):
         assert "crypto" in FALLBACK_CHAINS
         assert "hk_equity" in FALLBACK_CHAINS
+        assert "a_share" in FALLBACK_CHAINS
+        assert "us_equity" in FALLBACK_CHAINS
 
-    def test_resolve_crypto_tries_ccxt(self):
+    def test_resolve_returns_first_in_chain(self):
         _ensure_registered()
         loader = resolve_loader("crypto")
         assert loader.name == "ccxt"
@@ -81,81 +69,85 @@ class TestRegistry:
         with pytest.raises(NoAvailableSourceError):
             resolve_loader("nonexistent_market_xyz")
 
+    def test_resolve_hk_equity_returns_futu(self):
+        _ensure_registered()
+        loader = resolve_loader("hk_equity")
+        assert loader.name == "futu"
 
-class TestCCXTLoader:
-    def test_imports(self):
-        from backtest.loaders.ccxt_loader import CCXTLoader
-
-        assert CCXTLoader.name == "ccxt"
-        assert "crypto" in CCXTLoader.markets
-
-    def test_is_available_returns_bool(self):
-        from backtest.loaders.ccxt_loader import CCXTLoader
-
-        result = CCXTLoader().is_available()
-        assert isinstance(result, bool)
+    def test_resolve_us_returns_yfinance(self):
+        _ensure_registered()
+        loader = resolve_loader("us_equity")
+        assert loader.name == "yfinance"
 
 
-class TestFutuLoader:
-    def test_imports(self):
-        from backtest.loaders.futu_loader import (
-            FutuLoader,
-        )
-
-        assert FutuLoader.name == "futu"
-        assert "hk_equity" in FutuLoader.markets
-
-    def test_symbol_hk(self):
+class TestFutuSymbol:
+    def test_hk(self):
         from backtest.loaders.futu_loader import _to_futu_symbol
 
         assert _to_futu_symbol("700.HK") == "HK.00700"
 
-    def test_symbol_hk_short_padded(self):
+    def test_hk_short_padded(self):
         from backtest.loaders.futu_loader import _to_futu_symbol
 
         assert _to_futu_symbol("5.HK") == "HK.00005"
 
-    def test_symbol_sz(self):
+    def test_sz(self):
         from backtest.loaders.futu_loader import _to_futu_symbol
 
         assert _to_futu_symbol("000001.SZ") == "SZ.000001"
 
-    def test_symbol_sh(self):
+    def test_sh(self):
         from backtest.loaders.futu_loader import _to_futu_symbol
 
         assert _to_futu_symbol("600519.SH") == "SH.600519"
 
-    def test_symbol_case_insensitive(self):
+    def test_case_insensitive(self):
         from backtest.loaders.futu_loader import _to_futu_symbol
 
         assert _to_futu_symbol("700.hk") == "HK.00700"
 
-    def test_ktype_daily(self):
-        import sys
-        from unittest.mock import MagicMock
 
+class TestFutuKtype:
+    @pytest.fixture(autouse=True)
+    def mock_futu(self, monkeypatch):
+        futu_mock = MagicMock()
+        futu_mock.KLType.K_DAY = "K_DAY"
+        futu_mock.KLType.K_60M = "K_60M"
+        futu_mock.KLType.K_240M = "K_240M"
+        futu_mock.KLType.K_WEEK = "K_WEEK"
+        futu_mock.KLType.K_MON = "K_MON"
+        monkeypatch.setitem(sys.modules, "futu", futu_mock)
+
+    def test_daily(self):
         from backtest.loaders.futu_loader import _to_futu_ktype
 
-        futu_stub = MagicMock()
-        futu_stub.KLType.K_DAY = "K_DAY"
-        futu_stub.KLType.K_60M = "K_60M"
-        futu_stub.KLType.K_240M = "K_240M"
-        futu_stub.KLType.K_WEEK = "K_WEEK"
-        futu_stub.KLType.K_MON = "K_MON"
-        sys.modules["futu"] = futu_stub
-
         assert _to_futu_ktype("1D") == "K_DAY"
+
+    def test_hourly(self):
+        from backtest.loaders.futu_loader import _to_futu_ktype
+
         assert _to_futu_ktype("1H") == "K_60M"
+
+    def test_four_hour(self):
+        from backtest.loaders.futu_loader import _to_futu_ktype
+
+        assert _to_futu_ktype("4H") == "K_DAY"
+
+    def test_unknown_defaults_to_day(self):
+        from backtest.loaders.futu_loader import _to_futu_ktype
+
         assert _to_futu_ktype("unknown") == "K_DAY"
 
-    def test_normalize_frame_empty(self):
+
+class TestNormalizeFrame:
+    def test_empty_input(self):
         from backtest.loaders.futu_loader import _normalize_frame
 
         result = _normalize_frame(pd.DataFrame())
         assert result.empty
         assert list(result.columns) == ["open", "high", "low", "close", "volume"]
 
-    def test_normalize_frame_columns(self):
+    def test_happy_path(self):
         from backtest.loaders.futu_loader import _normalize_frame
 
         df = pd.DataFrame(
@@ -174,21 +166,3 @@ class TestFutuLoader:
         assert list(result.columns) == ["open", "high", "low", "close", "volume"]
         assert result.index.name == "trade_date"
         assert len(result) == 2
-
-    def test_normalize_frame_drops_nan_ohlc(self):
-        from backtest.loaders.futu_loader import _normalize_frame
-
-        df = pd.DataFrame(
-            {
-                "code": ["HK.00700", "HK.00700"],
-                "time_key": ["2024-01-02 00:00:00", "2024-01-03 00:00:00"],
-                "open": [350.0, None],
-                "high": [360.0, None],
-                "low": [345.0, None],
-                "close": [355.0, None],
-                "volume": [1_000_000, 900_000],
-                "turnover": [350_000_000.0, 320_000_000.0],
-            }
-        )
-        result = _normalize_frame(df)
-        assert len(result) == 1

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -12,7 +12,6 @@ from backtest.loaders.base import NoAvailableSourceError, validate_date_range
 from backtest.loaders.registry import (
     FALLBACK_CHAINS,
     LOADER_REGISTRY,
-    _ensure_registered,
     register,
     resolve_loader,
 )
@@ -49,7 +48,6 @@ class TestRegistry:
         assert LOADER_REGISTRY["_unittest_test"] is _TestLoader
 
     def test_registry_has_all_loaders(self):
-        _ensure_registered()
         assert "ccxt" in LOADER_REGISTRY
         assert "futu" in LOADER_REGISTRY
         assert "yfinance" in LOADER_REGISTRY
@@ -61,7 +59,6 @@ class TestRegistry:
         assert "us_equity" in FALLBACK_CHAINS
 
     def test_resolve_returns_first_in_chain(self):
-        _ensure_registered()
         loader = resolve_loader("crypto")
         assert loader.name == "ccxt"
 
@@ -70,12 +67,10 @@ class TestRegistry:
             resolve_loader("nonexistent_market_xyz")
 
     def test_resolve_hk_equity_returns_futu(self):
-        _ensure_registered()
         loader = resolve_loader("hk_equity")
         assert loader.name == "futu"
 
     def test_resolve_us_returns_yfinance(self):
-        _ensure_registered()
         loader = resolve_loader("us_equity")
         assert loader.name == "yfinance"
 
@@ -113,7 +108,7 @@ class TestFutuKtype:
         futu_mock = MagicMock()
         futu_mock.KLType.K_DAY = "K_DAY"
         futu_mock.KLType.K_60M = "K_60M"
-        futu_mock.KLType.K_240M = "K_240M"
+        futu_mock.KLType.K_30M = "K_30M"
         futu_mock.KLType.K_WEEK = "K_WEEK"
         futu_mock.KLType.K_MON = "K_MON"
         monkeypatch.setitem(sys.modules, "futu", futu_mock)
@@ -128,7 +123,7 @@ class TestFutuKtype:
 
         assert _to_futu_ktype("1H") == "K_60M"
 
-    def test_four_hour(self):
+    def test_four_hour_falls_back_to_day(self):
         from backtest.loaders.futu_loader import _to_futu_ktype
 
         assert _to_futu_ktype("4H") == "K_DAY"


### PR DESCRIPTION
## Summary
Data loader registry with direct deps
Add yfinance and futu-api to pyproject.toml dependencies
Loaders import dependencies eagerly at module level

## Motivation

add support to futu api

## How to Test

uv run pytest -q

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (add `--runslow` if you touched slow tests)
- [x] Documentation updated if behavior or public API changed
- [x] No API keys or secrets committed