### PR TITLE
feat: add OMS execution engine and Hyperliquid adapter foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,31 @@ BACKTEST_API_MAX_STEPS=5000
 # AIMM_CORS_ORIGINS=*
 # AIMM_LLM_MODE=          # 0=force off, 1=force on
 TWITTER_BEARER_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Execution engine (opt-in OMS layer)
+# ---------------------------------------------------------------------------
+# AI_MARKET_MAKER_EXECUTION_ENGINE=legacy   # default — NexusAdapter paper path unchanged
+# AI_MARKET_MAKER_EXECUTION_ENGINE=oms      # opt-in — routes through OMS lifecycle tracking
+
+# ---------------------------------------------------------------------------
+# Exchange selection
+# ---------------------------------------------------------------------------
+# EXCHANGE=paper           # default — no real keys needed
+# EXCHANGE=hyperliquid     # requires AI_MARKET_MAKER_ALLOW_LIVE=1
+
+# Guard: must be 1 to allow any non-paper exchange. Leave 0 for paper-only operation.
+AI_MARKET_MAKER_ALLOW_LIVE=0
+
+# ---------------------------------------------------------------------------
+# Hyperliquid adapter (requires EXCHANGE=hyperliquid + AI_MARKET_MAKER_ALLOW_LIVE=1)
+# WARNING: Real live order placement is NOT implemented in this version.
+#          HYPERLIQUID_DRY_RUN=1 is the only supported Hyperliquid path.
+#          Setting HYPERLIQUID_DRY_RUN=0 without a complete SDK implementation
+#          will raise RuntimeError at startup. See docs/run-modes.md.
+# ---------------------------------------------------------------------------
+HYPERLIQUID_TESTNET=1       # 1=testnet (default/safe), 0=mainnet
+HYPERLIQUID_DRY_RUN=1       # 1=parse+validate only, never sends real orders
+# HYPERLIQUID_API_BASE=     # optional: override API base URL
+# HYPERLIQUID_API_KEY=      # wallet address (leave blank for dry-run/testnet only)
+# HYPERLIQUID_SECRET=       # NEVER commit this — private key / secret

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Designed to feel like a small professional trading firm — not just another bot
 - Quant-style backtesting with built-in benchmarks (excess return vs buy-and-hold)
 - Unified agent interface + governance layer
 - **OpenClaw-ready packaging** (`SKILL.md` + `manifest.json` + dedicated runners)
-- Paper trading on Binance Testnet + rich local backtester
+- Paper trading on Binance Testnet + rich local backtester; Hyperliquid adapter (dry-run) via OMS layer
 - Modern web dashboard for telemetry and traces
 - Clean configuration (JSON policy + env for secrets only)
 

--- a/docs/run-modes.md
+++ b/docs/run-modes.md
@@ -19,3 +19,88 @@ You can override the mode for a single run with the CLI:
 
 ```bash
 uv run python src/main.py --mode paper
+```
+
+---
+
+## Execution Engine & Exchange Adapters
+
+This section documents the OMS layer and exchange adapter system added in the Hyperliquid OMS adapter PR.
+
+### Execution engine selection
+
+`AI_MARKET_MAKER_EXECUTION_ENGINE` controls which execution path `get_nexus_adapter()` returns.
+
+| Value | Behaviour |
+|-------|-----------|
+| `legacy` (default) | Returns `NexusAdapter` on the existing paper path — zero behaviour change |
+| `oms` | Returns `OmsNexusAdapter` wrapping an `Oms` instance — adds idempotency, lifecycle states, cancel/status/reconcile |
+
+The default is `legacy`. No env var needed for the existing paper path.
+
+### Exchange adapters
+
+| `EXCHANGE` value | Adapter | Status |
+|-----------------|---------|--------|
+| `paper` (default) | `NexusAdapter` | Fully supported |
+| `hyperliquid` | `HyperliquidAdapter` | Dry-run only — see below |
+
+### Hyperliquid adapter status
+
+`HyperliquidAdapter` is present and tested. The following are fully implemented:
+
+- `FakeHyperliquidClient` — pure-Python test double, injectable, no SDK required
+- `dry_run=True` path — validates + normalizes orders, returns `status="dry_run"` without calling the exchange
+- `_SdkHyperliquidClient` — lazy SDK wrapper; raises `RuntimeError` with clear message if `hyperliquid-python-sdk` is not installed
+- Symbol normalization — `"BTC/USDT"` → `"BTC"`, `"ETH-USD"` → `"ETH"`, etc.
+
+**Not implemented in this PR:** `_SdkHyperliquidClient` method bodies are `NotImplementedError` stubs. Real live order placement via the Hyperliquid SDK is intentionally deferred. Attempting it raises `RuntimeError("not implemented")` at startup before any orders are placed.
+
+### Safety model
+
+| Layer | Mechanism |
+|-------|-----------|
+| Allow-live gate | `AI_MARKET_MAKER_ALLOW_LIVE=1` required for any non-paper exchange |
+| Dry-run guard | `HYPERLIQUID_DRY_RUN=1` — `HyperliquidAdapter.place_order()` returns immediately, adapter never called |
+| OMS dry-run | `dry_run=True` propagated to `Oms` — order held in `CREATED` state, adapter never called |
+| Testnet default | `HYPERLIQUID_TESTNET` defaults to `1` — mainnet requires explicit opt-out |
+| Fail-closed | Unsupported live path raises `RuntimeError` at startup, not at order time |
+| Secret redaction | `__repr__` on both `HyperliquidAdapter` and `ExchangeConfig` never exposes `hyperliquid_secret` |
+| Unknown states | Unrecognised exchange status maps to `OrderState.UNKNOWN` (conservative) |
+| Idempotency | `Oms` deduplicates by SHA-256 key — duplicate submit calls return existing order |
+
+### Example configurations
+
+**Default paper mode (no env changes needed):**
+
+```env
+# Nothing required — legacy NexusAdapter paper path is the default
+AI_MARKET_MAKER_EXECUTION_ENGINE=legacy
+```
+
+**OMS paper mode (lifecycle tracking, no real exchange):**
+
+```env
+AI_MARKET_MAKER_EXECUTION_ENGINE=oms
+EXCHANGE=paper
+```
+
+**Hyperliquid dry-run via OMS (supported):**
+
+```env
+AI_MARKET_MAKER_EXECUTION_ENGINE=oms
+EXCHANGE=hyperliquid
+AI_MARKET_MAKER_ALLOW_LIVE=1
+HYPERLIQUID_TESTNET=1
+HYPERLIQUID_DRY_RUN=1
+# No real API key needed for dry-run
+```
+
+**Hyperliquid live trading (NOT YET SUPPORTED):**
+
+Real live order placement is blocked until a future PR implements and fully tests `_SdkHyperliquidClient`. Attempting to start without `HYPERLIQUID_DRY_RUN=1` raises:
+
+```
+RuntimeError: Hyperliquid live SDK execution is not implemented in this PR.
+Set HYPERLIQUID_DRY_RUN=1 to use dry-run mode, or use exchange=paper.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ aimm-export-eval = "eval_export:main"
 export = [
     "pyarrow>=16.0.0",
 ]
+hyperliquid = [
+    "hyperliquid-python-sdk>=0.1.0",
+]
 dev = [
     "pre-commit>=4.0.0",
     "pytest>=8.0.0",

--- a/src/adapters/exchange_protocol.py
+++ b/src/adapters/exchange_protocol.py
@@ -1,0 +1,68 @@
+"""Structural protocol for exchange adapters.
+
+Both NexusAdapter (paper/mock) and HyperliquidAdapter implement this protocol
+via duck-typing (no inheritance required).
+"""
+
+from __future__ import annotations
+
+from typing import Any, NotRequired, Protocol, TypedDict
+
+
+class ExchangeOrderResult(TypedDict):
+    status: str  # accepted | filled | cancelled | rejected | error | dry_run
+    exchange_order_id: str | None
+    client_order_id: str | None
+    symbol: str
+    side: str  # buy | sell | ""
+    qty: float
+    price: float | None
+    filled_qty: float
+    ts: int  # unix epoch seconds
+    raw: dict[str, Any]  # raw exchange response for audit
+    error: NotRequired[str]
+
+
+class ExchangeAdapter(Protocol):
+    """Structural protocol satisfied by NexusAdapter, HyperliquidAdapter, and test doubles."""
+
+    def place_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        price: float | None,
+        client_order_id: str | None,
+    ) -> ExchangeOrderResult: ...
+
+    def cancel_order(
+        self,
+        *,
+        symbol: str,
+        exchange_order_id: str,
+    ) -> ExchangeOrderResult: ...
+
+    def get_order_status(
+        self,
+        *,
+        symbol: str,
+        exchange_order_id: str,
+    ) -> ExchangeOrderResult: ...
+
+    def get_portfolio_health(
+        self,
+        *,
+        account_id: str | None,
+    ) -> dict[str, Any]: ...
+
+    def fetch_market_depth(
+        self,
+        *,
+        symbol: str,
+        limit: int,
+    ) -> dict[str, Any]: ...
+
+
+__all__ = ["ExchangeAdapter", "ExchangeOrderResult"]

--- a/src/adapters/hyperliquid_adapter.py
+++ b/src/adapters/hyperliquid_adapter.py
@@ -162,7 +162,9 @@ class FakeHyperliquidClient:
             }
 
     def fetch_open_orders(self, *, coin: str | None = None) -> list[dict[str, Any]]:
-        return list(self.submitted_orders)
+        if coin is None:
+            return list(self.submitted_orders)
+        return [o for o in self.submitted_orders if o.get("coin") == coin]
 
     def fetch_positions(self) -> list[dict[str, Any]]:
         return []
@@ -321,6 +323,20 @@ class HyperliquidAdapter:
         exchange_order_id: str,
     ) -> ExchangeOrderResult:
         now = int(time.time())
+        # dry_run never sends cancellations to the exchange
+        if self._config.dry_run:
+            return ExchangeOrderResult(
+                status="dry_run",
+                exchange_order_id=exchange_order_id,
+                client_order_id=None,
+                symbol=symbol,
+                side="",
+                qty=0.0,
+                price=None,
+                filled_qty=0.0,
+                ts=now,
+                raw={"dry_run": True},
+            )
         coin = normalize_hl_symbol(symbol)
         raw = self._client.cancel_order(coin=coin, oid=exchange_order_id)
         mapped_status = _map_hl_status(str(raw.get("status", "unknown")))

--- a/src/adapters/hyperliquid_adapter.py
+++ b/src/adapters/hyperliquid_adapter.py
@@ -273,7 +273,7 @@ class HyperliquidAdapter:
         # dry_run never sends orders to the exchange
         if self._config.dry_run:
             return ExchangeOrderResult(
-                status="accepted",
+                status="dry_run",
                 exchange_order_id=None,
                 client_order_id=client_order_id,
                 symbol=symbol,

--- a/src/adapters/hyperliquid_adapter.py
+++ b/src/adapters/hyperliquid_adapter.py
@@ -1,0 +1,421 @@
+"""Hyperliquid exchange adapter.
+
+Three classes:
+  - FakeHyperliquidClient  — pure-Python test double; no SDK required
+  - _SdkHyperliquidClient  — lazy-imports real SDK; only used in production
+  - HyperliquidAdapter     — satisfies ExchangeAdapter Protocol; injectable client
+
+Live trading remains opt-in: requires EXCHANGE=hyperliquid + AI_MARKET_MAKER_ALLOW_LIVE=1.
+SDK import is lazy: missing SDK raises RuntimeError only when _SdkHyperliquidClient is constructed.
+dry_run=True never sends orders to the exchange.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from adapters.exchange_protocol import ExchangeOrderResult
+from config.exchange_env import ExchangeConfig
+
+_HL_MAINNET_URL = "https://api.hyperliquid.xyz"
+_HL_TESTNET_URL = "https://api.hyperliquid-testnet.xyz"
+
+
+def normalize_hl_symbol(symbol: str) -> str:
+    """Map common pair notations to Hyperliquid coin name (e.g. BTC/USDT → BTC)."""
+    s = symbol.strip().upper()
+    if "/" in s:
+        return s.split("/")[0]
+    if "-" in s:
+        return s.split("-")[0]
+    # Strip known suffixes from plain strings like BTCUSDT
+    if s.endswith("USDT") and len(s) > 4:
+        return s[:-4]
+    if s.endswith("PERP") and len(s) > 4:
+        return s[:-4]
+    if s.endswith("USD") and len(s) > 3:
+        return s[:-3]
+    return s
+
+
+def _map_hl_status(raw: str) -> str:
+    """Map Hyperliquid API status strings to ExchangeAdapter conventions."""
+    if raw == "open":
+        return "accepted"
+    elif raw == "filled":
+        return "filled"
+    elif raw == "cancelled":
+        return "cancelled"
+    elif raw == "rejected":
+        return "rejected"
+    elif raw in ("partial", "partially_filled"):
+        return "partially_filled"
+    else:
+        return "unknown"
+
+
+class FakeHyperliquidClient:
+    """Pure-Python test double for the Hyperliquid client. Zero SDK imports."""
+
+    def __init__(self, *, default_response: str = "accepted") -> None:
+        self.default_response = default_response
+        self.submitted_orders: list[dict[str, Any]] = []
+        self.cancelled_orders: list[dict[str, Any]] = []
+
+    def place_order(
+        self,
+        *,
+        coin: str,
+        is_buy: bool,
+        sz: float,
+        limit_px: float | None,
+        order_type: str,
+        reduce_only: bool,
+        cloid: str | None,
+    ) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "coin": coin,
+            "is_buy": is_buy,
+            "sz": sz,
+            "limit_px": limit_px,
+            "order_type": order_type,
+            "reduce_only": reduce_only,
+            "cloid": cloid,
+            "ts": int(time.time()),
+        }
+        self.submitted_orders.append(record)
+        oid = f"fake-oid-{len(self.submitted_orders)}"
+        if self.default_response == "accepted":
+            return {"status": "open", "oid": oid, "cloid": cloid}
+        elif self.default_response == "rejected":
+            return {
+                "status": "rejected",
+                "error": "insufficient margin",
+                "oid": None,
+                "cloid": cloid,
+            }
+        elif self.default_response == "timeout":
+            return {"status": "timeout", "oid": None, "cloid": cloid}
+        else:
+            return {"status": "unknown", "oid": None, "cloid": cloid}
+
+    def cancel_order(self, *, coin: str, oid: str) -> dict[str, Any]:
+        self.cancelled_orders.append({"coin": coin, "oid": oid, "ts": int(time.time())})
+        return {"status": "cancelled", "oid": oid}
+
+    def get_order_status(self, *, oid: str) -> dict[str, Any]:
+        r = self.default_response
+        if r == "accepted":
+            return {
+                "status": "open",
+                "oid": oid,
+                "filled_sz": 0.0,
+                "sz": 1.0,
+                "limit_px": 100.0,
+                "side": "B",
+            }
+        elif r == "filled":
+            return {
+                "status": "filled",
+                "oid": oid,
+                "filled_sz": 1.0,
+                "sz": 1.0,
+                "limit_px": 100.0,
+                "side": "B",
+            }
+        elif r == "rejected":
+            return {
+                "status": "rejected",
+                "oid": oid,
+                "filled_sz": 0.0,
+                "sz": 0.0,
+                "limit_px": None,
+                "side": "",
+            }
+        elif r == "cancelled":
+            return {
+                "status": "cancelled",
+                "oid": oid,
+                "filled_sz": 0.0,
+                "sz": 1.0,
+                "limit_px": 100.0,
+                "side": "B",
+            }
+        elif r == "partial":
+            return {
+                "status": "partial",
+                "oid": oid,
+                "filled_sz": 0.5,
+                "sz": 1.0,
+                "limit_px": 100.0,
+                "side": "B",
+            }
+        else:
+            return {
+                "status": r,
+                "oid": oid,
+                "filled_sz": 0.0,
+                "sz": 0.0,
+                "limit_px": None,
+                "side": "",
+            }
+
+    def fetch_open_orders(self, *, coin: str | None = None) -> list[dict[str, Any]]:
+        return list(self.submitted_orders)
+
+    def fetch_positions(self) -> list[dict[str, Any]]:
+        return []
+
+    def fetch_market_depth(self, *, coin: str, limit: int) -> dict[str, Any]:
+        mid = 100.0
+        bids = [[mid - i * 0.5, 1.0] for i in range(1, limit + 1)]
+        asks = [[mid + i * 0.5, 1.0] for i in range(1, limit + 1)]
+        return {"coin": coin, "bids": bids, "asks": asks}
+
+    def healthcheck(self) -> dict[str, Any]:
+        return {"status": "ok"}
+
+
+class _SdkHyperliquidClient:
+    """Wraps the real hyperliquid-python-sdk. SDK is imported lazily.
+
+    SDK import is lazy: RuntimeError raised only on construction if SDK is absent.
+    """
+
+    def __init__(self, config: ExchangeConfig) -> None:
+        try:
+            import hyperliquid  # noqa: F401
+            from hyperliquid.exchange import Exchange
+            from hyperliquid.info import Info
+        except ImportError as exc:
+            raise RuntimeError(
+                "hyperliquid-python-sdk is required to use HyperliquidAdapter with a real client. "
+                "Install it with: pip install 'ai-market-maker[hyperliquid]'"
+            ) from exc
+
+        self._config = config
+        if config.hyperliquid_api_base:
+            base_url = config.hyperliquid_api_base
+        elif config.testnet:
+            base_url = _HL_TESTNET_URL
+        else:
+            base_url = _HL_MAINNET_URL
+
+        self._exchange = Exchange(
+            base_url=base_url,
+            wallet=config.hyperliquid_api_key,
+            private_key=config.hyperliquid_secret,
+        )
+        self._info = Info(base_url=base_url, skip_ws=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"_SdkHyperliquidClient("
+            f"api_key={self._config.hyperliquid_api_key!r}, "
+            f"secret=[REDACTED], "
+            f"testnet={self._config.testnet!r})"
+        )
+
+    def place_order(self, *, coin, is_buy, sz, limit_px, order_type, reduce_only, cloid):
+        raise NotImplementedError("SDK integration not yet implemented")
+
+    def cancel_order(self, *, coin, oid):
+        raise NotImplementedError("SDK integration not yet implemented")
+
+    def get_order_status(self, *, oid):
+        raise NotImplementedError("SDK integration not yet implemented")
+
+    def fetch_open_orders(self, *, coin=None):
+        raise NotImplementedError("SDK integration not yet implemented")
+
+    def fetch_positions(self):
+        raise NotImplementedError("SDK integration not yet implemented")
+
+    def fetch_market_depth(self, *, coin, limit):
+        raise NotImplementedError("SDK integration not yet implemented")
+
+    def healthcheck(self):
+        raise NotImplementedError("SDK integration not yet implemented")
+
+
+class HyperliquidAdapter:
+    """Exchange adapter for Hyperliquid. Satisfies ExchangeAdapter Protocol.
+
+    Inject FakeHyperliquidClient for tests. _SdkHyperliquidClient is used in production.
+    """
+
+    def __init__(self, *, config: ExchangeConfig, client: Any = None) -> None:
+        self._config = config
+        # Lazy SDK client only when no test double injected
+        self._client = client if client is not None else _SdkHyperliquidClient(config)
+
+    def __repr__(self) -> str:
+        return (
+            f"HyperliquidAdapter("
+            f"exchange={self._config.exchange_name!r}, "
+            f"testnet={self._config.testnet!r}, "
+            f"dry_run={self._config.dry_run!r}, "
+            f"api_key={self._config.hyperliquid_api_key!r})"
+        )
+
+    def place_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        price: float | None,
+        client_order_id: str | None,
+    ) -> ExchangeOrderResult:
+        now = int(time.time())
+        # dry_run never sends orders to the exchange
+        if self._config.dry_run:
+            return ExchangeOrderResult(
+                status="accepted",
+                exchange_order_id=None,
+                client_order_id=client_order_id,
+                symbol=symbol,
+                side=side,
+                qty=qty,
+                price=price,
+                filled_qty=0.0,
+                ts=now,
+                raw={"dry_run": True},
+            )
+
+        coin = normalize_hl_symbol(symbol)
+        is_buy = side.lower() == "buy"
+        raw = self._client.place_order(
+            coin=coin,
+            is_buy=is_buy,
+            sz=qty,
+            limit_px=price,
+            order_type=order_type,
+            reduce_only=False,
+            cloid=client_order_id,
+        )
+        oid = raw.get("oid")
+        mapped_status = _map_hl_status(str(raw.get("status", "unknown")))
+        kwargs: dict[str, Any] = {
+            "status": mapped_status,
+            "exchange_order_id": str(oid) if oid is not None else None,
+            "client_order_id": client_order_id,
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "price": price,
+            "filled_qty": 0.0,
+            "ts": now,
+            "raw": raw,
+        }
+        if mapped_status in ("rejected", "error"):
+            kwargs["error"] = str(raw.get("error", mapped_status))
+        return ExchangeOrderResult(**kwargs)
+
+    def cancel_order(
+        self,
+        *,
+        symbol: str,
+        exchange_order_id: str,
+    ) -> ExchangeOrderResult:
+        now = int(time.time())
+        coin = normalize_hl_symbol(symbol)
+        raw = self._client.cancel_order(coin=coin, oid=exchange_order_id)
+        mapped_status = _map_hl_status(str(raw.get("status", "unknown")))
+        return ExchangeOrderResult(
+            status=mapped_status,
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="",
+            qty=0.0,
+            price=None,
+            filled_qty=0.0,
+            ts=now,
+            raw=raw,
+        )
+
+    def get_order_status(
+        self,
+        *,
+        symbol: str,
+        exchange_order_id: str,
+    ) -> ExchangeOrderResult:
+        now = int(time.time())
+        raw = self._client.get_order_status(oid=exchange_order_id)
+        mapped_status = _map_hl_status(str(raw.get("status", "unknown")))
+        filled_qty = float(raw.get("filled_sz", 0.0))
+        raw_price = raw.get("limit_px")
+        price = float(raw_price) if raw_price is not None else None
+        raw_side = raw.get("side", "")
+        side = "buy" if raw_side == "B" else ("sell" if raw_side == "A" else "")
+        kwargs: dict[str, Any] = {
+            "status": mapped_status,
+            "exchange_order_id": exchange_order_id,
+            "client_order_id": None,
+            "symbol": symbol,
+            "side": side,
+            "qty": float(raw.get("sz", 0.0)),
+            "price": price,
+            "filled_qty": filled_qty,
+            "ts": now,
+            "raw": raw,
+        }
+        if mapped_status in ("rejected", "error"):
+            kwargs["error"] = str(raw.get("error", mapped_status))
+        return ExchangeOrderResult(**kwargs)
+
+    def get_portfolio_health(
+        self,
+        *,
+        account_id: str | None = None,
+    ) -> dict[str, Any]:
+        positions_raw = self._client.fetch_positions()
+        return {
+            "account_id": account_id or "default",
+            "ts": int(time.time()),
+            "exchange": "hyperliquid",
+            "testnet": self._config.testnet,
+            "positions": positions_raw,
+            "raw": positions_raw,
+        }
+
+    def fetch_market_depth(
+        self,
+        *,
+        symbol: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        coin = normalize_hl_symbol(symbol)
+        raw = self._client.fetch_market_depth(coin=coin, limit=limit)
+        return {
+            "symbol": symbol,
+            "coin": coin,
+            "bids": raw.get("bids", []),
+            "asks": raw.get("asks", []),
+            "ts": int(time.time()),
+            "source": "hyperliquid",
+        }
+
+    def fetch_open_orders(
+        self,
+        *,
+        symbol: str | None = None,
+    ) -> list[dict[str, Any]]:
+        coin = normalize_hl_symbol(symbol) if symbol is not None else None
+        return self._client.fetch_open_orders(coin=coin)
+
+    def fetch_positions(self) -> list[dict[str, Any]]:
+        return self._client.fetch_positions()
+
+    def healthcheck(self) -> dict[str, Any]:
+        return self._client.healthcheck()
+
+
+__all__ = [
+    "FakeHyperliquidClient",
+    "HyperliquidAdapter",
+    "normalize_hl_symbol",
+]

--- a/src/adapters/nexus_adapter.py
+++ b/src/adapters/nexus_adapter.py
@@ -368,9 +368,11 @@ def get_nexus_adapter() -> Any:
                 "Hyperliquid live SDK execution is not implemented in this PR. "
                 "Set HYPERLIQUID_DRY_RUN=1 to use dry-run mode, or use exchange=paper."
             )
-        from adapters.hyperliquid_adapter import HyperliquidAdapter
+        # dry_run=True: HyperliquidAdapter.place_order() returns immediately without
+        # calling the client, so inject FakeHyperliquidClient to avoid SDK import.
+        from adapters.hyperliquid_adapter import FakeHyperliquidClient, HyperliquidAdapter
 
-        hl_adapter = HyperliquidAdapter(config=cfg)
+        hl_adapter = HyperliquidAdapter(config=cfg, client=FakeHyperliquidClient())
         oms = Oms(adapter=hl_adapter)
         _adapter = OmsNexusAdapter(oms=oms, exchange_adapter=hl_adapter)
 

--- a/src/adapters/nexus_adapter.py
+++ b/src/adapters/nexus_adapter.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional
 
+from adapters.exchange_protocol import ExchangeOrderResult
 from config.app_settings import load_app_settings
 from config.fund_policy import load_fund_policy
 from config.nexus_env import load_nexus_data_base_url
@@ -178,24 +179,211 @@ class NexusAdapter:
 
         return base
 
+    # ------------------------------------------------------------------
+    # ExchangeAdapter Protocol compatibility methods
+    # ------------------------------------------------------------------
 
-_adapter: NexusAdapter | None = None
+    def place_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        price: float | None,
+        client_order_id: str | None,
+    ) -> ExchangeOrderResult:
+        """Bridge over place_smart_order() to satisfy ExchangeAdapter Protocol."""
+        now = int(time.time())
+        raw = self.place_smart_order(
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            order_type=order_type,
+            price=price,
+            client_order_id=client_order_id,
+        )
+        status = raw.get("status", "unknown")
+        if status == "accepted":
+            mapped = "accepted"
+        elif status == "rejected":
+            mapped = "rejected"
+        else:
+            mapped = "unknown"
+        kwargs: dict[str, Any] = {
+            "status": mapped,
+            "exchange_order_id": None,
+            "client_order_id": client_order_id,
+            "symbol": symbol,
+            "side": side,
+            "qty": float(qty),
+            "price": float(price) if price is not None else None,
+            "filled_qty": 0.0,
+            "ts": now,
+            "raw": raw,
+        }
+        if mapped == "rejected":
+            kwargs["error"] = str(raw.get("reason", "rejected"))
+        return ExchangeOrderResult(**kwargs)
+
+    def cancel_order(
+        self,
+        *,
+        symbol: str,
+        exchange_order_id: str,
+    ) -> ExchangeOrderResult:
+        """Paper adapter: acknowledge cancel locally, no exchange call."""
+        return ExchangeOrderResult(
+            status="cancelled",
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="",
+            qty=0.0,
+            price=None,
+            filled_qty=0.0,
+            ts=int(time.time()),
+            raw={},
+        )
+
+    def get_order_status(
+        self,
+        *,
+        symbol: str,
+        exchange_order_id: str,
+    ) -> ExchangeOrderResult:
+        """Paper adapter: all tracked orders are considered accepted."""
+        return ExchangeOrderResult(
+            status="accepted",
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="",
+            qty=0.0,
+            price=None,
+            filled_qty=0.0,
+            ts=int(time.time()),
+            raw={},
+        )
 
 
-def get_nexus_adapter() -> NexusAdapter:
+class OmsNexusAdapter:
+    """Routes place_smart_order() through Oms lifecycle. Drop-in replacement for NexusAdapter.
+
+    Used when AI_MARKET_MAKER_EXECUTION_ENGINE=oms. main.py requires no changes.
+    get_portfolio_health() and fetch_market_depth() delegate to the wrapped exchange adapter.
+    """
+
+    def __init__(self, *, oms: Any, exchange_adapter: Any) -> None:
+        self._oms = oms
+        self._exchange = exchange_adapter
+
+    def place_smart_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str = "market",
+        price: Optional[float] = None,
+        post_only: bool = False,
+        max_slippage_bps: Optional[float] = None,
+        client_order_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        nonce = str(int(time.time() * 1_000_000))
+        order = self._oms.submit_order(
+            symbol=symbol,
+            side=side,
+            order_type=order_type,
+            quantity=qty,
+            price=price,
+            strategy="oms",
+            run_id="default",
+            nonce=nonce,
+            client_order_id=client_order_id,
+        )
+        return {
+            "status": order.state.value,
+            "symbol": symbol,
+            "side": side,
+            "qty": float(qty),
+            "price": float(price) if price is not None else None,
+            "type": order_type,
+            "mode": "oms",
+            "venue": "oms",
+            "client_order_id": order.client_order_id,
+            "exchange_order_id": order.venue_order_id,
+            "oms_state": order.state.value,
+        }
+
+    def get_portfolio_health(self, *, account_id: Optional[str] = None) -> Dict[str, Any]:
+        return self._exchange.get_portfolio_health(account_id=account_id)
+
+    def fetch_market_depth(self, *, symbol: str, limit: int = 5) -> Dict[str, Any]:
+        return self._exchange.fetch_market_depth(symbol=symbol, limit=limit)
+
+
+_adapter: Any = None
+
+
+def get_nexus_adapter() -> Any:
+    """Return the singleton execution adapter.
+
+    Default (AI_MARKET_MAKER_EXECUTION_ENGINE=legacy): NexusAdapter paper path, unchanged.
+    Opt-in (AI_MARKET_MAKER_EXECUTION_ENGINE=oms): OmsNexusAdapter routes through OMS.
+    """
     global _adapter
-    if _adapter is None:
+    if _adapter is not None:
+        return _adapter
+
+    from config.execution_engine import ExecutionEngine, load_execution_engine
+
+    engine = load_execution_engine()
+
+    if engine == ExecutionEngine.LEGACY:
         mode = (os.getenv("MODE") or "paper").strip().lower()
         _adapter = NexusAdapter(
-            NexusAdapterConfig(
-                mode=mode,
-                nexus_data_base_url=load_nexus_data_base_url(),
-            )
+            NexusAdapterConfig(mode=mode, nexus_data_base_url=load_nexus_data_base_url())
         )
+        return _adapter
+
+    # OMS path — requires explicit AI_MARKET_MAKER_EXECUTION_ENGINE=oms
+    from config.exchange_env import load_exchange_config
+    from oms.oms import Oms
+
+    cfg = load_exchange_config()
+
+    if cfg.exchange_name == "paper":
+        mode = (os.getenv("MODE") or "paper").strip().lower()
+        inner = NexusAdapter(
+            NexusAdapterConfig(mode=mode, nexus_data_base_url=load_nexus_data_base_url())
+        )
+        oms = Oms(adapter=inner, dry_run=cfg.dry_run)
+        _adapter = OmsNexusAdapter(oms=oms, exchange_adapter=inner)
+
+    elif cfg.exchange_name == "hyperliquid":
+        # Raise before touching SDK import so the error is clear regardless of SDK presence
+        if not cfg.dry_run:
+            raise RuntimeError(
+                "Hyperliquid live SDK execution is not implemented in this PR. "
+                "Set HYPERLIQUID_DRY_RUN=1 to use dry-run mode, or use exchange=paper."
+            )
+        from adapters.hyperliquid_adapter import HyperliquidAdapter
+
+        hl_adapter = HyperliquidAdapter(config=cfg)
+        oms = Oms(adapter=hl_adapter)
+        _adapter = OmsNexusAdapter(oms=oms, exchange_adapter=hl_adapter)
+
+    else:
+        raise RuntimeError(
+            f"Unsupported exchange {cfg.exchange_name!r} for OMS engine. "
+            "Supported: 'paper', 'hyperliquid' (with HYPERLIQUID_DRY_RUN=1)."
+        )
+
     return _adapter
 
 
-def set_nexus_adapter(adapter: NexusAdapter | None) -> None:
+def set_nexus_adapter(adapter: Any) -> None:
     global _adapter
     _adapter = adapter
 
@@ -203,6 +391,7 @@ def set_nexus_adapter(adapter: NexusAdapter | None) -> None:
 __all__ = [
     "NexusAdapter",
     "NexusAdapterConfig",
+    "OmsNexusAdapter",
     "get_nexus_adapter",
     "set_nexus_adapter",
 ]

--- a/src/adapters/nexus_adapter.py
+++ b/src/adapters/nexus_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional
@@ -290,7 +291,7 @@ class OmsNexusAdapter:
         max_slippage_bps: Optional[float] = None,
         client_order_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        nonce = str(int(time.time() * 1_000_000))
+        nonce = uuid.uuid4().hex
         order = self._oms.submit_order(
             symbol=symbol,
             side=side,
@@ -373,7 +374,7 @@ def get_nexus_adapter() -> Any:
         from adapters.hyperliquid_adapter import FakeHyperliquidClient, HyperliquidAdapter
 
         hl_adapter = HyperliquidAdapter(config=cfg, client=FakeHyperliquidClient())
-        oms = Oms(adapter=hl_adapter)
+        oms = Oms(adapter=hl_adapter, dry_run=cfg.dry_run)
         _adapter = OmsNexusAdapter(oms=oms, exchange_adapter=hl_adapter)
 
     else:

--- a/src/config/exchange_env.py
+++ b/src/config/exchange_env.py
@@ -85,6 +85,7 @@ def load_exchange_config(*, env: Mapping[str, str] | None = None) -> ExchangeCon
 __all__ = [
     "EXCHANGE_ENV",
     "ExchangeConfig",
+    "HL_API_BASE_ENV",
     "HL_API_KEY_ENV",
     "HL_DRY_RUN_ENV",
     "HL_SECRET_ENV",

--- a/src/config/exchange_env.py
+++ b/src/config/exchange_env.py
@@ -1,0 +1,93 @@
+"""Environment config for the exchange adapter layer.
+
+Use:
+    EXCHANGE=paper           (default) — NexusAdapter, no real keys needed
+    EXCHANGE=hyperliquid     — HyperliquidAdapter; also requires AI_MARKET_MAKER_ALLOW_LIVE=1
+
+Hyperliquid-specific:
+    HYPERLIQUID_API_KEY      — wallet address or API key
+    HYPERLIQUID_SECRET       — private key / secret
+    HYPERLIQUID_TESTNET=1    — use testnet API base (default: 1 for safety)
+    HYPERLIQUID_DRY_RUN=1    — parse + validate but do not send orders (default: 0)
+    HYPERLIQUID_API_BASE     — override API base URL (optional)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+from config.run_mode import LIVE_CONFIRM_ENV
+
+EXCHANGE_ENV = "EXCHANGE"
+HL_API_KEY_ENV = "HYPERLIQUID_API_KEY"
+HL_SECRET_ENV = "HYPERLIQUID_SECRET"
+HL_TESTNET_ENV = "HYPERLIQUID_TESTNET"
+HL_DRY_RUN_ENV = "HYPERLIQUID_DRY_RUN"
+HL_API_BASE_ENV = "HYPERLIQUID_API_BASE"
+
+
+@dataclass(frozen=True)
+class ExchangeConfig:
+    exchange_name: str = "paper"
+    testnet: bool = True
+    dry_run: bool = False
+    hyperliquid_api_key: str | None = None
+    hyperliquid_secret: str | None = None
+    hyperliquid_api_base: str | None = None
+
+    def __repr__(self) -> str:
+        secret_display = "[REDACTED]" if self.hyperliquid_secret else None
+        return (
+            f"ExchangeConfig("
+            f"exchange_name={self.exchange_name!r}, "
+            f"testnet={self.testnet!r}, "
+            f"dry_run={self.dry_run!r}, "
+            f"hyperliquid_api_key={self.hyperliquid_api_key!r}, "
+            f"hyperliquid_secret={secret_display!r}, "
+            f"hyperliquid_api_base={self.hyperliquid_api_base!r}"
+            f")"
+        )
+
+
+def _truthy(val: str | None) -> bool:
+    return str(val or "").strip().lower() in ("1", "true", "yes")
+
+
+def load_exchange_config(*, env: Mapping[str, str] | None = None) -> ExchangeConfig:
+    e = env if env is not None else os.environ
+    name = (e.get(EXCHANGE_ENV) or "paper").strip().lower()
+
+    if name != "paper":
+        if not _truthy(e.get(LIVE_CONFIRM_ENV)):
+            raise ValueError(
+                f"EXCHANGE={name!r} requires {LIVE_CONFIRM_ENV}=1. "
+                "Set it explicitly to confirm real trading intent."
+            )
+
+    testnet = _truthy(e.get(HL_TESTNET_ENV, "1"))
+    dry_run = _truthy(e.get(HL_DRY_RUN_ENV))
+    api_key = (e.get(HL_API_KEY_ENV) or "").strip() or None
+    secret = (e.get(HL_SECRET_ENV) or "").strip() or None
+    api_base = (e.get(HL_API_BASE_ENV) or "").strip() or None
+
+    return ExchangeConfig(
+        exchange_name=name,
+        testnet=testnet,
+        dry_run=dry_run,
+        hyperliquid_api_key=api_key,
+        hyperliquid_secret=secret,
+        hyperliquid_api_base=api_base,
+    )
+
+
+__all__ = [
+    "EXCHANGE_ENV",
+    "ExchangeConfig",
+    "HL_API_KEY_ENV",
+    "HL_DRY_RUN_ENV",
+    "HL_SECRET_ENV",
+    "HL_TESTNET_ENV",
+    "load_exchange_config",
+]

--- a/src/config/execution_engine.py
+++ b/src/config/execution_engine.py
@@ -1,0 +1,33 @@
+"""Execution engine selection.
+
+AI_MARKET_MAKER_EXECUTION_ENGINE=legacy  (default) — existing NexusAdapter paper path, unchanged
+AI_MARKET_MAKER_EXECUTION_ENGINE=oms     — route through OMS lifecycle tracking (opt-in)
+
+No live exchange calls are made in either mode unless EXCHANGE and AI_MARKET_MAKER_ALLOW_LIVE
+are both set explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import StrEnum
+from typing import Mapping
+
+EXECUTION_ENGINE_ENV = "AI_MARKET_MAKER_EXECUTION_ENGINE"
+
+
+class ExecutionEngine(StrEnum):
+    LEGACY = "legacy"
+    OMS = "oms"
+
+
+def load_execution_engine(*, env: Mapping[str, str] | None = None) -> ExecutionEngine:
+    """Return the configured execution engine. Unknown values fall back to LEGACY."""
+    e = env if env is not None else os.environ
+    raw = (e.get(EXECUTION_ENGINE_ENV) or "legacy").strip().lower()
+    if raw == "oms":
+        return ExecutionEngine.OMS
+    return ExecutionEngine.LEGACY
+
+
+__all__ = ["EXECUTION_ENGINE_ENV", "ExecutionEngine", "load_execution_engine"]

--- a/src/oms/__init__.py
+++ b/src/oms/__init__.py
@@ -1,0 +1,12 @@
+"""Order Management System (OMS) package.
+
+Provides OmsOrder, OrderState, and the Oms class that wraps an ExchangeAdapter.
+No exchange SDK imports here — adapter coupling happens at the ExchangeAdapter protocol boundary only.
+"""
+
+from __future__ import annotations
+
+from oms.oms import Oms
+from oms.order import OmsOrder, OrderState
+
+__all__ = ["Oms", "OmsOrder", "OrderState"]

--- a/src/oms/oms.py
+++ b/src/oms/oms.py
@@ -59,10 +59,6 @@ def _apply_result(order: OmsOrder, result: dict[str, Any]) -> None:
     if filled is not None:
         order.filled_quantity = float(filled)
 
-    fill_price = result.get("price")
-    if fill_price is not None and order.filled_quantity > 0:
-        order.average_fill_price = float(fill_price)
-
     error_msg = result.get("error")
     if error_msg:
         order.error = str(error_msg)
@@ -303,7 +299,7 @@ class Oms:
             return []
 
         expired: list[OmsOrder] = []
-        for order in self._orders.values():
+        for order in list(self._orders.values()):
             if order.state not in _LIVE_STATES:
                 continue
             if order.venue_order_id is None:

--- a/src/oms/oms.py
+++ b/src/oms/oms.py
@@ -23,6 +23,7 @@ from oms.order import OmsOrder, OrderState
 _STATUS_MAP: dict[str, OrderState] = {
     "accepted": OrderState.ACCEPTED,
     "open": OrderState.ACCEPTED,
+    "dry_run": OrderState.ACCEPTED,  # dry_run results treated as accepted for OMS lifecycle
     "filled": OrderState.FILLED,
     "cancelled": OrderState.CANCELLED,
     "rejected": OrderState.REJECTED,

--- a/src/oms/oms.py
+++ b/src/oms/oms.py
@@ -1,0 +1,330 @@
+"""Order Management System — exchange-agnostic order lifecycle controller.
+
+Imports only from:
+  - oms.order          (OmsOrder, OrderState)
+  - adapters.exchange_protocol  (ExchangeAdapter, ExchangeOrderResult)
+  - stdlib
+
+No exchange-specific SDK imports. No real credentials required.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from adapters.exchange_protocol import ExchangeAdapter
+from oms.order import OmsOrder, OrderState
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_STATUS_MAP: dict[str, OrderState] = {
+    "accepted": OrderState.ACCEPTED,
+    "open": OrderState.ACCEPTED,
+    "filled": OrderState.FILLED,
+    "cancelled": OrderState.CANCELLED,
+    "rejected": OrderState.REJECTED,
+    "error": OrderState.REJECTED,
+    "partially_filled": OrderState.PARTIALLY_FILLED,
+    "partial": OrderState.PARTIALLY_FILLED,
+}
+
+_LIVE_STATES: frozenset[OrderState] = frozenset(
+    {
+        OrderState.SUBMITTED,
+        OrderState.ACCEPTED,
+        OrderState.PARTIALLY_FILLED,
+        OrderState.UNKNOWN,
+    }
+)
+
+
+def _map_status(raw_status: str) -> OrderState:
+    """Map an ExchangeOrderResult.status string to an OrderState.
+
+    Any unrecognised status — including "timeout", "dry_run", etc. — maps to UNKNOWN.
+    """
+    return _STATUS_MAP.get(raw_status.lower(), OrderState.UNKNOWN)
+
+
+def _apply_result(order: OmsOrder, result: dict[str, Any]) -> None:
+    """Update order fields from an ExchangeOrderResult dict, then transition state."""
+    venue_id = result.get("exchange_order_id")
+    if venue_id is not None:
+        order.venue_order_id = venue_id
+
+    filled = result.get("filled_qty")
+    if filled is not None:
+        order.filled_quantity = float(filled)
+
+    fill_price = result.get("price")
+    if fill_price is not None and order.filled_quantity > 0:
+        order.average_fill_price = float(fill_price)
+
+    error_msg = result.get("error")
+    if error_msg:
+        order.error = str(error_msg)
+
+    new_state = _map_status(str(result.get("status", "")))
+    order._transition(new_state)
+
+
+class Oms:
+    """Exchange-agnostic Order Management System.
+
+    Maintains an in-process order book keyed on client_order_id.
+    All exchange I/O is delegated to self._adapter (ExchangeAdapter protocol).
+
+    Args:
+        adapter:  Any object satisfying the ExchangeAdapter protocol.
+        dry_run:  When True, submit_order creates the order in CREATED state
+                  but never calls adapter.place_order.
+    """
+
+    def __init__(self, *, adapter: ExchangeAdapter, dry_run: bool = False) -> None:
+        self._adapter = adapter
+        self._dry_run = dry_run
+        # Primary store: client_order_id → OmsOrder
+        self._orders: dict[str, OmsOrder] = {}
+        # Reverse index for idempotency: idempotency_key → client_order_id
+        self._idem_index: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Static factory helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def make_idempotency_key(
+        strategy: str,
+        run_id: str,
+        symbol: str,
+        side: str,
+        order_type: str,
+        nonce: str,
+    ) -> str:
+        """Return a deterministic SHA-256 hex digest from the supplied fields.
+
+        The digest is stable: same inputs always produce the same key, making it
+        safe to use as a dedup guard across restarts within the same run.
+        """
+        raw = "|".join([strategy, run_id, symbol, side, order_type, nonce])
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    @staticmethod
+    def make_client_order_id(
+        strategy: str,
+        run_id: str,
+        symbol: str,
+        side: str,
+        order_type: str,
+        nonce: str,
+    ) -> str:
+        """Return a human-readable client order ID with a short hash suffix.
+
+        Format: ``<strategy>-<side>-<symbol_safe>-<short_hash>``
+        where ``symbol_safe`` replaces ``/`` with ``-`` and short_hash is the
+        first 8 hex chars of the SHA-256 of all fields.
+        """
+        symbol_safe = symbol.replace("/", "-")
+        short = hashlib.sha256(
+            "|".join([strategy, run_id, symbol, side, order_type, nonce]).encode()
+        ).hexdigest()[:8]
+        return f"{strategy}-{side}-{symbol_safe}-{short}"
+
+    # ------------------------------------------------------------------
+    # Order submission
+    # ------------------------------------------------------------------
+
+    def submit_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        order_type: str,
+        quantity: float,
+        price: float | None = None,
+        strategy: str,
+        run_id: str,
+        nonce: str,
+        client_order_id: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> OmsOrder:
+        """Place a new order via the adapter and track it internally.
+
+        Idempotency:
+            If ``idempotency_key`` resolves to an order already in the store,
+            the existing OmsOrder is returned immediately — adapter.place_order
+            is NOT called again.
+
+        Dry run:
+            If ``self._dry_run`` is True the order is created in CREATED state
+            and returned without any adapter call.
+
+        Exception handling:
+            Any exception raised by adapter.place_order is caught, recorded
+            in ``order.error``, and the order is transitioned to FAILED.
+        """
+        idem_key = idempotency_key or self.make_idempotency_key(
+            strategy, run_id, symbol, side, order_type, nonce
+        )
+
+        # Idempotency guard — return existing order immediately
+        existing_coid = self._idem_index.get(idem_key)
+        if existing_coid is not None and existing_coid in self._orders:
+            return self._orders[existing_coid]
+
+        coid = client_order_id or self.make_client_order_id(
+            strategy, run_id, symbol, side, order_type, nonce
+        )
+
+        order = OmsOrder(
+            client_order_id=coid,
+            idempotency_key=idem_key,
+            symbol=symbol,
+            side=side,
+            order_type=order_type,
+            quantity=quantity,
+            price=price,
+        )
+
+        self._orders[coid] = order
+        self._idem_index[idem_key] = coid
+
+        if self._dry_run:
+            # Dry run: persist the order in CREATED state, never touch the adapter
+            return order
+
+        # Transition to SUBMITTED before adapter call
+        order._transition(OrderState.SUBMITTED)
+
+        try:
+            result = self._adapter.place_order(
+                symbol=symbol,
+                side=side,
+                qty=quantity,
+                order_type=order_type,
+                price=price,
+                client_order_id=coid,
+            )
+            _apply_result(order, result)
+        except Exception as exc:
+            order.error = str(exc)
+            order._transition(OrderState.FAILED)
+
+        return order
+
+    # ------------------------------------------------------------------
+    # Cancel
+    # ------------------------------------------------------------------
+
+    def cancel_order(self, *, client_order_id: str) -> OmsOrder:
+        """Cancel an order.
+
+        If the order has no ``venue_order_id`` (e.g. was never confirmed by the
+        exchange), it is marked CANCELLED locally without contacting the adapter.
+
+        Returns the order as-is if it is already in a terminal state.
+        """
+        order = self._orders.get(client_order_id)
+        if order is None:
+            raise KeyError(f"No order found with client_order_id={client_order_id!r}")
+
+        if order.is_terminal:
+            return order
+
+        if order.venue_order_id is None:
+            order._transition(OrderState.CANCELLED)
+            return order
+
+        try:
+            result = self._adapter.cancel_order(
+                symbol=order.symbol,
+                exchange_order_id=order.venue_order_id,
+            )
+            _apply_result(order, result)
+        except Exception as exc:
+            order.error = str(exc)
+            order._transition(OrderState.FAILED)
+
+        return order
+
+    # ------------------------------------------------------------------
+    # Status refresh
+    # ------------------------------------------------------------------
+
+    def get_order_status(self, *, client_order_id: str) -> OmsOrder:
+        """Refresh order state by querying the adapter.
+
+        Returns the order as-is if it is already in a terminal state or has no
+        venue_order_id to query against.
+        """
+        order = self._orders.get(client_order_id)
+        if order is None:
+            raise KeyError(f"No order found with client_order_id={client_order_id!r}")
+
+        if order.is_terminal:
+            return order
+
+        if order.venue_order_id is None:
+            return order
+
+        try:
+            result = self._adapter.get_order_status(
+                symbol=order.symbol,
+                exchange_order_id=order.venue_order_id,
+            )
+            _apply_result(order, result)
+        except Exception as exc:
+            order.error = str(exc)
+            order._transition(OrderState.FAILED)
+
+        return order
+
+    # ------------------------------------------------------------------
+    # Reconciliation
+    # ------------------------------------------------------------------
+
+    def reconcile(self, *, known_venue_ids: set[str] | None = None) -> list[OmsOrder]:
+        """Mark orders as EXPIRED when their venue_order_id is absent from known_venue_ids.
+
+        Args:
+            known_venue_ids:
+                When None (default), this is a safe no-op — returns an empty list.
+                When a set of venue IDs, any live order whose venue_order_id is not
+                None and is NOT in the set is transitioned to EXPIRED.
+                No exchange calls are made.
+
+        Returns:
+            List of orders whose state was changed to EXPIRED during this call.
+        """
+        if known_venue_ids is None:
+            return []
+
+        expired: list[OmsOrder] = []
+        for order in self._orders.values():
+            if order.state not in _LIVE_STATES:
+                continue
+            if order.venue_order_id is None:
+                continue
+            if order.venue_order_id not in known_venue_ids:
+                order._transition(OrderState.EXPIRED)
+                expired.append(order)
+
+        return expired
+
+    # ------------------------------------------------------------------
+    # Read-only accessors
+    # ------------------------------------------------------------------
+
+    def get_order(self, *, client_order_id: str) -> OmsOrder | None:
+        """Return the OmsOrder for the given client_order_id, or None if not found."""
+        return self._orders.get(client_order_id)
+
+    def all_orders(self) -> list[OmsOrder]:
+        """Return a snapshot list of all orders currently in the store."""
+        return list(self._orders.values())
+
+
+__all__ = ["Oms"]

--- a/src/oms/order.py
+++ b/src/oms/order.py
@@ -1,0 +1,87 @@
+"""OmsOrder dataclass and OrderState StrEnum.
+
+Deliberately has NO imports from oms.py or any exchange SDK.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class OrderState(StrEnum):
+    """Lifecycle states for an OMS-tracked order.
+
+    Terminal states (FILLED, CANCELLED, REJECTED, EXPIRED, FAILED) cannot be
+    exited once entered — _transition() enforces this invariant.
+    """
+
+    CREATED = "created"
+    SUBMITTED = "submitted"
+    ACCEPTED = "accepted"
+    PARTIALLY_FILLED = "partially_filled"
+    FILLED = "filled"
+    CANCELLED = "cancelled"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+
+
+_TERMINAL_STATES: frozenset[OrderState] = frozenset(
+    {
+        OrderState.FILLED,
+        OrderState.CANCELLED,
+        OrderState.REJECTED,
+        OrderState.EXPIRED,
+        OrderState.FAILED,
+    }
+)
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+@dataclass
+class OmsOrder:
+    """A single order tracked by the OMS.
+
+    Not frozen — state transitions happen in-place via _transition().
+    created_at and updated_at are unix epoch seconds (int).
+    """
+
+    client_order_id: str
+    idempotency_key: str
+    symbol: str
+    side: str  # "buy" | "sell"
+    order_type: str  # "market" | "limit"
+    quantity: float
+    price: float | None = None
+    state: OrderState = OrderState.CREATED
+    venue_order_id: str | None = None
+    filled_quantity: float = 0.0
+    average_fill_price: float | None = None
+    error: str | None = None
+    created_at: int = field(default_factory=_now)
+    updated_at: int = field(default_factory=_now)
+
+    def _transition(self, new_state: OrderState) -> None:
+        """Move to new_state unless already in a terminal state.
+
+        Terminal states are a one-way door: calling _transition() on a terminal
+        order is a no-op (the order is returned as-is by all mutation paths).
+        """
+        if self.state in _TERMINAL_STATES:
+            return
+        self.state = new_state
+        self.updated_at = _now()
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if this order is in a state from which no further transitions are allowed."""
+        return self.state in _TERMINAL_STATES
+
+
+__all__ = ["OmsOrder", "OrderState"]

--- a/tests/test_exchange_config.py
+++ b/tests/test_exchange_config.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from config.exchange_env import (
+    EXCHANGE_ENV,
+    HL_API_KEY_ENV,
+    HL_DRY_RUN_ENV,
+    HL_SECRET_ENV,
+    HL_TESTNET_ENV,
+    load_exchange_config,
+)
+
+
+def test_default_exchange_config_is_paper(monkeypatch):
+    monkeypatch.delenv(EXCHANGE_ENV, raising=False)
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    cfg = load_exchange_config()
+    assert cfg.exchange_name == "paper"
+    assert cfg.testnet is True
+    assert cfg.dry_run is False
+    assert cfg.hyperliquid_api_key is None
+    assert cfg.hyperliquid_secret is None
+
+
+def test_hyperliquid_without_live_flag_raises(monkeypatch):
+    monkeypatch.setenv(EXCHANGE_ENV, "hyperliquid")
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    with pytest.raises(ValueError, match="AI_MARKET_MAKER_ALLOW_LIVE"):
+        load_exchange_config()
+
+
+def test_hyperliquid_with_live_flag(monkeypatch):
+    monkeypatch.setenv(EXCHANGE_ENV, "hyperliquid")
+    monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", "1")
+    monkeypatch.setenv(HL_API_KEY_ENV, "wallet-addr")
+    monkeypatch.setenv(HL_SECRET_ENV, "private-key")
+    monkeypatch.setenv(HL_TESTNET_ENV, "1")
+    cfg = load_exchange_config()
+    assert cfg.exchange_name == "hyperliquid"
+    assert cfg.testnet is True
+    assert cfg.hyperliquid_api_key == "wallet-addr"
+    assert cfg.hyperliquid_secret == "private-key"
+
+
+def test_hyperliquid_dry_run(monkeypatch):
+    monkeypatch.setenv(EXCHANGE_ENV, "hyperliquid")
+    monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", "1")
+    monkeypatch.setenv(HL_DRY_RUN_ENV, "1")
+    cfg = load_exchange_config()
+    assert cfg.dry_run is True
+
+
+def test_unknown_exchange_also_requires_live_flag(monkeypatch):
+    monkeypatch.setenv(EXCHANGE_ENV, "binance")
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    with pytest.raises(ValueError, match="AI_MARKET_MAKER_ALLOW_LIVE"):
+        load_exchange_config()
+
+
+def test_secret_not_in_repr(monkeypatch):
+    monkeypatch.setenv(EXCHANGE_ENV, "hyperliquid")
+    monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", "1")
+    monkeypatch.setenv(HL_SECRET_ENV, "super-secret-key-12345")
+    cfg = load_exchange_config()
+    r = repr(cfg)
+    assert "super-secret-key-12345" not in r
+
+
+def test_paper_mode_ignores_live_flag(monkeypatch):
+    monkeypatch.delenv(EXCHANGE_ENV, raising=False)
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    cfg = load_exchange_config()
+    assert cfg.exchange_name == "paper"
+
+
+def test_truthy_variants(monkeypatch):
+    for val in ("1", "true", "yes", "True", "YES"):
+        monkeypatch.setenv(EXCHANGE_ENV, "hyperliquid")
+        monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", val)
+        cfg = load_exchange_config()
+        assert cfg.exchange_name == "hyperliquid"

--- a/tests/test_exchange_config.py
+++ b/tests/test_exchange_config.py
@@ -4,6 +4,7 @@ import pytest
 
 from config.exchange_env import (
     EXCHANGE_ENV,
+    HL_API_BASE_ENV,
     HL_API_KEY_ENV,
     HL_DRY_RUN_ENV,
     HL_SECRET_ENV,
@@ -80,3 +81,21 @@ def test_truthy_variants(monkeypatch):
         monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", val)
         cfg = load_exchange_config()
         assert cfg.exchange_name == "hyperliquid"
+
+
+def test_testnet_defaults_true_for_non_paper_mode(monkeypatch):
+    """HYPERLIQUID_TESTNET unset must still yield testnet=True (safe default)."""
+    monkeypatch.setenv(EXCHANGE_ENV, "hyperliquid")
+    monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", "1")
+    monkeypatch.delenv(HL_TESTNET_ENV, raising=False)
+    cfg = load_exchange_config()
+    assert cfg.testnet is True
+
+
+def test_hl_api_base_env_constant_is_exported(monkeypatch):
+    """HL_API_BASE_ENV must be importable and used to override the API base URL."""
+    monkeypatch.setenv(EXCHANGE_ENV, "hyperliquid")
+    monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", "1")
+    monkeypatch.setenv(HL_API_BASE_ENV, "https://my-custom-hl-base.example.com")
+    cfg = load_exchange_config()
+    assert cfg.hyperliquid_api_base == "https://my-custom-hl-base.example.com"

--- a/tests/test_exchange_protocol.py
+++ b/tests/test_exchange_protocol.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import time
+
+from adapters.exchange_protocol import ExchangeAdapter, ExchangeOrderResult
+
+
+class _MinimalAdapter:
+    """Minimal concrete implementation satisfying ExchangeAdapter protocol."""
+
+    def place_order(
+        self, *, symbol, side, qty, order_type, price, client_order_id
+    ) -> ExchangeOrderResult:
+        return ExchangeOrderResult(
+            status="accepted",
+            exchange_order_id="x",
+            client_order_id=client_order_id,
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            price=price,
+            filled_qty=0.0,
+            ts=int(time.time()),
+            raw={},
+        )
+
+    def cancel_order(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return ExchangeOrderResult(
+            status="cancelled",
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="",
+            qty=0.0,
+            price=None,
+            filled_qty=0.0,
+            ts=int(time.time()),
+            raw={},
+        )
+
+    def get_order_status(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return ExchangeOrderResult(
+            status="filled",
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="buy",
+            qty=1.0,
+            price=100.0,
+            filled_qty=1.0,
+            ts=int(time.time()),
+            raw={},
+        )
+
+    def get_portfolio_health(self, *, account_id):
+        return {"balances": {}, "positions": []}
+
+    def fetch_market_depth(self, *, symbol, limit):
+        return {"symbol": symbol, "bids": [], "asks": []}
+
+
+def test_minimal_adapter_satisfies_protocol():
+    adapter: ExchangeAdapter = _MinimalAdapter()  # type: ignore[assignment]
+    result = adapter.place_order(
+        symbol="BTC/USDT",
+        side="buy",
+        qty=0.01,
+        order_type="market",
+        price=50000.0,
+        client_order_id="test-1",
+    )
+    assert result["status"] == "accepted"
+    assert result["symbol"] == "BTC/USDT"
+    assert result["filled_qty"] == 0.0
+
+
+def test_exchange_order_result_all_fields():
+    r = ExchangeOrderResult(
+        status="accepted",
+        exchange_order_id="e1",
+        client_order_id="c1",
+        symbol="ETH/USDT",
+        side="sell",
+        qty=0.5,
+        price=3000.0,
+        filled_qty=0.5,
+        ts=1700000000,
+        raw={},
+    )
+    assert r["filled_qty"] == 0.5
+    assert r["ts"] == 1700000000
+    assert r["raw"] == {}
+
+
+def test_exchange_order_result_optional_error():
+    r = ExchangeOrderResult(
+        status="rejected",
+        exchange_order_id=None,
+        client_order_id="c2",
+        symbol="BTC/USDT",
+        side="buy",
+        qty=0.01,
+        price=50000.0,
+        filled_qty=0.0,
+        ts=1700000000,
+        raw={},
+        error="insufficient margin",
+    )
+    assert r["error"] == "insufficient margin"
+    assert r["status"] == "rejected"
+
+
+def test_cancel_result():
+    adapter = _MinimalAdapter()
+    result = adapter.cancel_order(symbol="BTC/USDT", exchange_order_id="eid-99")
+    assert result["status"] == "cancelled"
+    assert result["exchange_order_id"] == "eid-99"
+
+
+def test_market_depth_result():
+    adapter = _MinimalAdapter()
+    depth = adapter.fetch_market_depth(symbol="BTC/USDT", limit=5)
+    assert depth["symbol"] == "BTC/USDT"
+    assert "bids" in depth and "asks" in depth

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -1,0 +1,291 @@
+"""Tests for execution engine wiring (Task 4).
+
+All tests use fake adapters — no real exchange calls, no real API keys.
+set_nexus_adapter(None) resets the singleton; every test that touches
+get_nexus_adapter() must do this in a finally block.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from adapters.exchange_protocol import ExchangeOrderResult
+from adapters.nexus_adapter import (
+    NexusAdapter,
+    NexusAdapterConfig,
+    OmsNexusAdapter,
+    get_nexus_adapter,
+    set_nexus_adapter,
+)
+from config.execution_engine import (
+    EXECUTION_ENGINE_ENV,
+    ExecutionEngine,
+    load_execution_engine,
+)
+from oms.oms import Oms
+
+# ---------------------------------------------------------------------------
+# Shared fake adapter (satisfies ExchangeAdapter Protocol, no I/O)
+# ---------------------------------------------------------------------------
+
+
+class _FakeExchangeAdapter:
+    def __init__(self) -> None:
+        self.place_order_count = 0
+
+    def place_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        price: float | None,
+        client_order_id: str | None,
+    ) -> ExchangeOrderResult:
+        self.place_order_count += 1
+        return ExchangeOrderResult(
+            status="accepted",
+            exchange_order_id=f"fake-{self.place_order_count}",
+            client_order_id=client_order_id,
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            price=price,
+            filled_qty=0.0,
+            ts=1_000_000,
+            raw={},
+        )
+
+    def cancel_order(self, *, symbol: str, exchange_order_id: str) -> ExchangeOrderResult:
+        return ExchangeOrderResult(
+            status="cancelled",
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="",
+            qty=0.0,
+            price=None,
+            filled_qty=0.0,
+            ts=1_000_000,
+            raw={},
+        )
+
+    def get_order_status(self, *, symbol: str, exchange_order_id: str) -> ExchangeOrderResult:
+        return ExchangeOrderResult(
+            status="accepted",
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="",
+            qty=0.0,
+            price=None,
+            filled_qty=0.0,
+            ts=1_000_000,
+            raw={},
+        )
+
+    def get_portfolio_health(self, *, account_id: str | None = None) -> dict[str, Any]:
+        return {"account_id": account_id or "default", "balances": {}, "positions": []}
+
+    def fetch_market_depth(self, *, symbol: str, limit: int) -> dict[str, Any]:
+        return {"symbol": symbol, "bids": [], "asks": []}
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_execution_engine
+# ---------------------------------------------------------------------------
+
+
+def test_load_execution_engine_defaults_to_legacy(monkeypatch):
+    monkeypatch.delenv(EXECUTION_ENGINE_ENV, raising=False)
+    assert load_execution_engine() == ExecutionEngine.LEGACY
+
+
+def test_load_execution_engine_oms(monkeypatch):
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "oms")
+    assert load_execution_engine() == ExecutionEngine.OMS
+
+
+def test_load_execution_engine_case_insensitive(monkeypatch):
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "OMS")
+    assert load_execution_engine() == ExecutionEngine.OMS
+
+
+def test_load_execution_engine_unknown_falls_back_to_legacy(monkeypatch):
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "turbo")
+    assert load_execution_engine() == ExecutionEngine.LEGACY
+
+
+# ---------------------------------------------------------------------------
+# Tests: NexusAdapter now satisfies ExchangeAdapter Protocol (5 methods)
+# ---------------------------------------------------------------------------
+
+
+def test_nexus_adapter_satisfies_exchange_adapter_protocol():
+    adapter = NexusAdapter(NexusAdapterConfig(mode="paper"))
+    for method in (
+        "place_order",
+        "cancel_order",
+        "get_order_status",
+        "get_portfolio_health",
+        "fetch_market_depth",
+    ):
+        assert callable(getattr(adapter, method, None)), f"Missing protocol method: {method}"
+
+
+def test_nexus_adapter_cancel_order_returns_typed_result():
+    adapter = NexusAdapter(NexusAdapterConfig(mode="paper"))
+    result = adapter.cancel_order(symbol="BTC/USDT", exchange_order_id="eid-1")
+    assert result["status"] == "cancelled"
+    assert result["exchange_order_id"] == "eid-1"
+    assert result["symbol"] == "BTC/USDT"
+
+
+def test_nexus_adapter_get_order_status_returns_typed_result():
+    adapter = NexusAdapter(NexusAdapterConfig(mode="paper"))
+    result = adapter.get_order_status(symbol="ETH/USDT", exchange_order_id="eid-2")
+    assert result["status"] == "accepted"
+    assert result["exchange_order_id"] == "eid-2"
+
+
+# ---------------------------------------------------------------------------
+# Tests: OmsNexusAdapter routes through OMS
+# ---------------------------------------------------------------------------
+
+
+def test_oms_nexus_adapter_routes_place_smart_order_through_oms():
+    fake = _FakeExchangeAdapter()
+    oms = Oms(adapter=fake)
+    oms_adapter = OmsNexusAdapter(oms=oms, exchange_adapter=fake)
+
+    result = oms_adapter.place_smart_order(
+        symbol="BTC/USDT",
+        side="buy",
+        qty=0.1,
+        order_type="limit",
+        price=50_000.0,
+    )
+    assert result["status"] == "accepted"
+    assert result["symbol"] == "BTC/USDT"
+    assert result["side"] == "buy"
+    assert result["qty"] == 0.1
+    assert fake.place_order_count == 1  # OMS called the adapter exactly once
+
+
+def test_oms_nexus_adapter_does_not_call_exchange_in_dry_run():
+    fake = _FakeExchangeAdapter()
+    oms = Oms(adapter=fake, dry_run=True)
+    oms_adapter = OmsNexusAdapter(oms=oms, exchange_adapter=fake)
+
+    oms_adapter.place_smart_order(
+        symbol="BTC/USDT",
+        side="buy",
+        qty=0.1,
+        order_type="market",
+        price=None,
+    )
+    assert fake.place_order_count == 0  # dry_run: adapter never called
+
+
+def test_oms_nexus_adapter_delegates_portfolio_health():
+    fake = _FakeExchangeAdapter()
+    oms_adapter = OmsNexusAdapter(oms=Oms(adapter=fake), exchange_adapter=fake)
+
+    health = oms_adapter.get_portfolio_health(account_id="test-account")
+    assert health["account_id"] == "test-account"
+
+
+def test_oms_nexus_adapter_delegates_market_depth():
+    fake = _FakeExchangeAdapter()
+    oms_adapter = OmsNexusAdapter(oms=Oms(adapter=fake), exchange_adapter=fake)
+
+    depth = oms_adapter.fetch_market_depth(symbol="ETH/USDT", limit=5)
+    assert depth["symbol"] == "ETH/USDT"
+
+
+def test_oms_nexus_adapter_result_shape_compatible_with_execution_result():
+    """OmsNexusAdapter result must have the minimum keys main.py expects."""
+    fake = _FakeExchangeAdapter()
+    oms_adapter = OmsNexusAdapter(oms=Oms(adapter=fake), exchange_adapter=fake)
+
+    result = oms_adapter.place_smart_order(
+        symbol="ETH/USDT",
+        side="sell",
+        qty=0.5,
+        order_type="market",
+        price=3_000.0,
+    )
+    for key in ("status", "symbol", "side", "qty"):
+        assert key in result, f"Missing key in execution_result shape: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_nexus_adapter() factory
+# ---------------------------------------------------------------------------
+
+
+def test_get_nexus_adapter_default_returns_nexus_adapter(monkeypatch):
+    """Default (no env vars) must return NexusAdapter — legacy path unchanged."""
+    monkeypatch.delenv(EXECUTION_ENGINE_ENV, raising=False)
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    set_nexus_adapter(None)
+    try:
+        adapter = get_nexus_adapter()
+        assert isinstance(adapter, NexusAdapter)
+    finally:
+        set_nexus_adapter(None)
+
+
+def test_get_nexus_adapter_explicit_legacy_returns_nexus_adapter(monkeypatch):
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "legacy")
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    set_nexus_adapter(None)
+    try:
+        adapter = get_nexus_adapter()
+        assert isinstance(adapter, NexusAdapter)
+    finally:
+        set_nexus_adapter(None)
+
+
+def test_get_nexus_adapter_oms_paper_returns_oms_adapter(monkeypatch):
+    """OMS engine with paper exchange must return OmsNexusAdapter."""
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "oms")
+    monkeypatch.delenv("EXCHANGE", raising=False)
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    set_nexus_adapter(None)
+    try:
+        adapter = get_nexus_adapter()
+        assert isinstance(adapter, OmsNexusAdapter)
+    finally:
+        set_nexus_adapter(None)
+
+
+def test_get_nexus_adapter_oms_hyperliquid_without_dry_run_raises(monkeypatch):
+    """OMS + Hyperliquid without dry_run must fail closed with a clear RuntimeError."""
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "oms")
+    monkeypatch.setenv("EXCHANGE", "hyperliquid")
+    monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", "1")
+    monkeypatch.delenv("HYPERLIQUID_DRY_RUN", raising=False)
+    set_nexus_adapter(None)
+    try:
+        with pytest.raises(RuntimeError, match="not implemented"):
+            get_nexus_adapter()
+    finally:
+        set_nexus_adapter(None)
+
+
+def test_missing_sdk_does_not_break_legacy_path(monkeypatch):
+    """Missing Hyperliquid SDK must never affect the default paper/legacy path."""
+    monkeypatch.setitem(sys.modules, "hyperliquid", None)
+    monkeypatch.delenv(EXECUTION_ENGINE_ENV, raising=False)
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    set_nexus_adapter(None)
+    try:
+        adapter = get_nexus_adapter()
+        assert isinstance(adapter, NexusAdapter)
+    finally:
+        set_nexus_adapter(None)

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -302,7 +302,7 @@ def test_get_nexus_adapter_oms_hyperliquid_dry_run_returns_oms_adapter(monkeypat
         result = adapter.place_smart_order(
             symbol="BTC/USDT", side="buy", qty=0.01, order_type="limit", price=50_000.0
         )
-        assert result["status"] == "accepted"
+        assert result["status"] == "created"  # dry_run=True: Oms never submits, order stays CREATED
     finally:
         set_nexus_adapter(None)
 

--- a/tests/test_execution_engine.py
+++ b/tests/test_execution_engine.py
@@ -208,7 +208,12 @@ def test_oms_nexus_adapter_delegates_market_depth():
 
 
 def test_oms_nexus_adapter_result_shape_compatible_with_execution_result():
-    """OmsNexusAdapter result must have the minimum keys main.py expects."""
+    """Per-order result must satisfy what main.py reads from smart_orders entries.
+
+    main.py: execution_result["smart_order"] = smart_orders[0]
+    e2e test: assert smart_order["status"] == "accepted"
+    paper_account falls back to paper_snapshot when "paper" key is absent — no issue.
+    """
     fake = _FakeExchangeAdapter()
     oms_adapter = OmsNexusAdapter(oms=Oms(adapter=fake), exchange_adapter=fake)
 
@@ -219,8 +224,11 @@ def test_oms_nexus_adapter_result_shape_compatible_with_execution_result():
         order_type="market",
         price=3_000.0,
     )
-    for key in ("status", "symbol", "side", "qty"):
-        assert key in result, f"Missing key in execution_result shape: {key}"
+    # Keys that main.py and the e2e test read from individual smart_orders entries
+    assert result["status"] == "accepted"
+    assert result["symbol"] == "ETH/USDT"
+    assert result["side"] == "sell"
+    assert result["qty"] == 0.5
 
 
 # ---------------------------------------------------------------------------
@@ -274,6 +282,27 @@ def test_get_nexus_adapter_oms_hyperliquid_without_dry_run_raises(monkeypatch):
     try:
         with pytest.raises(RuntimeError, match="not implemented"):
             get_nexus_adapter()
+    finally:
+        set_nexus_adapter(None)
+
+
+def test_get_nexus_adapter_oms_hyperliquid_dry_run_returns_oms_adapter(monkeypatch):
+    """OMS + Hyperliquid + dry_run=True must return OmsNexusAdapter without SDK."""
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "oms")
+    monkeypatch.setenv("EXCHANGE", "hyperliquid")
+    monkeypatch.setenv("AI_MARKET_MAKER_ALLOW_LIVE", "1")
+    monkeypatch.setenv("HYPERLIQUID_DRY_RUN", "1")
+    # SDK absent — must still work because FakeHyperliquidClient is injected
+    monkeypatch.setitem(sys.modules, "hyperliquid", None)
+    set_nexus_adapter(None)
+    try:
+        adapter = get_nexus_adapter()
+        assert isinstance(adapter, OmsNexusAdapter)
+        # OMS maps dry_run adapter response → ACCEPTED order state (no real order sent)
+        result = adapter.place_smart_order(
+            symbol="BTC/USDT", side="buy", qty=0.01, order_type="limit", price=50_000.0
+        )
+        assert result["status"] == "accepted"
     finally:
         set_nexus_adapter(None)
 

--- a/tests/test_hyperliquid_adapter.py
+++ b/tests/test_hyperliquid_adapter.py
@@ -56,7 +56,7 @@ def test_dry_run_place_order_does_not_call_client():
         price=50000.0,
         client_order_id="coid-dry-1",
     )
-    assert result["status"] == "accepted"
+    assert result["status"] == "dry_run"
     assert result["exchange_order_id"] is None
     assert result["symbol"] == "BTC/USDT"
     assert result["side"] == "buy"
@@ -211,6 +211,16 @@ def test_repr_does_not_expose_secret():
     )
     r = repr(adapter)
     assert "VERY-SECRET-KEY-XYZ" not in r
+
+
+def test_sdk_client_repr_does_not_expose_secret():
+    config = _make_config(hyperliquid_secret="VERY-SECRET-KEY-XYZ")
+    # Bypass __init__ (which requires the SDK) to test __repr__ in isolation
+    client = _SdkHyperliquidClient.__new__(_SdkHyperliquidClient)
+    client._config = config
+    r = repr(client)
+    assert "VERY-SECRET-KEY-XYZ" not in r
+    assert "[REDACTED]" in r
 
 
 @pytest.mark.parametrize(

--- a/tests/test_hyperliquid_adapter.py
+++ b/tests/test_hyperliquid_adapter.py
@@ -200,8 +200,19 @@ def test_missing_sdk_raises_runtime_error(monkeypatch):
     monkeypatch.setitem(sys.modules, "hyperliquid.exchange", None)
     monkeypatch.setitem(sys.modules, "hyperliquid.info", None)
     config = _make_config()
-    with pytest.raises(RuntimeError, match="hyperliquid-python-sdk"):
+    with pytest.raises(RuntimeError, match="hyperliquid-python-sdk") as exc_info:
         _SdkHyperliquidClient(config)
+    assert isinstance(exc_info.value.__cause__, ImportError)
+
+
+def test_dry_run_cancel_order_does_not_call_client():
+    fake = FakeHyperliquidClient()
+    adapter = HyperliquidAdapter(config=_make_config(dry_run=True), client=fake)
+    result = adapter.cancel_order(symbol="BTC/USDT", exchange_order_id="oid-dry-1")
+    assert result["status"] == "dry_run"
+    assert result["exchange_order_id"] == "oid-dry-1"
+    assert result["raw"] == {"dry_run": True}
+    assert len(fake.cancelled_orders) == 0
 
 
 def test_repr_does_not_expose_secret():

--- a/tests/test_hyperliquid_adapter.py
+++ b/tests/test_hyperliquid_adapter.py
@@ -1,0 +1,227 @@
+"""Tests for HyperliquidAdapter (Task 3).
+
+All tests use FakeHyperliquidClient — no real SDK, no real API keys.
+_SdkHyperliquidClient is tested only for the RuntimeError path.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from adapters.hyperliquid_adapter import (
+    FakeHyperliquidClient,
+    HyperliquidAdapter,
+    _SdkHyperliquidClient,
+    normalize_hl_symbol,
+)
+from config.exchange_env import ExchangeConfig
+
+
+def _make_config(**overrides: Any) -> ExchangeConfig:
+    defaults: dict[str, Any] = dict(
+        exchange_name="hyperliquid",
+        testnet=True,
+        dry_run=False,
+        hyperliquid_api_key="test-wallet-addr",
+        hyperliquid_secret="test-secret-DO-NOT-EXPOSE",
+        hyperliquid_api_base=None,
+    )
+    defaults.update(overrides)
+    return ExchangeConfig(**defaults)
+
+
+def test_protocol_conformance_all_five_methods_exist():
+    adapter = HyperliquidAdapter(config=_make_config(), client=FakeHyperliquidClient())
+    for method in (
+        "place_order",
+        "cancel_order",
+        "get_order_status",
+        "get_portfolio_health",
+        "fetch_market_depth",
+    ):
+        assert callable(getattr(adapter, method, None)), f"Missing method: {method}"
+
+
+def test_dry_run_place_order_does_not_call_client():
+    fake = FakeHyperliquidClient()
+    adapter = HyperliquidAdapter(config=_make_config(dry_run=True), client=fake)
+    result = adapter.place_order(
+        symbol="BTC/USDT",
+        side="buy",
+        qty=0.1,
+        order_type="limit",
+        price=50000.0,
+        client_order_id="coid-dry-1",
+    )
+    assert result["status"] == "accepted"
+    assert result["exchange_order_id"] is None
+    assert result["symbol"] == "BTC/USDT"
+    assert result["side"] == "buy"
+    assert result["qty"] == 0.1
+    assert result["price"] == 50000.0
+    assert result["filled_qty"] == 0.0
+    assert result["raw"] == {"dry_run": True}
+    assert len(fake.submitted_orders) == 0
+
+
+def test_place_order_accepted_via_fake_client():
+    fake = FakeHyperliquidClient(default_response="accepted")
+    adapter = HyperliquidAdapter(config=_make_config(), client=fake)
+    result = adapter.place_order(
+        symbol="ETH/USDT",
+        side="buy",
+        qty=1.0,
+        order_type="limit",
+        price=3000.0,
+        client_order_id="coid-1",
+    )
+    assert result["status"] == "accepted"
+    assert result["exchange_order_id"] is not None
+    assert result["exchange_order_id"].startswith("fake-oid-")
+    assert result["symbol"] == "ETH/USDT"
+    assert result["side"] == "buy"
+    assert result["qty"] == 1.0
+    assert result["price"] == 3000.0
+    assert len(fake.submitted_orders) == 1
+    assert fake.submitted_orders[0]["coin"] == "ETH"
+    assert fake.submitted_orders[0]["is_buy"] is True
+    assert "error" not in result
+
+
+def test_place_order_rejected_via_fake_client():
+    fake = FakeHyperliquidClient(default_response="rejected")
+    adapter = HyperliquidAdapter(config=_make_config(), client=fake)
+    result = adapter.place_order(
+        symbol="BTC/USDT",
+        side="sell",
+        qty=0.05,
+        order_type="limit",
+        price=60000.0,
+        client_order_id="coid-2",
+    )
+    assert result["status"] == "rejected"
+    assert result["exchange_order_id"] is None
+    assert "error" in result
+    assert "insufficient margin" in result["error"]
+    assert result["raw"]["status"] == "rejected"
+
+
+def test_place_order_timeout_maps_to_unknown():
+    fake = FakeHyperliquidClient(default_response="timeout")
+    adapter = HyperliquidAdapter(config=_make_config(), client=fake)
+    result = adapter.place_order(
+        symbol="BTC/USDT",
+        side="buy",
+        qty=0.1,
+        order_type="market",
+        price=None,
+        client_order_id=None,
+    )
+    assert result["status"] == "unknown"
+    assert result["raw"]["status"] == "timeout"
+
+
+def test_cancel_order_returns_cancelled():
+    fake = FakeHyperliquidClient()
+    adapter = HyperliquidAdapter(config=_make_config(), client=fake)
+    result = adapter.cancel_order(symbol="BTC/USDT", exchange_order_id="oid-99")
+    assert result["status"] == "cancelled"
+    assert result["exchange_order_id"] == "oid-99"
+    assert result["symbol"] == "BTC/USDT"
+    assert result["side"] == ""
+    assert result["qty"] == 0.0
+    assert len(fake.cancelled_orders) == 1
+    assert fake.cancelled_orders[0]["coin"] == "BTC"
+    assert fake.cancelled_orders[0]["oid"] == "oid-99"
+
+
+@pytest.mark.parametrize(
+    "fake_response,expected_status",
+    [
+        ("accepted", "accepted"),
+        ("filled", "filled"),
+        ("cancelled", "cancelled"),
+        ("rejected", "rejected"),
+        ("partial", "partially_filled"),
+    ],
+)
+def test_get_order_status_maps_all_statuses(fake_response: str, expected_status: str):
+    fake = FakeHyperliquidClient(default_response=fake_response)
+    adapter = HyperliquidAdapter(config=_make_config(), client=fake)
+    result = adapter.get_order_status(symbol="BTC/USDT", exchange_order_id="oid-1")
+    assert result["status"] == expected_status
+    assert result["exchange_order_id"] == "oid-1"
+    assert result["symbol"] == "BTC/USDT"
+
+
+def test_fetch_open_orders_returns_list():
+    fake = FakeHyperliquidClient()
+    adapter = HyperliquidAdapter(config=_make_config(), client=fake)
+    adapter.place_order(
+        symbol="BTC/USDT",
+        side="buy",
+        qty=0.1,
+        order_type="limit",
+        price=50000.0,
+        client_order_id="c1",
+    )
+    adapter.place_order(
+        symbol="ETH/USDT",
+        side="sell",
+        qty=1.0,
+        order_type="limit",
+        price=3000.0,
+        client_order_id="c2",
+    )
+    orders = adapter.fetch_open_orders()
+    assert isinstance(orders, list)
+    assert len(orders) == 2
+
+
+def test_fetch_positions_returns_list():
+    fake = FakeHyperliquidClient()
+    adapter = HyperliquidAdapter(config=_make_config(), client=fake)
+    positions = adapter.fetch_positions()
+    assert isinstance(positions, list)
+
+
+def test_healthcheck_returns_ok():
+    fake = FakeHyperliquidClient()
+    adapter = HyperliquidAdapter(config=_make_config(), client=fake)
+    result = adapter.healthcheck()
+    assert result["status"] == "ok"
+
+
+def test_missing_sdk_raises_runtime_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "hyperliquid", None)
+    monkeypatch.setitem(sys.modules, "hyperliquid.exchange", None)
+    monkeypatch.setitem(sys.modules, "hyperliquid.info", None)
+    config = _make_config()
+    with pytest.raises(RuntimeError, match="hyperliquid-python-sdk"):
+        _SdkHyperliquidClient(config)
+
+
+def test_repr_does_not_expose_secret():
+    adapter = HyperliquidAdapter(
+        config=_make_config(hyperliquid_secret="VERY-SECRET-KEY-XYZ"),
+        client=FakeHyperliquidClient(),
+    )
+    r = repr(adapter)
+    assert "VERY-SECRET-KEY-XYZ" not in r
+
+
+@pytest.mark.parametrize(
+    "symbol,expected",
+    [
+        ("BTC/USDT", "BTC"),
+        ("BTC-USD", "BTC"),
+        ("BTCUSDT", "BTC"),
+        ("BTC", "BTC"),
+        ("ETH/USDT", "ETH"),
+    ],
+)
+def test_normalize_hl_symbol_all_cases(symbol: str, expected: str):
+    assert normalize_hl_symbol(symbol) == expected

--- a/tests/test_oms.py
+++ b/tests/test_oms.py
@@ -50,6 +50,7 @@ class _AcceptingAdapter:
 
     def __init__(self) -> None:
         self.place_order_call_count = 0
+        self.cancel_order_call_count = 0
 
     def place_order(
         self, *, symbol, side, qty, order_type, price, client_order_id
@@ -65,6 +66,7 @@ class _AcceptingAdapter:
         )
 
     def cancel_order(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        self.cancel_order_call_count += 1
         return _base_result(status="cancelled", symbol=symbol, exchange_order_id=exchange_order_id)
 
     def get_order_status(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
@@ -279,11 +281,13 @@ def test_dry_run_submit_does_not_call_adapter():
 
 def test_cancel_accepted_order():
     """Cancelling an ACCEPTED order must transition it to CANCELLED."""
-    oms = Oms(adapter=_AcceptingAdapter())
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter)
     order = _submit(oms)
     assert order.state == OrderState.ACCEPTED
 
     cancelled = oms.cancel_order(client_order_id=order.client_order_id)
+    assert adapter.cancel_order_call_count == 1
     assert cancelled.state == OrderState.CANCELLED
     assert cancelled is order  # same object, mutated in-place
 

--- a/tests/test_oms.py
+++ b/tests/test_oms.py
@@ -1,0 +1,389 @@
+"""Tests for the OMS package (Task 2).
+
+Fake adapters are defined in this file and implement the full ExchangeAdapter
+protocol without any monkeypatching of real modules.
+No Hyperliquid SDK is imported anywhere.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import time
+from typing import Any
+
+from adapters.exchange_protocol import ExchangeOrderResult
+from oms.oms import Oms
+from oms.order import OmsOrder, OrderState
+
+# ---------------------------------------------------------------------------
+# Fake adapters — full ExchangeAdapter protocol (all 5 methods)
+# ---------------------------------------------------------------------------
+
+
+def _base_result(
+    *,
+    status: str,
+    symbol: str = "BTC/USDT",
+    side: str = "buy",
+    qty: float = 0.1,
+    price: float | None = 50_000.0,
+    exchange_order_id: str | None = "eid-1",
+    client_order_id: str | None = None,
+    filled_qty: float = 0.0,
+) -> ExchangeOrderResult:
+    return ExchangeOrderResult(
+        status=status,
+        exchange_order_id=exchange_order_id,
+        client_order_id=client_order_id,
+        symbol=symbol,
+        side=side,
+        qty=qty,
+        price=price,
+        filled_qty=filled_qty,
+        ts=int(time.time()),
+        raw={},
+    )
+
+
+class _AcceptingAdapter:
+    """Always accepts orders with status='accepted'."""
+
+    def __init__(self) -> None:
+        self.place_order_call_count = 0
+
+    def place_order(
+        self, *, symbol, side, qty, order_type, price, client_order_id
+    ) -> ExchangeOrderResult:
+        self.place_order_call_count += 1
+        return _base_result(
+            status="accepted",
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            price=price,
+            client_order_id=client_order_id,
+        )
+
+    def cancel_order(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return _base_result(status="cancelled", symbol=symbol, exchange_order_id=exchange_order_id)
+
+    def get_order_status(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return _base_result(status="accepted", symbol=symbol, exchange_order_id=exchange_order_id)
+
+    def get_portfolio_health(self, *, account_id: str | None = None) -> dict[str, Any]:
+        return {"balances": {}, "positions": []}
+
+    def fetch_market_depth(self, *, symbol: str, limit: int) -> dict[str, Any]:
+        return {"symbol": symbol, "bids": [], "asks": []}
+
+
+class _RejectingAdapter:
+    """Always rejects orders with status='rejected'."""
+
+    def place_order(
+        self, *, symbol, side, qty, order_type, price, client_order_id
+    ) -> ExchangeOrderResult:
+        return _base_result(
+            status="rejected",
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            price=price,
+            client_order_id=client_order_id,
+        )
+
+    def cancel_order(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return _base_result(status="cancelled", symbol=symbol, exchange_order_id=exchange_order_id)
+
+    def get_order_status(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return _base_result(status="rejected", symbol=symbol, exchange_order_id=exchange_order_id)
+
+    def get_portfolio_health(self, *, account_id: str | None = None) -> dict[str, Any]:
+        return {"balances": {}, "positions": []}
+
+    def fetch_market_depth(self, *, symbol: str, limit: int) -> dict[str, Any]:
+        return {"symbol": symbol, "bids": [], "asks": []}
+
+
+class _FilledStatusAdapter:
+    """Returns 'accepted' on place_order, then 'filled' on get_order_status."""
+
+    def place_order(
+        self, *, symbol, side, qty, order_type, price, client_order_id
+    ) -> ExchangeOrderResult:
+        return _base_result(
+            status="accepted",
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            price=price,
+            client_order_id=client_order_id,
+            exchange_order_id="eid-fill",
+            filled_qty=0.0,
+        )
+
+    def cancel_order(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return _base_result(status="cancelled", symbol=symbol, exchange_order_id=exchange_order_id)
+
+    def get_order_status(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return _base_result(
+            status="filled",
+            symbol=symbol,
+            exchange_order_id=exchange_order_id,
+            filled_qty=0.1,
+            price=50_000.0,
+        )
+
+    def get_portfolio_health(self, *, account_id: str | None = None) -> dict[str, Any]:
+        return {"balances": {}, "positions": []}
+
+    def fetch_market_depth(self, *, symbol: str, limit: int) -> dict[str, Any]:
+        return {"symbol": symbol, "bids": [], "asks": []}
+
+
+class _TimeoutAdapter:
+    """Returns status='timeout' — an unrecognised status that maps to UNKNOWN."""
+
+    def place_order(
+        self, *, symbol, side, qty, order_type, price, client_order_id
+    ) -> ExchangeOrderResult:
+        return _base_result(
+            status="timeout",
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            price=price,
+            client_order_id=client_order_id,
+            exchange_order_id="eid-timeout",
+        )
+
+    def cancel_order(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return _base_result(status="cancelled", symbol=symbol, exchange_order_id=exchange_order_id)
+
+    def get_order_status(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+        return _base_result(status="timeout", symbol=symbol, exchange_order_id=exchange_order_id)
+
+    def get_portfolio_health(self, *, account_id: str | None = None) -> dict[str, Any]:
+        return {"balances": {}, "positions": []}
+
+    def fetch_market_depth(self, *, symbol: str, limit: int) -> dict[str, Any]:
+        return {"symbol": symbol, "bids": [], "asks": []}
+
+
+# ---------------------------------------------------------------------------
+# Shared submit helper
+# ---------------------------------------------------------------------------
+
+
+def _submit(oms: Oms, *, nonce: str = "n1", **kwargs: Any) -> OmsOrder:
+    defaults: dict[str, Any] = dict(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="market",
+        quantity=0.1,
+        strategy="test-strat",
+        run_id="run-001",
+        nonce=nonce,
+    )
+    defaults.update(kwargs)
+    return oms.submit_order(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — fresh OmsOrder default state
+# ---------------------------------------------------------------------------
+
+
+def test_new_order_default_state_is_created():
+    """A freshly constructed OmsOrder must start in CREATED state."""
+    order = OmsOrder(
+        client_order_id="coid-1",
+        idempotency_key="idem-1",
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="market",
+        quantity=0.1,
+    )
+    assert order.state == OrderState.CREATED
+    assert order.venue_order_id is None
+    assert order.filled_quantity == 0.0
+    assert order.error is None
+    assert isinstance(order.created_at, int)
+    assert isinstance(order.updated_at, int)
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — accepted transition
+# ---------------------------------------------------------------------------
+
+
+def test_submit_order_accepted_transitions_to_accepted():
+    """When adapter returns 'accepted', order state must be ACCEPTED."""
+    oms = Oms(adapter=_AcceptingAdapter())
+    order = _submit(oms)
+    assert order.state == OrderState.ACCEPTED
+    assert order.venue_order_id is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — idempotency dedup
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_idempotency_key_does_not_call_adapter_twice():
+    """Second submit_order with the same idempotency key must return the cached
+    OmsOrder without calling adapter.place_order again."""
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter)
+
+    idem = Oms.make_idempotency_key("s", "r", "BTC/USDT", "buy", "market", "n1")
+
+    order_a = _submit(oms, idempotency_key=idem, nonce="n1")
+    order_b = _submit(oms, idempotency_key=idem, nonce="n1")
+
+    assert order_a is order_b
+    assert adapter.place_order_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — rejected transition
+# ---------------------------------------------------------------------------
+
+
+def test_submit_rejected_transitions_to_rejected():
+    """When adapter returns 'rejected', order state must be REJECTED."""
+    oms = Oms(adapter=_RejectingAdapter())
+    order = _submit(oms)
+    assert order.state == OrderState.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — dry run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_submit_does_not_call_adapter():
+    """With dry_run=True, adapter.place_order must never be called and order
+    remains in CREATED state."""
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter, dry_run=True)
+    order = _submit(oms)
+    assert order.state == OrderState.CREATED
+    assert adapter.place_order_call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — cancel accepted order
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_accepted_order():
+    """Cancelling an ACCEPTED order must transition it to CANCELLED."""
+    oms = Oms(adapter=_AcceptingAdapter())
+    order = _submit(oms)
+    assert order.state == OrderState.ACCEPTED
+
+    cancelled = oms.cancel_order(client_order_id=order.client_order_id)
+    assert cancelled.state == OrderState.CANCELLED
+    assert cancelled is order  # same object, mutated in-place
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — get_order_status maps 'filled'
+# ---------------------------------------------------------------------------
+
+
+def test_get_order_status_maps_filled():
+    """After adapter reports 'filled', order state must be FILLED."""
+    oms = Oms(adapter=_FilledStatusAdapter())
+    order = _submit(oms)
+    # place_order returned 'accepted' — start from ACCEPTED
+    assert order.state == OrderState.ACCEPTED
+
+    refreshed = oms.get_order_status(client_order_id=order.client_order_id)
+    assert refreshed.state == OrderState.FILLED
+    assert refreshed is order
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — unknown status stays UNKNOWN, no auto-retry
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_status_from_adapter_stays_unknown():
+    """Adapter returning an unrecognised status ('timeout') must map to UNKNOWN,
+    not trigger a retry or raise an exception."""
+    oms = Oms(adapter=_TimeoutAdapter())
+    order = _submit(oms)
+    assert order.state == OrderState.UNKNOWN
+
+    # Calling get_order_status on an UNKNOWN order (non-terminal, has venue_id)
+    # must not raise and must remain UNKNOWN when adapter still returns 'timeout'
+    refreshed = oms.get_order_status(client_order_id=order.client_order_id)
+    assert refreshed.state == OrderState.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — reconcile marks missing orders EXPIRED, no exchange calls
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_no_exchange_calls():
+    """reconcile(known_venue_ids={...}) must:
+    - Mark orders whose venue_order_id is absent from the set as EXPIRED
+    - NOT call any adapter method
+    - Leave orders whose venue_order_id IS in the set untouched
+    """
+
+    class _SpyAdapter(_AcceptingAdapter):
+        def get_order_status(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+            raise AssertionError("get_order_status must not be called during reconcile")
+
+        def cancel_order(self, *, symbol, exchange_order_id) -> ExchangeOrderResult:
+            raise AssertionError("cancel_order must not be called during reconcile")
+
+    adapter = _SpyAdapter()
+    oms = Oms(adapter=adapter)
+
+    order_a = _submit(oms, nonce="a")
+    order_b = _submit(oms, nonce="b")
+    order_c = _submit(oms, nonce="c")
+
+    # Confirm all are ACCEPTED (adapter accepts all)
+    assert order_a.state == OrderState.ACCEPTED
+    assert order_b.state == OrderState.ACCEPTED
+    assert order_c.state == OrderState.ACCEPTED
+
+    # Assign deterministic venue IDs so reconcile has distinct values to compare
+    order_a.venue_order_id = "venue-a"
+    order_b.venue_order_id = "venue-b"
+    order_c.venue_order_id = "venue-c"
+
+    # Only venue-a is known; venue-b and venue-c should be expired
+    expired = oms.reconcile(known_venue_ids={"venue-a"})
+
+    assert order_a.state == OrderState.ACCEPTED  # untouched — was in known set
+    assert order_b.state == OrderState.EXPIRED
+    assert order_c.state == OrderState.EXPIRED
+
+    assert len(expired) == 2
+    assert order_b in expired
+    assert order_c in expired
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — no hyperliquid imports in oms source
+# ---------------------------------------------------------------------------
+
+
+def test_oms_has_no_hyperliquid_import():
+    """oms.py and order.py must contain no reference to 'hyperliquid'."""
+    src_root = pathlib.Path(__file__).resolve().parents[1] / "src"
+
+    for rel_path in ("oms/oms.py", "oms/order.py"):
+        path = src_root / rel_path
+        source = path.read_text(encoding="utf-8")
+        assert "import hyperliquid" not in source.lower(), (
+            f"Found 'import hyperliquid' in {rel_path}"
+        )
+        assert "from hyperliquid" not in source.lower(), f"Found 'from hyperliquid' in {rel_path}"


### PR DESCRIPTION
## Summary

This PR adds a safe, opt-in OMS execution layer and a Hyperliquid adapter foundation without changing the default paper execution path.

The default behaviour remains legacy/paper execution through `NexusAdapter`. OMS routing is only enabled when `AI_MARKET_MAKER_EXECUTION_ENGINE=oms` is explicitly configured.

## Changes

- Added `ExchangeAdapter` protocol and exchange config loader
- Added `Oms` with idempotency, order lifecycle states, dry-run handling, cancel/status/reconcile hooks
- Added `HyperliquidAdapter` with fake client, lazy SDK import, dry-run guard, symbol normalization, and secret-safe repr
- Added `OmsNexusAdapter` and factory routing via `get_nexus_adapter()`
- Updated `.env.example`, `docs/run-modes.md`, and README

## Safety

- Default paper path is unchanged
- Live trading is not enabled by default
- `AI_MARKET_MAKER_ALLOW_LIVE` defaults to `0`
- Hyperliquid testnet defaults to enabled
- Hyperliquid dry-run is the only supported Hyperliquid path in this PR
- Real SDK live order placement is intentionally not implemented
- Unsupported live path fails closed
- Secrets are not exposed in repr/log-friendly output

## Test Plan

- `uv run pytest tests -q`
- `uv run pre-commit run --all-files`
- Default paper path verified unchanged
- Unsupported Hyperliquid live path verified fail-closed

## Note

This PR intentionally stops short of real Hyperliquid live SDK order placement. It introduces the execution safety boundary first, so a future PR can implement the SDK client against this tested OMS/adapter contract.