### PR TITLE
feat(oms): persistent order ledger with SQLite backend and event table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,17 @@ HYPERLIQUID_DRY_RUN=1       # 1=parse+validate only, never sends real orders
 # HYPERLIQUID_API_BASE=     # optional: override API base URL
 # HYPERLIQUID_API_KEY=      # wallet address (leave blank for dry-run/testnet only)
 # HYPERLIQUID_SECRET=       # NEVER commit this — private key / secret
+
+# ---------------------------------------------------------------------------
+# OMS persistent ledger (opt-in, only active when execution engine is OMS)
+# ---------------------------------------------------------------------------
+# AI_MARKET_MAKER_OMS_LEDGER=in_memory   # default — no filesystem side-effects
+# AI_MARKET_MAKER_OMS_LEDGER=sqlite      # opt-in — SQLite persistence (stdlib only)
+#
+# When sqlite is selected:
+#   - Restart-safe idempotency: duplicate orders blocked across process restarts
+#   - Order state and events survive process exits
+#   - oms_orders and oms_order_events tables are created lazily on first use
+#   - No secrets are stored; only order metadata already held in OmsOrder
+#
+# AI_MARKET_MAKER_OMS_SQLITE_PATH=.runs/oms/orders.sqlite   # default path

--- a/docs/run-modes.md
+++ b/docs/run-modes.md
@@ -104,3 +104,59 @@ Real live order placement is blocked until a future PR implements and fully test
 RuntimeError: Hyperliquid live SDK execution is not implemented in this PR.
 Set HYPERLIQUID_DRY_RUN=1 to use dry-run mode, or use exchange=paper.
 ```
+
+---
+
+## OMS Persistent Order Ledger
+
+When `AI_MARKET_MAKER_EXECUTION_ENGINE=oms`, order state lives in memory by default. The ledger layer makes it optional to persist that state to SQLite so it survives process restarts.
+
+### Ledger types
+
+| `AI_MARKET_MAKER_OMS_LEDGER` | Behaviour |
+|------------------------------|-----------|
+| `in_memory` (default) | No filesystem side-effects — identical to no ledger |
+| `sqlite` | Persists `oms_orders` and `oms_order_events` to a local SQLite file |
+
+### What SQLite persistence enables
+
+- **Restart-safe idempotency** — duplicate order submissions blocked across process restarts, not just within a single run
+- **Order state recovery** — `ACCEPTED`, `PARTIALLY_FILLED`, and other live orders reload on startup
+- **Event audit trail** — every state transition (created, submitted, accepted, cancelled, expired, …) is appended to `oms_order_events` for future reconciliation
+- No external services required — uses Python stdlib `sqlite3`
+
+### Schema
+
+**`oms_orders`** — one row per order, upserted on every state change:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `client_order_id` | TEXT PK | stable across restarts |
+| `idempotency_key` | TEXT UNIQUE | SHA-256 of strategy+run+symbol+side+type+nonce |
+| `state` | TEXT | `OrderState` string value |
+| `venue_order_id` | TEXT | set after exchange confirms |
+| … | | all other `OmsOrder` fields |
+
+**`oms_order_events`** — append-only event log, keyed on `client_order_id`:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | INTEGER PK AUTOINCREMENT | insertion order |
+| `event_type` | TEXT | `order_created`, `order_submitted`, `order_accepted`, … |
+| `payload_json` | TEXT | small JSON payload (no secrets) |
+| `created_at` | INTEGER | unix epoch seconds |
+
+### Configuration
+
+```env
+AI_MARKET_MAKER_OMS_LEDGER=sqlite
+AI_MARKET_MAKER_OMS_SQLITE_PATH=.runs/oms/orders.sqlite   # default path
+```
+
+### Safety
+
+- No secrets are written to the ledger — only order metadata already held in `OmsOrder`
+- `in_memory` is the default — no SQLite file is created unless explicitly configured
+- The SQLite file and its parent directories are created lazily on first use
+- WAL journal mode is enabled for crash safety
+- This PR still does not implement real Hyperliquid live SDK order placement

--- a/src/adapters/nexus_adapter.py
+++ b/src/adapters/nexus_adapter.py
@@ -350,16 +350,20 @@ def get_nexus_adapter() -> Any:
 
     # OMS path — requires explicit AI_MARKET_MAKER_EXECUTION_ENGINE=oms
     from config.exchange_env import load_exchange_config
+    from config.oms_config import load_oms_config
+    from oms.ledger import SqliteLedger
     from oms.oms import Oms
 
     cfg = load_exchange_config()
+    oms_cfg = load_oms_config()
+    ledger = SqliteLedger(oms_cfg.sqlite_path) if oms_cfg.ledger_type == "sqlite" else None
 
     if cfg.exchange_name == "paper":
         mode = (os.getenv("MODE") or "paper").strip().lower()
         inner = NexusAdapter(
             NexusAdapterConfig(mode=mode, nexus_data_base_url=load_nexus_data_base_url())
         )
-        oms = Oms(adapter=inner, dry_run=cfg.dry_run)
+        oms = Oms(adapter=inner, dry_run=cfg.dry_run, ledger=ledger)
         _adapter = OmsNexusAdapter(oms=oms, exchange_adapter=inner)
 
     elif cfg.exchange_name == "hyperliquid":
@@ -374,7 +378,7 @@ def get_nexus_adapter() -> Any:
         from adapters.hyperliquid_adapter import FakeHyperliquidClient, HyperliquidAdapter
 
         hl_adapter = HyperliquidAdapter(config=cfg, client=FakeHyperliquidClient())
-        oms = Oms(adapter=hl_adapter, dry_run=cfg.dry_run)
+        oms = Oms(adapter=hl_adapter, dry_run=cfg.dry_run, ledger=ledger)
         _adapter = OmsNexusAdapter(oms=oms, exchange_adapter=hl_adapter)
 
     else:

--- a/src/config/oms_config.py
+++ b/src/config/oms_config.py
@@ -1,0 +1,53 @@
+"""OMS ledger configuration.
+
+AI_MARKET_MAKER_OMS_LEDGER=in_memory   (default) — pure in-memory, no filesystem side-effects
+AI_MARKET_MAKER_OMS_LEDGER=sqlite      — SQLite persistence; requires no external services
+
+AI_MARKET_MAKER_OMS_SQLITE_PATH=.runs/oms/orders.sqlite
+    Path to the SQLite file. Only read when ledger type is 'sqlite'.
+    Defaults to .runs/oms/orders.sqlite if not set.
+    The directory is created lazily when SqliteLedger is first constructed.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+OMS_LEDGER_ENV = "AI_MARKET_MAKER_OMS_LEDGER"
+OMS_SQLITE_PATH_ENV = "AI_MARKET_MAKER_OMS_SQLITE_PATH"
+_DEFAULT_SQLITE_PATH = ".runs/oms/orders.sqlite"
+
+
+@dataclass(frozen=True)
+class OmsConfig:
+    ledger_type: str = "in_memory"  # "in_memory" | "sqlite"
+    sqlite_path: Path | None = None  # only meaningful when ledger_type == "sqlite"
+
+
+def load_oms_config(*, env: Mapping[str, str] | None = None) -> OmsConfig:
+    """Load OMS ledger config from the environment.
+
+    Raises:
+        ValueError: if AI_MARKET_MAKER_OMS_LEDGER is set to an unsupported value.
+    """
+    e = env if env is not None else os.environ
+    ledger_type = (e.get(OMS_LEDGER_ENV) or "in_memory").strip().lower()
+
+    if ledger_type not in ("in_memory", "sqlite"):
+        raise ValueError(
+            f"AI_MARKET_MAKER_OMS_LEDGER={ledger_type!r} is not supported. "
+            "Valid values: 'in_memory' (default), 'sqlite'."
+        )
+
+    sqlite_path: Path | None = None
+    if ledger_type == "sqlite":
+        raw = (e.get(OMS_SQLITE_PATH_ENV) or _DEFAULT_SQLITE_PATH).strip()
+        sqlite_path = Path(raw)
+
+    return OmsConfig(ledger_type=ledger_type, sqlite_path=sqlite_path)
+
+
+__all__ = ["OMS_LEDGER_ENV", "OMS_SQLITE_PATH_ENV", "OmsConfig", "load_oms_config"]

--- a/src/oms/__init__.py
+++ b/src/oms/__init__.py
@@ -6,7 +6,8 @@ No exchange SDK imports here — adapter coupling happens at the ExchangeAdapter
 
 from __future__ import annotations
 
+from oms.ledger import InMemoryLedger, OmsLedger, SqliteLedger
 from oms.oms import Oms
 from oms.order import OmsOrder, OrderState
 
-__all__ = ["Oms", "OmsOrder", "OrderState"]
+__all__ = ["Oms", "InMemoryLedger", "OmsLedger", "OmsOrder", "OrderState", "SqliteLedger"]

--- a/src/oms/ledger.py
+++ b/src/oms/ledger.py
@@ -1,0 +1,270 @@
+"""OMS persistent ledger abstractions.
+
+Two implementations:
+  InMemoryLedger — default, no I/O, zero side-effects (same behaviour as no ledger)
+  SqliteLedger   — opt-in, stdlib sqlite3 only, WAL journal mode
+
+No exchange SDK imports. No secrets stored beyond what OmsOrder already holds.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from oms.order import OmsOrder, OrderState
+
+# Non-terminal states (orders that may still transition)
+_OPEN_STATES: frozenset[str] = frozenset(
+    {
+        OrderState.CREATED,
+        OrderState.SUBMITTED,
+        OrderState.ACCEPTED,
+        OrderState.PARTIALLY_FILLED,
+        OrderState.UNKNOWN,
+    }
+)
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS oms_orders (
+    client_order_id    TEXT PRIMARY KEY,
+    idempotency_key    TEXT NOT NULL,
+    symbol             TEXT NOT NULL,
+    side               TEXT NOT NULL,
+    order_type         TEXT NOT NULL,
+    quantity           REAL NOT NULL,
+    price              REAL,
+    state              TEXT NOT NULL,
+    venue_order_id     TEXT,
+    filled_quantity    REAL NOT NULL DEFAULT 0.0,
+    average_fill_price REAL,
+    error              TEXT,
+    created_at         INTEGER NOT NULL,
+    updated_at         INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_oms_orders_idem
+    ON oms_orders(idempotency_key);
+
+CREATE TABLE IF NOT EXISTS oms_order_events (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_order_id  TEXT NOT NULL,
+    event_type       TEXT NOT NULL,
+    payload_json     TEXT,
+    created_at       INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_oms_events_coid
+    ON oms_order_events(client_order_id);
+"""
+
+
+def _row_to_order(row: sqlite3.Row) -> OmsOrder:
+    return OmsOrder(
+        client_order_id=row["client_order_id"],
+        idempotency_key=row["idempotency_key"],
+        symbol=row["symbol"],
+        side=row["side"],
+        order_type=row["order_type"],
+        quantity=row["quantity"],
+        price=row["price"],
+        state=OrderState(row["state"]),
+        venue_order_id=row["venue_order_id"],
+        filled_quantity=row["filled_quantity"],
+        average_fill_price=row["average_fill_price"],
+        error=row["error"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+@runtime_checkable
+class OmsLedger(Protocol):
+    """Minimal persistence contract for OMS order state and events."""
+
+    def upsert_order(self, order: OmsOrder) -> None: ...
+
+    def load_orders(self) -> list[OmsOrder]: ...
+
+    def get_order_by_client_id(self, client_order_id: str) -> OmsOrder | None: ...
+
+    def get_order_by_idempotency_key(self, idempotency_key: str) -> OmsOrder | None: ...
+
+    def list_open_orders(self) -> list[OmsOrder]: ...
+
+    def append_event(
+        self,
+        client_order_id: str,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None: ...
+
+    def list_events(self, client_order_id: str) -> list[dict[str, Any]]: ...
+
+
+class InMemoryLedger:
+    """In-memory ledger — no I/O, protocol-compatible. Default when no ledger is configured."""
+
+    def __init__(self) -> None:
+        self._orders: dict[str, OmsOrder] = {}
+        self._idem_index: dict[str, str] = {}
+        self._events: dict[str, list[dict[str, Any]]] = {}
+
+    def upsert_order(self, order: OmsOrder) -> None:
+        self._orders[order.client_order_id] = order
+        self._idem_index[order.idempotency_key] = order.client_order_id
+
+    def load_orders(self) -> list[OmsOrder]:
+        return list(self._orders.values())
+
+    def get_order_by_client_id(self, client_order_id: str) -> OmsOrder | None:
+        return self._orders.get(client_order_id)
+
+    def get_order_by_idempotency_key(self, idempotency_key: str) -> OmsOrder | None:
+        coid = self._idem_index.get(idempotency_key)
+        return self._orders.get(coid) if coid else None
+
+    def list_open_orders(self) -> list[OmsOrder]:
+        return [o for o in self._orders.values() if o.state in _OPEN_STATES]
+
+    def append_event(
+        self,
+        client_order_id: str,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        self._events.setdefault(client_order_id, []).append(
+            {
+                "client_order_id": client_order_id,
+                "event_type": event_type,
+                "payload": payload or {},
+                "created_at": int(time.time()),
+            }
+        )
+
+    def list_events(self, client_order_id: str) -> list[dict[str, Any]]:
+        return list(self._events.get(client_order_id, []))
+
+
+class SqliteLedger:
+    """SQLite-backed OMS ledger using stdlib sqlite3 only.
+
+    Creates parent directories and initialises the schema on construction.
+    WAL journal mode is enabled for crash safety and concurrent reads.
+    """
+
+    def __init__(self, db_path: Path | str) -> None:
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(_DDL)
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Orders
+    # ------------------------------------------------------------------
+
+    def upsert_order(self, order: OmsOrder) -> None:
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO oms_orders (
+                client_order_id, idempotency_key, symbol, side, order_type,
+                quantity, price, state, venue_order_id, filled_quantity,
+                average_fill_price, error, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                order.client_order_id,
+                order.idempotency_key,
+                order.symbol,
+                order.side,
+                order.order_type,
+                order.quantity,
+                order.price,
+                order.state.value,
+                order.venue_order_id,
+                order.filled_quantity,
+                order.average_fill_price,
+                order.error,
+                order.created_at,
+                order.updated_at,
+            ),
+        )
+        self._conn.commit()
+
+    def load_orders(self) -> list[OmsOrder]:
+        rows = self._conn.execute("SELECT * FROM oms_orders").fetchall()
+        return [_row_to_order(r) for r in rows]
+
+    def get_order_by_client_id(self, client_order_id: str) -> OmsOrder | None:
+        row = self._conn.execute(
+            "SELECT * FROM oms_orders WHERE client_order_id = ?",
+            (client_order_id,),
+        ).fetchone()
+        return _row_to_order(row) if row else None
+
+    def get_order_by_idempotency_key(self, idempotency_key: str) -> OmsOrder | None:
+        row = self._conn.execute(
+            "SELECT * FROM oms_orders WHERE idempotency_key = ?",
+            (idempotency_key,),
+        ).fetchone()
+        return _row_to_order(row) if row else None
+
+    def list_open_orders(self) -> list[OmsOrder]:
+        placeholders = ",".join("?" * len(_OPEN_STATES))
+        rows = self._conn.execute(
+            f"SELECT * FROM oms_orders WHERE state IN ({placeholders})",
+            tuple(_OPEN_STATES),
+        ).fetchall()
+        return [_row_to_order(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Events
+    # ------------------------------------------------------------------
+
+    def append_event(
+        self,
+        client_order_id: str,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO oms_order_events (client_order_id, event_type, payload_json, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                client_order_id,
+                event_type,
+                json.dumps(payload) if payload else None,
+                int(time.time()),
+            ),
+        )
+        self._conn.commit()
+
+    def list_events(self, client_order_id: str) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT * FROM oms_order_events WHERE client_order_id = ? ORDER BY id",
+            (client_order_id,),
+        ).fetchall()
+        return [
+            {
+                "id": r["id"],
+                "client_order_id": r["client_order_id"],
+                "event_type": r["event_type"],
+                "payload": json.loads(r["payload_json"]) if r["payload_json"] else {},
+                "created_at": r["created_at"],
+            }
+            for r in rows
+        ]
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+__all__ = ["InMemoryLedger", "OmsLedger", "SqliteLedger"]

--- a/src/oms/oms.py
+++ b/src/oms/oms.py
@@ -14,6 +14,7 @@ import hashlib
 from typing import Any
 
 from adapters.exchange_protocol import ExchangeAdapter
+from oms.ledger import OmsLedger
 from oms.order import OmsOrder, OrderState
 
 # ---------------------------------------------------------------------------
@@ -80,13 +81,37 @@ class Oms:
                   but never calls adapter.place_order.
     """
 
-    def __init__(self, *, adapter: ExchangeAdapter, dry_run: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        adapter: ExchangeAdapter,
+        dry_run: bool = False,
+        ledger: OmsLedger | None = None,
+    ) -> None:
         self._adapter = adapter
         self._dry_run = dry_run
+        self._ledger = ledger
         # Primary store: client_order_id → OmsOrder
         self._orders: dict[str, OmsOrder] = {}
         # Reverse index for idempotency: idempotency_key → client_order_id
         self._idem_index: dict[str, str] = {}
+        if ledger is not None:
+            for order in ledger.load_orders():
+                self._orders[order.client_order_id] = order
+                self._idem_index[order.idempotency_key] = order.client_order_id
+
+    # ------------------------------------------------------------------
+    # Ledger helpers
+    # ------------------------------------------------------------------
+
+    def _record(
+        self, order: OmsOrder, event_type: str, payload: dict[str, Any] | None = None
+    ) -> None:
+        """Upsert the order snapshot and append an event. No-op when no ledger is set."""
+        if self._ledger is None:
+            return
+        self._ledger.upsert_order(order)
+        self._ledger.append_event(order.client_order_id, event_type, payload)
 
     # ------------------------------------------------------------------
     # Static factory helpers
@@ -188,6 +213,7 @@ class Oms:
 
         self._orders[coid] = order
         self._idem_index[idem_key] = coid
+        self._record(order, "order_created", {"dry_run": True} if self._dry_run else None)
 
         if self._dry_run:
             # Dry run: persist the order in CREATED state, never touch the adapter
@@ -195,6 +221,7 @@ class Oms:
 
         # Transition to SUBMITTED before adapter call
         order._transition(OrderState.SUBMITTED)
+        self._record(order, "order_submitted")
 
         try:
             result = self._adapter.place_order(
@@ -206,9 +233,11 @@ class Oms:
                 client_order_id=coid,
             )
             _apply_result(order, result)
+            self._record(order, f"order_{order.state.value}")
         except Exception as exc:
             order.error = str(exc)
             order._transition(OrderState.FAILED)
+            self._record(order, "order_failed", {"error": str(exc)})
 
         return order
 
@@ -233,6 +262,7 @@ class Oms:
 
         if order.venue_order_id is None:
             order._transition(OrderState.CANCELLED)
+            self._record(order, "order_cancelled")
             return order
 
         try:
@@ -241,9 +271,11 @@ class Oms:
                 exchange_order_id=order.venue_order_id,
             )
             _apply_result(order, result)
+            self._record(order, f"order_{order.state.value}")
         except Exception as exc:
             order.error = str(exc)
             order._transition(OrderState.FAILED)
+            self._record(order, "order_failed", {"error": str(exc)})
 
         return order
 
@@ -273,9 +305,11 @@ class Oms:
                 exchange_order_id=order.venue_order_id,
             )
             _apply_result(order, result)
+            self._record(order, "order_status_updated", {"state": order.state.value})
         except Exception as exc:
             order.error = str(exc)
             order._transition(OrderState.FAILED)
+            self._record(order, "order_failed", {"error": str(exc)})
 
         return order
 
@@ -307,6 +341,7 @@ class Oms:
                 continue
             if order.venue_order_id not in known_venue_ids:
                 order._transition(OrderState.EXPIRED)
+                self._record(order, "order_expired")
                 expired.append(order)
 
         return expired

--- a/tests/test_oms_ledger.py
+++ b/tests/test_oms_ledger.py
@@ -1,0 +1,684 @@
+"""Tests for OMS ledger implementations, Oms+ledger integration, and OmsConfig.
+
+All SQLite tests use pytest's tmp_path — no external services, no persistent filesystem state.
+InMemoryLedger tests need no fixtures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from adapters.exchange_protocol import ExchangeOrderResult
+from adapters.nexus_adapter import OmsNexusAdapter, get_nexus_adapter, set_nexus_adapter
+from config.execution_engine import EXECUTION_ENGINE_ENV
+from config.oms_config import (
+    OMS_LEDGER_ENV,
+    OMS_SQLITE_PATH_ENV,
+    load_oms_config,
+)
+from oms.ledger import _OPEN_STATES, InMemoryLedger, OmsLedger, SqliteLedger
+from oms.oms import Oms
+from oms.order import OmsOrder, OrderState
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_order(
+    client_order_id: str = "coid-1",
+    idempotency_key: str = "idem-1",
+    state: OrderState = OrderState.CREATED,
+    venue_order_id: str | None = None,
+) -> OmsOrder:
+    return OmsOrder(
+        client_order_id=client_order_id,
+        idempotency_key=idempotency_key,
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        state=state,
+        venue_order_id=venue_order_id,
+        created_at=1_000_000,
+        updated_at=1_000_000,
+    )
+
+
+class _AcceptingAdapter:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def place_order(self, *, symbol, side, qty, order_type, price, client_order_id):
+        self.call_count += 1
+        return ExchangeOrderResult(
+            status="accepted",
+            exchange_order_id=f"eid-{self.call_count}",
+            client_order_id=client_order_id,
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            price=price,
+            filled_qty=0.0,
+            ts=1_000_000,
+            raw={},
+        )
+
+    def cancel_order(self, *, symbol, exchange_order_id):
+        return ExchangeOrderResult(
+            status="cancelled",
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="",
+            qty=0.0,
+            price=None,
+            filled_qty=0.0,
+            ts=1_000_000,
+            raw={},
+        )
+
+    def get_order_status(self, *, symbol, exchange_order_id):
+        return ExchangeOrderResult(
+            status="accepted",
+            exchange_order_id=exchange_order_id,
+            client_order_id=None,
+            symbol=symbol,
+            side="",
+            qty=0.0,
+            price=None,
+            filled_qty=0.0,
+            ts=1_000_000,
+            raw={},
+        )
+
+    def get_portfolio_health(self, *, account_id=None):
+        return {}
+
+    def fetch_market_depth(self, *, symbol, limit):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# InMemoryLedger tests
+# ---------------------------------------------------------------------------
+
+
+def test_in_memory_ledger_upsert_and_load():
+    ledger = InMemoryLedger()
+    order = _make_order()
+    ledger.upsert_order(order)
+    loaded = ledger.load_orders()
+    assert len(loaded) == 1
+    assert loaded[0].client_order_id == "coid-1"
+
+
+def test_in_memory_ledger_get_by_client_id():
+    ledger = InMemoryLedger()
+    order = _make_order(client_order_id="abc")
+    ledger.upsert_order(order)
+    assert ledger.get_order_by_client_id("abc") is order
+    assert ledger.get_order_by_client_id("missing") is None
+
+
+def test_in_memory_ledger_get_by_idempotency_key():
+    ledger = InMemoryLedger()
+    order = _make_order(idempotency_key="idem-xyz")
+    ledger.upsert_order(order)
+    assert ledger.get_order_by_idempotency_key("idem-xyz") is order
+    assert ledger.get_order_by_idempotency_key("missing") is None
+
+
+def test_in_memory_ledger_upsert_overwrites():
+    ledger = InMemoryLedger()
+    order = _make_order(state=OrderState.CREATED)
+    ledger.upsert_order(order)
+    order.state = OrderState.ACCEPTED  # mutate in place
+    ledger.upsert_order(order)
+    assert ledger.get_order_by_client_id("coid-1").state == OrderState.ACCEPTED
+
+
+def test_in_memory_ledger_list_open_orders():
+    ledger = InMemoryLedger()
+    for state in OrderState:
+        ledger.upsert_order(
+            _make_order(client_order_id=state.value, idempotency_key=state.value, state=state)
+        )
+    open_states = {o.state for o in ledger.list_open_orders()}
+    assert open_states == set(_OPEN_STATES)
+
+
+def test_in_memory_ledger_append_and_list_events():
+    ledger = InMemoryLedger()
+    ledger.append_event("coid-1", "order_created")
+    ledger.append_event("coid-1", "order_submitted", {"venue": "test"})
+    events = ledger.list_events("coid-1")
+    assert len(events) == 2
+    assert events[0]["event_type"] == "order_created"
+    assert events[1]["event_type"] == "order_submitted"
+    assert events[1]["payload"] == {"venue": "test"}
+
+
+def test_in_memory_ledger_events_isolated_per_order():
+    ledger = InMemoryLedger()
+    ledger.append_event("coid-1", "order_created")
+    ledger.append_event("coid-2", "order_created")
+    assert len(ledger.list_events("coid-1")) == 1
+    assert len(ledger.list_events("coid-2")) == 1
+    assert ledger.list_events("coid-3") == []
+
+
+def test_in_memory_ledger_satisfies_protocol():
+    assert isinstance(InMemoryLedger(), OmsLedger)
+
+
+# ---------------------------------------------------------------------------
+# SqliteLedger tests
+# ---------------------------------------------------------------------------
+
+
+def test_sqlite_creates_schema_on_init(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    # Both tables must exist
+    tables = {
+        r[0]
+        for r in ledger._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert "oms_orders" in tables
+    assert "oms_order_events" in tables
+    ledger.close()
+
+
+def test_sqlite_creates_parent_dirs(tmp_path: Path):
+    db = tmp_path / "a" / "b" / "c" / "oms.db"
+    ledger = SqliteLedger(db)
+    assert db.exists()
+    ledger.close()
+
+
+def test_sqlite_upsert_and_load_roundtrip(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    order = _make_order(venue_order_id="v-1")
+    order.filled_quantity = 0.05
+    order.error = None
+    ledger.upsert_order(order)
+
+    loaded = ledger.load_orders()
+    assert len(loaded) == 1
+    o = loaded[0]
+    assert o.client_order_id == order.client_order_id
+    assert o.idempotency_key == order.idempotency_key
+    assert o.symbol == "BTC/USDT"
+    assert o.side == "buy"
+    assert o.order_type == "limit"
+    assert o.quantity == 0.1
+    assert o.price == 50_000.0
+    assert o.state == OrderState.CREATED
+    assert o.venue_order_id == "v-1"
+    assert o.filled_quantity == 0.05
+    assert o.created_at == 1_000_000
+    assert o.updated_at == 1_000_000
+    ledger.close()
+
+
+def test_sqlite_upsert_overwrites_state(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    order = _make_order(state=OrderState.CREATED)
+    ledger.upsert_order(order)
+    order._transition(OrderState.ACCEPTED)
+    ledger.upsert_order(order)
+    loaded = ledger.load_orders()
+    assert loaded[0].state == OrderState.ACCEPTED
+    ledger.close()
+
+
+def test_sqlite_all_order_states_roundtrip(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    for i, state in enumerate(OrderState):
+        order = _make_order(
+            client_order_id=f"coid-{i}",
+            idempotency_key=f"idem-{i}",
+            state=state,
+        )
+        ledger.upsert_order(order)
+    loaded = {o.client_order_id: o for o in ledger.load_orders()}
+    for i, state in enumerate(OrderState):
+        assert loaded[f"coid-{i}"].state == state
+    ledger.close()
+
+
+def test_sqlite_list_open_orders_excludes_terminal(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    terminal_states = {
+        OrderState.FILLED,
+        OrderState.CANCELLED,
+        OrderState.REJECTED,
+        OrderState.EXPIRED,
+        OrderState.FAILED,
+    }
+    for i, state in enumerate(OrderState):
+        ledger.upsert_order(
+            _make_order(client_order_id=f"coid-{i}", idempotency_key=f"idem-{i}", state=state)
+        )
+    open_orders = ledger.list_open_orders()
+    open_states = {o.state for o in open_orders}
+    assert open_states.isdisjoint(terminal_states)
+    assert open_states == set(_OPEN_STATES)
+    ledger.close()
+
+
+def test_sqlite_get_by_client_id(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    ledger.upsert_order(_make_order(client_order_id="target"))
+    result = ledger.get_order_by_client_id("target")
+    assert result is not None
+    assert result.client_order_id == "target"
+    assert ledger.get_order_by_client_id("missing") is None
+    ledger.close()
+
+
+def test_sqlite_get_by_idempotency_key(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    ledger.upsert_order(_make_order(idempotency_key="idem-unique"))
+    result = ledger.get_order_by_idempotency_key("idem-unique")
+    assert result is not None
+    assert result.idempotency_key == "idem-unique"
+    assert ledger.get_order_by_idempotency_key("missing") is None
+    ledger.close()
+
+
+def test_sqlite_multiple_orders(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    for i in range(5):
+        ledger.upsert_order(_make_order(client_order_id=f"c{i}", idempotency_key=f"k{i}"))
+    assert len(ledger.load_orders()) == 5
+    ledger.close()
+
+
+def test_sqlite_append_and_list_events(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    ledger.append_event("coid-1", "order_created")
+    ledger.append_event("coid-1", "order_submitted", {"nonce": "abc"})
+    events = ledger.list_events("coid-1")
+    assert len(events) == 2
+    assert events[0]["event_type"] == "order_created"
+    assert events[0]["payload"] == {}
+    assert events[1]["event_type"] == "order_submitted"
+    assert events[1]["payload"] == {"nonce": "abc"}
+    assert events[0]["id"] < events[1]["id"]  # ordered by insertion
+    ledger.close()
+
+
+def test_sqlite_events_isolated_per_order(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    ledger.append_event("coid-A", "order_created")
+    ledger.append_event("coid-B", "order_created")
+    ledger.append_event("coid-A", "order_submitted")
+    assert len(ledger.list_events("coid-A")) == 2
+    assert len(ledger.list_events("coid-B")) == 1
+    assert ledger.list_events("coid-X") == []
+    ledger.close()
+
+
+def test_sqlite_satisfies_protocol(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    ledger = SqliteLedger(db)
+    assert isinstance(ledger, OmsLedger)
+    ledger.close()
+
+
+# ---------------------------------------------------------------------------
+# Oms + ledger integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_oms_with_ledger_persists_submitted_order(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter, ledger=SqliteLedger(db))
+    order = oms.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+    )
+    # Must be in the DB
+    ledger = SqliteLedger(db)
+    persisted = ledger.get_order_by_client_id(order.client_order_id)
+    assert persisted is not None
+    assert persisted.state == OrderState.ACCEPTED
+    ledger.close()
+
+
+def test_oms_survives_restart_with_sqlite_ledger(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    adapter = _AcceptingAdapter()
+
+    oms1 = Oms(adapter=adapter, ledger=SqliteLedger(db))
+    order = oms1.submit_order(
+        symbol="ETH/USDT",
+        side="sell",
+        order_type="market",
+        quantity=1.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+    )
+    coid = order.client_order_id
+
+    # Simulate restart: new Oms with same DB
+    oms2 = Oms(adapter=_AcceptingAdapter(), ledger=SqliteLedger(db))
+    reloaded = oms2.get_order(client_order_id=coid)
+    assert reloaded is not None
+    assert reloaded.state == OrderState.ACCEPTED
+    assert reloaded.client_order_id == coid
+
+
+def test_oms_idempotency_survives_restart(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    adapter1 = _AcceptingAdapter()
+
+    oms1 = Oms(adapter=adapter1, ledger=SqliteLedger(db))
+    order = oms1.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+        idempotency_key="idem-restart-test",
+    )
+    assert adapter1.call_count == 1
+
+    # Restart: second Oms with same DB and same idempotency_key
+    adapter2 = _AcceptingAdapter()
+    oms2 = Oms(adapter=adapter2, ledger=SqliteLedger(db))
+    duplicate = oms2.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+        idempotency_key="idem-restart-test",
+    )
+    assert adapter2.call_count == 0  # deduped by reloaded idem index
+    assert duplicate.client_order_id == order.client_order_id
+
+
+def test_oms_open_orders_survive_restart(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    adapter = _AcceptingAdapter()
+
+    oms1 = Oms(adapter=adapter, ledger=SqliteLedger(db))
+    oms1.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+    )
+    oms1.submit_order(
+        symbol="ETH/USDT",
+        side="sell",
+        order_type="market",
+        quantity=1.0,
+        strategy="s",
+        run_id="r",
+        nonce="n2",
+    )
+
+    ledger2 = SqliteLedger(db)
+    open_orders = ledger2.list_open_orders()
+    assert len(open_orders) == 2
+    ledger2.close()
+
+
+def test_oms_terminal_orders_not_returned_as_open(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter, ledger=SqliteLedger(db))
+
+    order = oms.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+    )
+    # Cancel the accepted order (it has a venue_order_id now)
+    oms.cancel_order(client_order_id=order.client_order_id)
+
+    ledger = SqliteLedger(db)
+    open_orders = ledger.list_open_orders()
+    assert not any(o.client_order_id == order.client_order_id for o in open_orders)
+    ledger.close()
+
+
+def test_oms_events_emitted_on_submit(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter, ledger=SqliteLedger(db))
+
+    order = oms.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+    )
+    ledger = SqliteLedger(db)
+    events = ledger.list_events(order.client_order_id)
+    event_types = [e["event_type"] for e in events]
+    assert "order_created" in event_types
+    assert "order_submitted" in event_types
+    assert "order_accepted" in event_types
+    ledger.close()
+
+
+def test_oms_events_emitted_on_dry_run_submit(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter, dry_run=True, ledger=SqliteLedger(db))
+
+    order = oms.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+    )
+    ledger = SqliteLedger(db)
+    events = ledger.list_events(order.client_order_id)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "order_created"
+    assert events[0]["payload"].get("dry_run") is True
+    ledger.close()
+
+
+def test_oms_events_emitted_on_cancel(tmp_path: Path):
+    db = tmp_path / "oms.db"
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter, ledger=SqliteLedger(db))
+
+    order = oms.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+    )
+    oms.cancel_order(client_order_id=order.client_order_id)
+
+    ledger = SqliteLedger(db)
+    event_types = [e["event_type"] for e in ledger.list_events(order.client_order_id)]
+    assert "order_cancelled" in event_types
+    ledger.close()
+
+
+def test_oms_without_ledger_behaviour_unchanged():
+    """Oms(adapter=...) with no ledger must behave exactly as before this PR."""
+    adapter = _AcceptingAdapter()
+    oms = Oms(adapter=adapter)
+    order = oms.submit_order(
+        symbol="BTC/USDT",
+        side="buy",
+        order_type="limit",
+        quantity=0.1,
+        price=50_000.0,
+        strategy="s",
+        run_id="r",
+        nonce="n1",
+    )
+    assert order.state == OrderState.ACCEPTED
+    assert adapter.call_count == 1
+    assert oms.get_order(client_order_id=order.client_order_id) is order
+
+
+# ---------------------------------------------------------------------------
+# OmsConfig / load_oms_config tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_oms_config_default_is_in_memory(monkeypatch):
+    monkeypatch.delenv(OMS_LEDGER_ENV, raising=False)
+    cfg = load_oms_config()
+    assert cfg.ledger_type == "in_memory"
+    assert cfg.sqlite_path is None
+
+
+def test_load_oms_config_sqlite_uses_default_path(monkeypatch):
+    monkeypatch.setenv(OMS_LEDGER_ENV, "sqlite")
+    monkeypatch.delenv(OMS_SQLITE_PATH_ENV, raising=False)
+    cfg = load_oms_config()
+    assert cfg.ledger_type == "sqlite"
+    assert cfg.sqlite_path is not None
+    assert str(cfg.sqlite_path) == ".runs/oms/orders.sqlite"
+
+
+def test_load_oms_config_sqlite_custom_path(monkeypatch, tmp_path: Path):
+    custom = str(tmp_path / "custom.db")
+    monkeypatch.setenv(OMS_LEDGER_ENV, "sqlite")
+    monkeypatch.setenv(OMS_SQLITE_PATH_ENV, custom)
+    cfg = load_oms_config()
+    assert cfg.sqlite_path == Path(custom)
+
+
+def test_load_oms_config_invalid_raises(monkeypatch):
+    monkeypatch.setenv(OMS_LEDGER_ENV, "redis")
+    with pytest.raises(ValueError, match="not supported"):
+        load_oms_config()
+
+
+def test_load_oms_config_case_insensitive(monkeypatch):
+    monkeypatch.setenv(OMS_LEDGER_ENV, "SQLITE")
+    cfg = load_oms_config()
+    assert cfg.ledger_type == "sqlite"
+
+
+def test_no_sqlite_file_created_with_default_config(tmp_path: Path, monkeypatch):
+    """Default in_memory config must never create any SQLite file."""
+    monkeypatch.delenv(OMS_LEDGER_ENV, raising=False)
+    cfg = load_oms_config()
+    assert cfg.ledger_type == "in_memory"
+    assert cfg.sqlite_path is None
+    # No db file should exist anywhere under tmp_path (nothing was created)
+    assert list(tmp_path.glob("**/*.sqlite")) == []
+    assert list(tmp_path.glob("**/*.db")) == []
+
+
+# ---------------------------------------------------------------------------
+# Factory integration: get_nexus_adapter ledger injection
+# ---------------------------------------------------------------------------
+
+
+def test_get_nexus_adapter_oms_paper_default_no_ledger_file(monkeypatch, tmp_path: Path):
+    """OMS + paper + default (in_memory) config must not create any SQLite file."""
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "oms")
+    monkeypatch.delenv("EXCHANGE", raising=False)
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    monkeypatch.delenv(OMS_LEDGER_ENV, raising=False)
+    set_nexus_adapter(None)
+    try:
+        adapter = get_nexus_adapter()
+        assert isinstance(adapter, OmsNexusAdapter)
+        # In-memory by default — no DB files should appear
+        assert list(tmp_path.glob("**/*.sqlite")) == []
+    finally:
+        set_nexus_adapter(None)
+
+
+def test_get_nexus_adapter_oms_sqlite_injects_ledger(monkeypatch, tmp_path: Path):
+    """OMS + paper + sqlite config must create and inject a SqliteLedger."""
+    db = tmp_path / "test_oms.sqlite"
+    monkeypatch.setenv(EXECUTION_ENGINE_ENV, "oms")
+    monkeypatch.delenv("EXCHANGE", raising=False)
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    monkeypatch.setenv(OMS_LEDGER_ENV, "sqlite")
+    monkeypatch.setenv(OMS_SQLITE_PATH_ENV, str(db))
+    set_nexus_adapter(None)
+    try:
+        adapter = get_nexus_adapter()
+        assert isinstance(adapter, OmsNexusAdapter)
+        # Place an order — should be written to the SQLite file
+        result = adapter.place_smart_order(
+            symbol="BTC/USDT", side="buy", qty=0.01, order_type="limit", price=50_000.0
+        )
+        assert result["status"] in ("accepted", "created")
+        # DB file should now exist
+        assert db.exists()
+    finally:
+        set_nexus_adapter(None)
+
+
+def test_get_nexus_adapter_legacy_path_unchanged(monkeypatch):
+    """Legacy path must never construct a ledger regardless of OMS_LEDGER env."""
+    from adapters.nexus_adapter import NexusAdapter  # noqa: PLC0415
+
+    monkeypatch.delenv(EXECUTION_ENGINE_ENV, raising=False)
+    monkeypatch.setenv(OMS_LEDGER_ENV, "sqlite")  # should be ignored on legacy path
+    monkeypatch.delenv("AI_MARKET_MAKER_ALLOW_LIVE", raising=False)
+    set_nexus_adapter(None)
+    try:
+        adapter = get_nexus_adapter()
+        assert isinstance(adapter, NexusAdapter)  # legacy, not OmsNexusAdapter
+    finally:
+        set_nexus_adapter(None)


### PR DESCRIPTION
## Summary

Adds an opt-in persistent OMS order ledger so order state, idempotency keys, venue order IDs, and state-transition events survive process restarts.

Default behaviour is unchanged — `Oms()` with no ledger argument remains purely in-memory.

## Changes

- Added `src/oms/ledger.py` with `OmsLedger` Protocol, `InMemoryLedger`, and `SqliteLedger`
- Added SQLite-backed `oms_orders` snapshot table and `oms_order_events` append-only event table
- Added `src/config/oms_config.py` for `AI_MARKET_MAKER_OMS_LEDGER` and `AI_MARKET_MAKER_OMS_SQLITE_PATH`
- Updated `Oms` to accept an optional ledger, replay persisted state on init, and record state-transition events
- Updated `get_nexus_adapter()` so `SqliteLedger` is injected only when explicitly configured
- Updated `.env.example` and `docs/run-modes.md`
- Added restart-safe idempotency tests using `tmp_path`

## Safety

- No live exchange calls
- No SDK changes
- HyperliquidAdapter untouched
- No secrets stored in the ledger
- SQLite file is created only when explicitly configured
- Default config produces zero filesystem side effects
- Invalid OMS ledger config raises `ValueError` at startup

## Test Plan

- `uv run pytest tests -q` — 213 passed
- `uv run pre-commit run --all-files` — passed clean
- Existing `test_oms.py` unchanged and passing
- Restart-safe idempotency verified with SQLite temp database

## Note

This PR builds on the merged OMS execution foundation by adding persistence only. It does not implement real live exchange execution or Hyperliquid SDK order placement.