### PR TITLE
feat: Add weighted arbitrator, profile agent, agent scaffoldin

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,111 +1,157 @@
-## Configuration
+# Configuration & Environment
 
-Default settings live in versioned JSON files under the `config/` folder.
+## Philosophy
 
-Use `.env` **only** for secrets, API endpoints, and run mode. Strategy and policy values should stay in git.
-`.env` is loaded for local development defaults only; if a variable is already set in your environment, it takes precedence.
+AIMM is designed to run **with an LLM token** — no LLM-less fallback paths.
+This eliminates the `AI_MARKET_MAKER_USE_LLM` toggle. If you have an
+`OPENAI_API_KEY` (or compatible endpoint), the system runs at full capability.
 
-### Why config-first + env override is good practice
+Three configuration layers:
 
-This repo uses a **config-first** approach for non-secret defaults (checked into git), with **environment variables**
-as *optional overrides*.
-
-- **Reproducibility**: a tagged commit + `config/*.json` fully describes default behavior.
-- **Reviewability**: behavior changes show up in diffs/PR review instead of being hidden in shell history.
-- **Deployment friendliness**: env overrides remain available for containerized deployments and emergency toggles.
-- **Secret hygiene**: `.env` stays focused on secrets/endpoints rather than “random tuning knobs.”
-
-### Run artifacts (`.runs/`) retention
-
-Runs and backtests write artifacts under `.runs/`. To prevent multi-GB accumulation, the project enforces a
-simple retention policy after each run:
-
-- **`runs.max_total_mb`**: cap total disk usage under `.runs/` (default: `500`)
-- **`runs.keep_last`**: keep at least this many newest artifacts (default: `200`)
-- **`runs.index.max_mb`**: cap `.runs/index.jsonl` size (default: `25`)
-- **`runs.index.keep_last`**: keep last N index rows (default: `20000`)
-
-Optional env overrides (emergency / one-off):
-
-- `AIMM_RUNS_MAX_TOTAL_MB`
-- `AIMM_RUNS_KEEP_LAST`
-- `AIMM_RUNS_BACKTESTS_MAX_TOTAL_MB`
-- `AIMM_RUNS_BACKTESTS_KEEP_LAST`
-
-Backtests retention is **disabled by default** to avoid surprising deletions. Enable it in `config/app.default.json`:
-
-- `runs.backtests.retention_enabled: true`
-
-### Evaluation export (benchmarking)
-
-To compare runs in a spreadsheet or against other projects, export the compact ledger plus backtest summaries:
-
-```bash
-uv run python -m eval_export --runs-dir .runs -o exports/evaluation --format csv
-uv run aimm-export-eval -o exports/evaluation.csv
+```
+.env                        → env vars (secrets, overrides)
+config/app.default.json     → app defaults (tuning params, presets)
+config/policy.default.json  → trading policy (risk, sizing, rules)
 ```
 
-Parquet output needs the optional extra: `uv sync --extra export` (installs `pyarrow`). The combined table uses `record_kind` to distinguish `index` rows (from `.runs/index.jsonl`) from `backtest` rows (from `.runs/backtests/<id>/summary.json`).
+---
 
-### Flow logging detail
+## Required Environment Variables
 
-To keep `.runs/*.events.jsonl` useful but not bloated, flow reasoning events can be compacted:
+| Variable            | Purpose                                       |
+|---------------------|-----------------------------------------------|
+| `OPENAI_API_KEY`    | LLM provider key (OpenAI / compatible)        |
+| `BINANCE_API_KEY`   | Binance API key for market data               |
+| `BINANCE_API_SECRET`| Binance API secret                            |
+| `NEXUS_API_KEY`     | Olaxbt Nexus data API key                     |
 
-- `flow.detail: full | standard | compact` (default: `standard`)
-  - `full`: include tool results and larger blobs (best for deep debugging; biggest logs)
-  - `standard`: omit large tool result payloads but keep tool call metadata
-  - `compact`: keep only the high-signal decision fields; drop bulky context
+> **No LLM key → the process exits with a clear error.** No fallback, no silent
+> degradation. This is intentional — the system is an LLM-native architecture.
 
-### Paper trading and backtest: spot vs mock perp (leverage)
+---
 
-Paper mode and multi-step backtests can simulate **spot** (full-cash) or a **USDT-linear perp-style** account with **initial margin ≈ notional / leverage**. This is a research mock (no funding, liquidation engine, or venue queue semantics); it exists so results are comparable when others run the same config.
+## Optional Environment Variables
 
-- **`paper.instrument`**: `"spot"` (default) or `"perp"`.
-- **`paper.leverage`**: used when `instrument` is `"perp"` (clamped against `fund_policy.max_leverage` where applicable).
+### Arbitrator Mode
 
-For CLI backtests, `src/backtest/run_demo.py` accepts **`--instrument spot|perp`** and **`--leverage`** (defaults follow `config/app.default.json` / `load_app_settings().paper` when omitted).
+| Variable              | Values                                     | Default                |
+|-----------------------|--------------------------------------------|------------------------|
+| `AIMM_ARBITRATOR_MODE`| `weighted_convergence` / `llm` / `legacy`  | `weighted_convergence` |
 
-### Quick Start
+- **weighted_convergence** (default): deterministic factor-weighted engine, no LLM cost
+- **llm**: LLM-based synthesis (uses OPENAI_API_KEY)
+- **legacy**: original Tier-0 consensus voting
 
-```bash
-uv run python -u src/main.py --ticker BTC/USDT
+### Agent Toggles
+
+| Variable                         | Effect                                  |
+|----------------------------------|-----------------------------------------|
+| `AIMM_ORCHESTRATOR_DISABLE`      | Skip policy orchestrator node           |
+| `AIMM_TA_TIER0_DISABLE`          | Disable technical TA agent              |
+| `AIMM_RISK_GUARD_KILL_SWITCH`    | Emergency stop — blocks all trades      |
+
+
+Each agent derives its enabled/disabled state from:
+1. Hardcoded default (e.g., Whale 4.1 is disabled by default)
+2. Environment variable override
+3. Orchestrator policy override (when orchestrator is active)
+
+### Debug & Observability
+
+| Variable                  | Purpose                                      |
+|---------------------------|----------------------------------------------|
+| `AIMM_DEBUG_RISK`         | Verbose risk calculation logs                |
+| `AIMM_FLOW_INCLUDE_FULL_DEBATE` | Include full debate transcript in output |
+| `AIMM_LLM_DESK_DEBATE`    | Enable LLM desk debate (costly)              |
+| `STRATEGY_INTERVAL_SEC`   | Graph run interval (default: 180)            |
+
+### Execution
+
+| Variable                          | Values                  | Default |
+|-----------------------------------|-------------------------|---------|
+| `AI_MARKET_MAKER_ALLOW_LIVE`      | 0 / 1                   | 0       |
+| `AI_MARKET_MAKER_EXECUTION_ENGINE`| `legacy` / `oms`        | `legacy`|
+| `MODE`                            | `paper` / `live` / `backtest` | `paper` |
+
+---
+
+
+
+## Opt-In / Opt-Out Architecture
+
+The system is designed as a **modular pipeline** where each component can be
+individually enabled or disabled:
+
+```
+policy_orchestrator ── [AIMM_ORCHESTRATOR_DISABLE]
+        │
+desk_market_scan ── [always on]
+        │
+├─ monetary_sentinel ── [config weight=0 → skip]
+├─ news_narrative_miner ── [config weight=0 → skip]
+├─ pattern_recognition_bot ── [config weight=0 → skip]
+├─ statistical_alpha_engine ── [config weight=0 → skip]
+├─ technical_ta_engine ── [AIMM_TA_TIER0_DISABLE or weight=0]
+├─ retail_hype_tracker ── [config weight=0 → skip]
+├─ pro_bias_analyst ── [config weight=0 → skip]
+├─ whale_behavior_analyst ── [disabled by default in weight config]
+├─ liquidity_order_flow ── [config weight=0 → skip]
+        │
+desk_risk ── [always on]
+desk_debate ── [always on, LLM part guarded by AIMM_LLM_DESK_DEBATE]
+signal_arbitrator ── [AIMM_ARBITRATOR_MODE selects engine]
+portfolio_proposal ── [always on]
+desk_risk_guard ── [AIMM_RISK_GUARD_KILL_SWITCH]
+portfolio_execute ── [MODE controls real vs paper]
+audit ── [always on]
 ```
 
-### Agent prompt configuration (optional)
+### Enabling/disabling agents via weight config
 
-Some LLM nodes support operator-configurable prompt settings via `config/agent_prompts` (see code: `config/agent_prompts.py`).
-This is useful when you want to tweak tone/verbosity/tools without editing the graph logic.
+Setting an agent's weight to `0.0` effectively disables it. The remaining enabled
+weights are re-normalized automatically:
 
-### LLM mode (agentic nodes)
+```python
+weights = {"2.1": 0.25, "2.3": 0.30, "4.2": 0.15}  # others set to 0
+# Normalized internally: 0.25 + 0.30 + 0.15 = 0.70 ≠ 1.0
+# Each weight scaled by 1/0.70: 0.357 + 0.429 + 0.214 = 1.0
+```
 
-LLM-driven nodes (like the Tier-2 `signal_arbitrator`) are enabled automatically when `OPENAI_API_KEY` is set,
-or explicitly when `AIMM_LLM_MODE=1`.
+This is useful for:
+- **Minimal mode** (Pattern + TA + Liquidity only → 70% of original voting power)
+- **Testing** (single agent active → verify its factor extraction)
+- **Abnormal regimes** (disable retail hype during high-vol, etc.)
 
-#### Structured output enforcement (recommended)
+---
 
-To keep trading signals reliable, the `signal_arbitrator` uses **schema-constrained prompting** plus a
-**validate + retry** loop. This prevents malformed JSON from silently degrading into default `HOLD`.
+## Layer-Specific Env Design
 
-Defaults live in `config/app.default.json` under `llm`, and can be overridden via environment variables.
+### Layer 0 — Data Sources (none required, but recommended)
+```
+BINANCE_API_KEY / SECRET   ← OHLCV data
+NEXUS_API_KEY              ← Nexus/Olaxbt data (news, KOL, OI, funding)
+TWITTER_BEARER_TOKEN        ← Social sentiment (optional, experimental)
+```
 
-Environment variables (optional overrides):
+### Layer 1 — Agents (optional toggles)
+```
+AIMM_TA_TIER0_DISABLE      ← Technical TA
+```
 
-- **`AIMM_LLM_OUTPUT_RETRIES`**: Number of retries when the model output fails validation (default: `2`, max: `5`)
-- **`AIMM_LLM_STRICT_JSON`**: If `1`, append strict “JSON only” requirements to the arbitrator prompt (default: `1`)
+### Layer 2 — Arbitrator
+```
+AIMM_ARBITRATOR_MODE       ← Engine selection
+```
 
-The run payload includes:
+### Layer 3 — Execution
+```
+MODE                       ← paper / live / backtest
+AI_MARKET_MAKER_ALLOW_LIVE ← double-gate for live
+```
 
-- `proposed_signal.params.llm_attempts`
-- `proposed_signal.params.llm_retry_reasons`
-- `proposed_signal.params.llm_json_parse_ok`
-- `proposed_signal.params.llm_validation_warnings`
+### Layer 4 — Safety
+```
+AIMM_RISK_GUARD_KILL_SWITCH ← emergency stop
+```
 
-The portfolio LLM proposal also records:
 
-- `proposal.llm_attempts`
-- `proposal.llm_retry_reasons`
-
-The portfolio LLM execution plan also records:
-
-- `execution.llm_attempts`
-- `execution.llm_retry_reasons`

--- a/docs/personas/01_policy_orchestrator.md
+++ b/docs/personas/01_policy_orchestrator.md
@@ -1,20 +1,55 @@
-# Persona: Policy Orchestrator (Supervisor / 策略編排器)
+# Persona: Policy Orchestrator (Supervisor / 策略编排器)
 
 ## Position
-Governance layer — sits at the graph entry point.
+Supervisor layer that selects policy config/presets and initializes shared memory (paper account snapshot) for each run. The first node executed in the graph.
+
+## Agent Classification
+- **Agent ID**: N/A (Governance)
+- **Type**: Governance/Supervisor
+- **Code Class**: `PolicyOrchestratorAgent` (`src/agents/governance/policy_orchestrator.py`)
+- **Enabled by default**: Yes
 
 ## Goals
-- Read persistent memory (events.jsonl) from prior runs.
-- Select the right policy config/preset for the current trading cycle.
-- Apply decision to environment variables so downstream desks pick it up.
+- Select and apply the correct policy configuration for the current run mode (paper/backtest/live)
+- Read persistent policy memory (JSONL) and record decisions
+- Initialize paper account snapshot with cash, positions, and entry averages for downstream nodes
+- Disable via env `AIMM_ORCHESTRATOR_DISABLE=1`
 
 ## SOP
-1. **Input**: Empty state (or kill-switch check).
-2. **Process**: Read recent events from `PolicyMemoryStore` → call `decide_policy_from_memory()` → select `config_path` + `policy_preset` + `desk_strategy_preset`.
-3. **Output**: `policy_decision` dict (applied to env vars).
-4. **Feedback**: Write decision back to `events.jsonl` for future cycles.
+1. **Input**: `run_mode`, `ticker`, `shared_memory` from state
+2. **Process**:
+   - `PolicyOrchestratorAgent.process()` reads policy memory store and selects config/preset for this run
+   - If paper mode: fetches portfolio health from Nexus adapter (`get_portfolio_health`) and fills `shared_memory["paper"]` with `cash_usdt`, `instrument`, `positions` map, and `updated_ts`
+3. **Output**:
+   - `policy_decision` — the selected policy preset/config
+   - `shared_memory["paper"]` — initialized paper account snapshot (paper mode only)
+4. **Telemetry**: FlowEvent reasoning entries for policy decision
+
+## Data Contract
+```python
+{
+    "policy_decision": {
+        # Selected policy preset/config dict
+    },
+    "shared_memory": {
+        "paper": {  # paper mode only
+            "cash_usdt": float,
+            "instrument": str,   # e.g. "spot", "perp"
+            "positions": {       # symbol → position detail
+                "BTC/USDT": {
+                    "qty_signed": float,
+                    "avg_entry": float,
+                    "margin_locked_usdt": float
+                }
+            },
+            "updated_ts": int
+        }
+    }
+}
+```
 
 ## Rules / Constraints
-- Can be disabled entirely via `AIMM_ORCHESTRATOR_DISABLE`.
-- Does NOT route messages, fan-out to desks, or gate execution.
-- Pure config/preset selection — no trading decisions.
+- Must execute before `market_scan`
+- Paper account snapshot is loaded once at orchestration — downstream nodes read from `shared_memory`
+- Skippable via `AIMM_ORCHESTRATOR_DISABLE=1` env var
+- No direct market data access — pure governance layer

--- a/docs/personas/02_market_scan.md
+++ b/docs/personas/02_market_scan.md
@@ -1,20 +1,64 @@
-# Persona: Market Scan (Alpha Desk — Momentum / 市場掃描者)
+# Persona: Market Scan (Data Aggregation / 市场扫描器)
 
 ## Position
-Alpha-generation desk. First active research layer using ccxt + CoinGecko.
+Data aggregation node that fetches and hydrates market data for the primary ticker and universe symbols. Determines universe composition and runs initial market context for Tier-0 agents.
+
+## Agent Classification
+- **Agent ID**: N/A (Data)
+- **Type**: Data Aggregation
+- **Code Class**: `MarketScanAgent` + `market_scan` node function (`src/main.py`)
+- **Enabled by default**: Yes
 
 ## Goals
-- Fetch exchange market data (Binance by default) via CCXT.
-- Scan new listings, delisting risks, and volume/market-cap anomalies.
-- Produce a ranked watchlist for downstream desks.
+- Fetch OHLCV + depth data for primary ticker and universe symbols
+- Select and expand the trading universe (env-configured or volume-ranked with OI augmentation)
+- Attach Nexus data bundle (`shared_memory["nexus"]`) when Nexus feeds are enabled
+- Scan meme coin candidates (paper/live only)
 
 ## SOP
-1. **Input**: Exchange credentials, optional testnet flag.
-2. **Process**: Fetch from exchange API → filter candidates → detect anomalies.
-3. **Output**: `Report` (ranked pool) backed by live exchange data.
-4. **Feedback**: None currently (no PID loop — re-fetches each cycle).
+1. **Input**: `ticker`, `run_mode`, `shared_memory` from state; `market.scan.*` app settings
+2. **Process**:
+   - Backtest mode: use provided `market_data`, build universe from configured symbols
+   - Paper/live mode: call `MarketScanAgent.fetch_data()` per symbol, use `select_universe_from_tickers()` with optional OI augmentation, attach Nexus depth and global bundle
+   - Meme coin scan via `MarketScanAgent.scan_meme_coins()` (paper/live only)
+   - Universe pairs computed via combinatorial expansion for correlation analysis
+3. **Output**:
+   - `market_data` — enriched `{symbol: {ohlcv, nexus_depth, ...}}` dict
+   - `universe` — ordered symbol list
+   - `universe_pairs` — correlation pairs
+   - `market_scan` — meme coin candidates
+   - `shared_memory["nexus"]` — Nexus global bundle (when available)
+4. **Telemetry**: FlowEvent node_start/node_end; reasoning entry with scan decision
+
+## Data Contract
+```python
+{
+    "ticker": str,
+    "universe": [str, ...],       # ordered list of symbols
+    "universe_pairs": [[str, str], ...],
+    "market_data": {
+        "BTC/USDT": {
+            "ohlcv": [[ts, o, h, l, c, v], ...],
+            "nexus_depth": { ... },
+            "status": "success" | "error",
+            ...
+        },
+        ...
+    },
+    "market_scan": [  # meme candidates (paper/live)
+        {"symbol": str, ...},
+        ...
+    ],
+    "shared_memory": {
+        "nexus": { ... }  # when nexus_feeds_enabled()
+    }
+}
+```
 
 ## Rules / Constraints
-- Report-only — no execution.
-- Rate-limit aware (CCXT handles this internally with `enableRateLimit: True`).
-- Requires `BINANCE_API_KEY` and `BINANCE_API_SECRET` env vars.
+- Universe size controlled by `app_settings.market.universe_size` (default ~30)
+- Universe symbols configurable via `app_settings.market.universe_symbols`
+- Always includes primary ticker first in universe list
+- Backtest mode is deterministic and offline-friendly
+- Nexus depth fetched per symbol (5 levels, via `get_nexus_adapter()`)
+- Meme scan limited to top 2 candidates

--- a/docs/personas/03_monetary_sentinel.md
+++ b/docs/personas/03_monetary_sentinel.md
@@ -1,20 +1,52 @@
-# Persona: Monetary Sentinel (Alpha Desk — Macro / 貨幣哨兵)
-
-> Internal role: `macro_economist`
+# Persona: Monetary Sentinel — Agent 1.1 (Macro Economist / 宏观经济学家)
 
 ## Position
-Alpha-generation desk — macro context layer (Tier-0 AIMM8).
+Tier-0 perception agent that computes macro liquidity regime and systemic beta score for each symbol. Assesses whether market conditions favor risk-on (expansionary liquidity) or risk-off (contractionary) positioning.
+
+## Agent Classification
+- **Agent ID**: 1.1
+- **Type**: `monetary_sentinel`
+- **Code Class**: `MonetarySentinelAgent` (`src/agents/monetary_sentinel.py`)
+- **Enabled by default**: Yes (weight: 0.05)
 
 ## Goals
-- Parse Nexus data bundle for macro and OHLCV context.
-- Detect macro regime shifts from liquidity and market structure.
+- Determine the liquidity regime (risk_on / neutral / risk_off) from market data and optional Nexus context
+- Compute a systemic beta score [0–100] indicating macro tail risk
+- Provide the weighted arbitrator with macro regime context for all downstream factors
 
 ## SOP
-1. **Input**: Nexus context bundle (market_data, endpoints), ticker.
-2. **Process**: Extract OHLCV length + market metrics from Nexus payload → classify regime.
-3. **Output**: Dict with status, macro context, and any flagged shifts.
-4. **Feedback**: None — stateless per-cycle function.
+1. **Input**: `ticker`, `universe`, `market_data`, optional `nexus_context` from shared memory
+2. **Process**:
+   - `MonetarySentinelAgent.analyze()` evaluates OHLCV liquidity proxies (volume depth, spread stability) and Nexus macro endpoints
+   - Returns `liquidity_regime` (str) and `systemic_beta_score` (float, 0–100)
+3. **Output**:
+   - `monetary_sentinel["primary"]` — analysis dict for primary ticker
+   - `monetary_sentinel["by_symbol"]` — per-symbol analysis dict
+   - `tier0_contracts` — one entry for agent 1.1 via `build_tier0_contract_json()`
+4. **Telemetry**: FlowEvent reasoning entry with analysis decision
+
+## Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "1.1",
+    "ticker": str,
+    "status": "success" | "error",
+    "macro_regime_state": 0 | 1 | 2,   # risk_off=0, neutral=1, risk_on=2
+    "regime_prob": float,               # [0.01, 0.99] scaled from score
+    "Liquidity_Score": int              # [0, 100] rounded systemic beta
+}
+```
+
+## Factor Map
+Agent 1.1 has no configured factors in `AGENT_FACTOR_MAP`. The weight assigner uses a 60/40 blend of regime state and liquidity score as a `macro_bias` factor.
+
+| Factor | Source Field | Normalization |
+|--------|-------------|---------------|
+| `macro_bias` (implicit) | `macro_regime_state` (60%), `Liquidity_Score` (40%) | Linear map 0→0, 2→1 for regime; 0→0, 100→1 for score |
 
 ## Rules / Constraints
-- Pure data extraction from Nexus bundle — no external API calls.
-- Output consumed by downstream synthesis (Signal Arbitrator).
+- Weight 0.05 — low conviction, acts as context/mood rather than strong signal
+- Always enabled — macro regime is a background check for all strategies
+- Falls back to neutral/score=50 when Nexus data unavailable
+- `regime_prob` clamped to [0.01, 0.99]

--- a/docs/personas/04_news_narrative_miner.md
+++ b/docs/personas/04_news_narrative_miner.md
@@ -1,20 +1,61 @@
-# Persona: News Narrative Miner (Alpha Desk — Media / 新聞敘事礦工)
-
-> Internal role: `event_driven_analyst`
+# Persona: News & Narrative Miner — Agent 1.2 (新闻叙事挖掘者)
 
 ## Position
-Alpha-generation desk — news & event-driven analysis (Tier-0 AIMM8).
+Tier-0 perception agent that evaluates event-driven impact and narrative freshness. Scores headline risk on a breaker scale and classifies event type (Routine → Black Swan) to measure narrative-driven market shocks.
+
+## Agent Classification
+- **Agent ID**: 1.2
+- **Type**: `news_narrative_miner`
+- **Code Class**: `NewsNarrativeMinerAgent` (`src/agents/news_narrative_miner.py`)
+- **Enabled by default**: Yes (weight: 0.05)
 
 ## Goals
-- Fetch and score news items from Nexus data bundle.
-- Flag breaking narratives, FUD, and regulatory events.
+- Compute a breaker score [0–100] measuring news impact magnitude
+- Classify the event type into severity buckets (Routine / Elevated / Major Catalyst / Black Swan)
+- Track narrative freshness/decay to avoid stale catalyst pricing
 
 ## SOP
-1. **Input**: Nexus context bundle (lenpoint: `news`), ticker.
-2. **Process**: Extract news items from `nexus_context.endpoints.news` → score relevance & sentiment.
-3. **Output**: Dict with `status`, `items` (parsed news), `headline_summary`.
-4. **Feedback**: None — stateless per-cycle.
+1. **Input**: `ticker`, `universe`, `market_data`, optional `nexus_context` from shared memory
+2. **Process**:
+   - `NewsNarrativeMinerAgent.analyze()` evaluates Nexus news/narrative endpoints and market data for sudden volatility shifts
+   - Returns `breaker_score` (float) and `decay_factor` (float, narrative freshness half-life)
+3. **Output**:
+   - `news_narrative_miner["primary"]` — analysis dict for primary ticker
+   - `news_narrative_miner["by_symbol"]` — per-symbol analysis dict
+   - `tier0_contracts` — one entry for agent 1.2 via `build_tier0_contract_json()`
+4. **Telemetry**: FlowEvent reasoning entry with analysis decision
+
+## Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "1.2",
+    "ticker": str,
+    "status": "success" | "error",
+    "News_Impact_Score": int,         # [0, 100] rounded breaker_score
+    "Event_Type": str,                # "Routine" | "Elevated" | "Major Catalyst" | "Black Swan"
+    "decay_factor": float | None      # narrative freshness decay
+}
+```
+
+Event Type thresholds:
+| Impact Score | Event Type |
+|-------------|------------|
+| < 25 | Routine |
+| 25–44 | Elevated |
+| 45–74 | Major Catalyst |
+| ≥ 75 | Black Swan |
+
+## Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `sentiment_score` | 0.28 | Inverted `News_Impact_Score` | High impact → bearish (low score) |
+| `impact_score` | 0.38 | Inverted `News_Impact_Score` | Same as sentiment_score |
+| `event_type` | 0.19 | `Event_Type` mapping | Routine→0.55, Elevated→0.45, Major→0.35, Black Swan→0.15 |
+| `narrative_freshness` | 0.15 | Default 0.5 | Not in contract fields |
 
 ## Rules / Constraints
-- Reads from Nexus API only — no RSS or external news fetch.
-- Returns empty result if Nexus news endpoint is unavailable.
+- Weight 0.05 — news context is background noise, not a strong signal
+- Inverted impact logic: high news impact = bearish (uncertainty shock)
+- Black Swan events force near-zero bullish factor signal
+- `decay_factor` may be None if narrative freshness not tracked

--- a/docs/personas/05_technical_analysis_desk.md
+++ b/docs/personas/05_technical_analysis_desk.md
@@ -1,23 +1,121 @@
-# Persona: Technical Analysis Desk (Merged n4 + n6 / 技術分析台)
-
-> **Merged from: n4 Pattern Recognition Bot + n6 Technical TA Engine**
-> Internal roles: `geometry_and_signal_technician` + TA-Lib computation
+# Persona: Technical Analysis Agents — 2.1 Pattern Recognition, 2.2 Statistical Alpha, 2.3 Technical TA (技术分析集群)
 
 ## Position
-Alpha-generation desk — comprehensive technical analysis combining Nexus TA endpoints with local TA-Lib computation.
+Tier-0 perception cluster encompassing all chart-based, statistical, and classical technical analysis. Together these three agents carry the highest combined weight (0.65) in the weighted convergence arbitrator, making them the dominant factor cluster.
 
-## Goals
-- Extract chart patterns and support/resistance from Nexus technical analysis data.
-- Compute classical indicators (MACD, RSI, OBV, ATR, Keltner) using TA-Lib.
-- Fuse both sources into one unified technical signal.
+## Agent Classification
 
-## SOP
-1. **Input**: OHLCV multi-bar, Nexus `technical_analysis` endpoint, ticker.
-2. **Process**: Read Nexus TA endpoint for pre-computed patterns → compute TA-Lib indicators locally → cross-validate → require ≥2 confirmations.
-3. **Output**: Dict with `status`, technical pattern scores, indicator values, combined verdict.
-4. **Feedback**: Track pattern completion and indicator precision/recall by market regime.
+| Agent ID | Code ID | Name | Weight | Class |
+|----------|---------|------|--------|-------|
+| 2.1 | pattern_recognition_bot | Pattern Recognition | 0.25 | `PatternRecognitionBotAgent` |
+| 2.2 | statistical_alpha_engine | Statistical Alpha | 0.10 | `StatisticalAlphaEngineAgent` |
+| 2.3 | technical_ta_engine | Technical Analysis | 0.30 | `TechnicalTaEngineAgent` |
+
+---
+
+### Agent 2.1 — Pattern Recognition Bot
+
+**Role**: Chart geometry and setup quality analyzer. Identifies technical patterns (cup-and-handle, bull/bear flags, VCP, accumulation/distribution) and computes setup confidence scores.
+
+#### Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "2.1",
+    "ticker": str,
+    "status": "success" | "error",
+    "Setup_Score": int,               # [0, 100] setup confidence
+    "kalman_support": float | None,   # support level from Kalman filter
+    "pattern": str                    # pattern name (accumulation, vcp, bull_flag, etc.)
+}
+```
+
+#### Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `setup_score` | 0.40 | `Setup_Score` | Linear 0→0, 100→1 |
+| `pattern_quality` | 0.30 | `pattern` field | Pattern quality mapping (VCP→0.75, distribution→0.30) |
+| `timeframe_align` | 0.20 | `kalman_support` presence | 0.55 if support exists, else 0.50 |
+| `volume_conf` | 0.10 | `Setup_Score` proxy | Same linear map |
+
+---
+
+### Agent 2.2 — Statistical Alpha Engine
+
+**Role**: Cross-sectional multi-factor analysis. Computes z-scores and alpha signals (Strong Buy / Buy / Hold / Sell / Strong Sell) relative to the trading universe. Determines factor confluence confidence.
+
+#### Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "2.2",
+    "ticker": str,
+    "status": "success" | "error",
+    "Factor_Confluence": int,         # [0, 95+] confidence from cross-sectional rank
+    "cross_sectional_z_score": float, # [-3.0, 3.0] z-score vs universe
+    "alpha_signal": str               # "Strong Buy" | "Buy" | "Hold" | "Sell" | "Strong Sell"
+}
+```
+
+#### Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `alpha_signal` | 0.50 | `alpha_signal` | Strong Buy→0.85, Hold→0.50, Strong Sell→0.15 |
+| `z_score` | 0.25 | `cross_sectional_z_score` | z=-3→0, z=0→0.5, z=+3→1 |
+| `regime_fit` | 0.25 | Default 0.50 | Not in contract, neutral default |
+
+---
+
+### Agent 2.3 — Technical TA Engine
+
+**Role**: Classical TA-Lib technical analysis bundle. Computes RSI, MACD, OBV, ATR, ADX, EMA cross signals, volume, and pattern recognition from OHLCV data.
+
+#### Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "2.3",
+    "ticker": str,
+    "status": "success" | "error",
+    "ta_indicators": {
+        "rsi": float,          # [0, 100] relative strength index
+        "macd_hist": float,     # MACD histogram value
+        "macd": float,          # MACD line
+        "macd_signal": float,   # MACD signal line
+        "obv": float,           # On-Balance Volume
+        "atr": float,           # Average True Range (% of price)
+        "adx": float,           # Average Directional Index
+        "ema": {"fast": float, "slow": float},
+        "volume": float,        # Current volume
+        "pattern_rec": float    # Pattern recognition score (optional)
+    }
+}
+```
+
+#### Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `rsi` | 0.15 | RSI | Inverted linear: oversold=1, overbought=0 |
+| `macd` | 0.20 | MACD histogram | Positive→bullish, negative→bearish |
+| `obv` | 0.10 | OBV flow | Positive divergence→bullish |
+| `atr` | 0.05 | ATR % | Low=stable(bullish), high=volatile(bearish) |
+| `adx` | 0.15 | ADX | 0→0, 25→0.5, 50→1 trending strength |
+| `ema_cross` | 0.10 | EMA fast/slow cross | Fast>slow→bullish |
+| `volume` | 0.15 | Volume | Linear scale up to 1M |
+| `pattern_rec` | 0.10 | Pattern rec score | Raw pass-through |
+
+## SOP (All Three Agents)
+
+1. **Input**: `ticker`, `universe`, `market_data` (and optional `nexus_context` for 2.1/2.2)
+2. **Process**:
+   - 2.1: `PatternRecognitionBotAgent.analyze()` — pattern identification + setup scoring
+   - 2.2: `StatisticalAlphaEngineAgent.analyze()` — cross-sectional z-score, alpha signal
+   - 2.3: `TechnicalTaEngineAgent.analyze()` — full TA-Lib bundle from OHLCV
+3. **Output**: Each agent writes its node-specific payload and appends one entry to `tier0_contracts`
+4. **Telemetry**: FlowEvent reasoning entries per agent with analysis decision
 
 ## Rules / Constraints
-- Require ≥2 confirmations (either from Nexus patterns + TA-Lib, or multi-timeframe alignment).
-- All TA-Lib parameters transparent — no black-box tuning.
-- If Nexus endpoint unavailable, rely solely on local TA-Lib computation (and vice versa).
+- Agent 2.3 (Technical TA) has the highest single weight in the system (0.30)
+- Combined weight of 2.1 + 2.2 + 2.3 = 0.65 — these three agents dominate the weighted convergence
+- All three run in parallel as sibling Tier-0 nodes
+- 2.3 does NOT depend on Nexus data (pure OHLCV analysis)

--- a/docs/personas/06_open_interest_positioning.md
+++ b/docs/personas/06_open_interest_positioning.md
@@ -1,20 +1,79 @@
-# Persona: Open Interest & Positioning (Alpha Desk — OI / 持倉分析)
-
-> Internal role: `multi_factor_actuary`
+# Persona: Sentiment & Flow Agents — 3.1 Retail Hype Tracker, 3.2 Pro Bias Analyst (情绪与资金流分析)
 
 ## Position
-Alpha-generation desk — open interest & positioning analysis (Tier-0 AIMM8).
+Tier-0 perception cluster covering retail sentiment and institutional/smart-money flow. These agents monitor market psychology extremes (retail euphoria/fear) and professional positioning (ETF flows, funding rates, OI changes) to detect crowd-driven inflection points.
 
-## Goals
-- Analyse open interest data from Nexus bundle.
-- Detect futures positioning extremes, OI divergences, and liquidation clusters.
+## Agent Classification
 
-## SOP
-1. **Input**: Nexus context bundle (endpoints: `oi_top_ranking`), ticker.
-2. **Process**: Fetch OI ranking data → extract per-ticker positioning → compute divergence scores.
-3. **Output**: Dict with `status`, `oi_data`, `diverge_flag`, positional extremes.
-4. **Feedback**: None — stateless per-cycle.
+| Agent ID | Code ID | Name | Weight | Class |
+|----------|---------|------|--------|-------|
+| 3.1 | retail_hype_tracker | Retail Hype Tracker | 0.05 | `RetailHypeTrackerAgent` |
+| 3.2 | pro_bias_analyst | Pro Bias / Smart Money | 0.05 | `ProBiasAnalystAgent` |
+
+---
+
+### Agent 3.1 — Retail Hype Tracker
+
+**Role**: Behavioral psychologist — measures retail FOMO/euphoria levels and social volume extremes. Detects divergence warnings when crowded retail positioning contradicts price action.
+
+#### Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "3.1",
+    "ticker": str,
+    "status": "success" | "error",
+    "FOMO_Level": int,                # [0, 100] retail euphoria metric
+    "Divergence_Warning": bool,        # retail positioning vs price divergence
+    "Social_Volume": int               # optional social media volume proxy
+}
+```
+
+#### Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `fomo_level` | 0.35 | Inverted `FOMO_Level` | High FOMO = bearish (retail euphoria) |
+| `social_volume` | 0.25 | Proxy from FOMO * 0.5 | Inverse proxy |
+| `divergence_warning` | 0.40 | `Divergence_Warning` | True→0.20, False→0.55 |
+
+---
+
+### Agent 3.2 — Pro Bias Analyst (Smart Money)
+
+**Role**: Smart money flow tracker — monitors ETF accumulation/distribution trends, funding rate regimes, and open interest (OI) deltas to measure institutional conviction.
+
+#### Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "3.2",
+    "ticker": str,
+    "status": "success" | "error",
+    "Pro_Bias": int,                  # [0, 100] professional bias score
+    "ETF_Trend": str,                 # "Accumulation" | "Neutral" | "Distribution"
+    "Funding_Rate": float,            # Current funding rate
+    "OI_Delta": float                 # Open Interest change
+}
+```
+
+#### Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `etf_trend` | 0.40 | `ETF_Trend` mapping | Accumulation→0.70, Neutral→0.50, Distribution→0.30 |
+| `funding_rate` | 0.30 | `Pro_Bias` proxy | Linear 0→0, 100→1 |
+| `oi_delta` | 0.30 | `Pro_Bias` proxy | Linear 0→0, 100→1 (blended with 0.25 offset) |
+
+## SOP (Both Agents)
+
+1. **Input**: `ticker`, `universe`, `market_data`, optional `nexus_context`
+2. **Process**:
+   - 3.1: `RetailHypeTrackerAgent.analyze()` — social volume proxies, FOMO estimation
+   - 3.2: `ProBiasAnalystAgent.analyze()` — ETF flow signals, funding rate evaluation
+3. **Output**: Each agent writes its node-specific payload and appends one entry to `tier0_contracts`
+4. **Telemetry**: FlowEvent reasoning entries per agent
 
 ## Rules / Constraints
-- Focused on OI and futures positioning, NOT pair trading or cointegration.
-- Data sourced from Nexus OI API — no local exchange connection.
+- Both agents carry weight 0.05 — moderate conviction but not decisive alone
+- High FOMO + divergence warning from Agent 3.1 is a strong bearish alignment signal
+- ETF Accumulation from Agent 3.2 provides direct institutional conviction proxy
+- Both stubbed when Nexus data unavailable

--- a/docs/personas/07_retail_hype_tracker.md
+++ b/docs/personas/07_retail_hype_tracker.md
@@ -1,21 +1,52 @@
-# Persona: Retail Hype Tracker (Alpha Desk — Social / 散戶狂熱追蹤)
-
-> Internal role: `behavioral_psychologist`
+# Persona: Retail Hype Tracker — Agent 3.1 (零售热度追踪者)
 
 ## Position
-Alpha-generation desk — retail sentiment & crowd psychology (Tier-0 AIMM8).
+Tier-0 perception agent that monitors retail trader euphoria/fear cycles. Acts as a contrarian indicator — extreme retail FOMO signals potential tops, while retail despair signals bottoms.
+
+## Agent Classification
+- **Agent ID**: 3.1
+- **Type**: `retail_hype`
+- **Code Class**: `RetailHypeTrackerAgent` (`src/agents/retail_hype_tracker.py`)
+- **Enabled by default**: Yes (weight: 0.05)
 
 ## Goals
-- Measure retail FOMO, panic, and hype-price divergence from Nexus sentiment data.
-- Flag extreme sentiment as contrarian indicators.
+- Measure FOMO/euphoria levels on a 0–100 scale from social and behavioral proxies
+- Detect divergence warnings when retail positioning conflicts with price action
+- Provide contrarian sentiment extremes to the weighted arbitrator
 
 ## SOP
-1. **Input**: Nexus context bundle (endpoints: `sentiment`, `sentiment_trends`, `kol_heatmap`), ticker.
-2. **Process**: Extract mention Z-scores, bullish ratios, KOL heatmap scores → compute FOMO level → detect divergence.
-3. **Output**: Dict with `fomo_level` (0-100), `divergence_warning` (bool), `sentiment_z_score`, raw inputs.
-4. **Feedback**: None — stateless per-cycle.
+1. **Input**: `ticker`, `universe`, `market_data`, optional `nexus_context`
+2. **Process**:
+   - `RetailHypeTrackerAgent.analyze()` evaluates social sentiment, funding rate retail tilt, and volume anomalies
+   - Returns `FOMO_Level` (int), `Divergence_Warning` (bool), and `Social_Volume` proxy
+3. **Output**:
+   - `retail_hype_tracker["primary"]` — analysis for primary ticker
+   - `retail_hype_tracker["by_symbol"]` — per-symbol analysis
+   - `tier0_contracts` — one entry for agent 3.1
+4. **Telemetry**: FlowEvent reasoning entry with FOMO and divergence details
+
+## Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "3.1",
+    "ticker": str,
+    "status": "success" | "error",
+    "FOMO_Level": int,                # [0, 100] retail euphoria
+    "Divergence_Warning": bool,       # retail vs price divergence
+    "Social_Volume": int              # optional proxy
+}
+```
+
+## Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `fomo_level` | 0.35 | `FOMO_Level` | Inverted: 100→0, 0→1 (high FOMO = bearish) |
+| `social_volume` | 0.25 | Proxy from FOMO × 0.5 | Inverse proxy |
+| `divergence_warning` | 0.40 | `Divergence_Warning` | True→0.20, False→0.55 |
 
 ## Rules / Constraints
-- Divergence flag if: mention Z > 3 AND price momentum < 0, OR abs(sentiment_Z) > 1.5, OR heatmap proxy > 40.
-- FOMO formula: `50 + z*8 + mention_z*5 + min(heat_proxy, 40) + bullish_ratio*20`.
-- Returns "skipped" if all Nexus data sources are unavailable.
+- Contrarian logic: high FOMO is bearish (retail crowded long), low FOMO is bullish (fear/despair)
+- Divergence warning at FOMO ≥ 80 triggers a strong bearish tilt in downstream alignment gating
+- Stubbed when Nexus data unavailable — returns neutral values
+- Combined with Agent 3.2 (Pro Bias) for the full sentiment picture

--- a/docs/personas/08_pro_bias_analyst.md
+++ b/docs/personas/08_pro_bias_analyst.md
@@ -1,21 +1,55 @@
-# Persona: Pro Bias Analyst (Alpha Desk — Smart Money / 專業偏見分析師)
-
-> Internal role: `smart_money_flow_tracker`
+# Persona: Pro Bias / Smart Money Analyst — Agent 3.2 (聪明钱流分析)
 
 ## Position
-Alpha-generation desk — institutional & smart-money positioning (Tier-0 AIMM8).
+Tier-0 perception agent that tracks institutional flow and smart money positioning. Measures ETF accumulation/distribution trends, funding rate regimes, and open interest delta to detect where professional capital is moving.
+
+## Agent Classification
+- **Agent ID**: 3.2
+- **Type**: `pro_bias`
+- **Code Class**: `ProBiasAnalystAgent` (`src/agents/pro_bias_analyst.py`)
+- **Enabled by default**: Yes (weight: 0.05)
 
 ## Goals
-- Track smart-money token flows (top traders, net deltas) from Nexus data.
-- Monitor TradFi ETF metrics (premium, flow velocity).
-- Classify regime: accumulation / distribution / passive rotation.
+- Determine ETF flow trend (Accumulation / Neutral / Distribution)
+- Evaluate funding rate as a proxy for long/short positioning cost
+- Compute Pro Bias score [0–100] aggregating institutional sentiment
+- Detect OI delta changes that signal position building or unwinding
 
 ## SOP
-1. **Input**: Nexus context bundle (endpoints: `smart_money_tokens`, `etf_metrics`), ticker.
-2. **Process**: Match ticker to smart-money token row → extract score / net delta / EMA slope → fetch ETF NAV premium & flow → classify regime.
-3. **Output**: Dict with `pro_bias_score` (0-100), `regime`, `ema_slope`, raw metrics.
-4. **Feedback**: None — stateless per-cycle.
+1. **Input**: `ticker`, `universe`, `market_data`, optional `nexus_context`
+2. **Process**:
+   - `ProBiasAnalystAgent.analyze()` evaluates ETF premium/discount, funding rate z-score, and OI trends
+   - Returns `ETF_Trend` (str), `Funding_Rate` (float), `OI_Delta` (float), `Pro_Bias` (int)
+3. **Output**:
+   - `pro_bias_analyst["primary"]` — analysis for primary ticker
+   - `pro_bias_analyst["by_symbol"]` — per-symbol analysis
+   - `tier0_contracts` — one entry for agent 3.2
+4. **Telemetry**: FlowEvent reasoning entry with institutional flow details
+
+## Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "3.2",
+    "ticker": str,
+    "status": "success" | "error",
+    "Pro_Bias": int,                  # [0, 100] aggregate institutional bias
+    "ETF_Trend": str,                 # "Accumulation" | "Neutral" | "Distribution"
+    "Funding_Rate": float,            # current funding rate
+    "OI_Delta": float                 # open interest delta
+}
+```
+
+## Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `etf_trend` | 0.40 | `ETF_Trend` mapping | Accumulation→0.70, Neutral→0.50, Distribution→0.30 |
+| `funding_rate` | 0.30 | `Pro_Bias` proxy | Linear 0→0, 100→1 |
+| `oi_delta` | 0.30 | `Pro_Bias` proxy | Linear × 0.5 + 0.25 |
 
 ## Rules / Constraints
-- Score ≤ 40 or negative ETF flow → "distribution"; Score ≥ 60 or positive flow/premium → "accumulation"; else "passive_rotation".
-- Returns "skipped" if no smart-money or ETF data available.
+- ETF Accumulation is the most reliable bullish signal from this agent
+- Distribution is a strong bearish signal — institutions distributing to retail
+- Funding rate proxy uses Pro_Bias as a fallback when direct funding data unavailable
+- Stubbed when Nexus feeds disabled — returns neutral values
+- Combined with Agent 3.1 (Retail Hype) for the complete sentiment picture

--- a/docs/personas/09_market_microstructure.md
+++ b/docs/personas/09_market_microstructure.md
@@ -1,23 +1,79 @@
-# Persona: Market Microstructure Desk (Merged n9 + n10 / 市場微結構台)
-
-> **Merged from: n9 Whale Behavior Analyst + n10 Liquidity & Order Flow**
-> Internal roles: `onchain_defense_sentinel` + `market_microstructure_analyst`
+# Persona: Microstructure Agents — 4.1 Whale Behavior Analyst, 4.2 Liquidity & Order Flow (微观结构分析)
 
 ## Position
-Alpha-generation desk — dual-view market health combining on-chain settlement flow with live order book microstructure.
+Tier-0 perception cluster covering market microstructure: large-holder behavior and order-book quality. These agents detect whale dump risk and execution quality conditions. Agent 4.1 is disabled by default; enable by setting weight > 0 in agent_weights config.
 
-## Goals
-- Monitor on-chain whale divergences and exchange netflow from Nexus data.
-- Assess order book depth, spread, slippage risk from market data.
-- Produce a unified liquidity profile covering both settlement and live layers.
+## Agent Classification
 
-## SOP
-1. **Input**: Nexus context bundle (endpoints: `divergences`, `per_symbol`), market_data (depth/OHLCV), ticker.
-2. **Process**: Extract on-chain netflow and divergence signals → compute order book quant summary (spread, depth, slippage) → fuse into liquidity score.
-3. **Output**: Dict with `status`, on-chain metrics (divergence, netflow), microstructure metrics (depth, spread, slippage), combined liquidity grade.
-4. **Feedback**: Track realised slippage vs estimates; update order book model.
+| Agent ID | Code ID | Name | Weight | Default | Class |
+|----------|---------|------|--------|---------|-------|
+| 4.1 | whale_behavior_analyst | Whale Behavior | 0.05 | Disabled | `WhaleBehaviorAnalystAgent` |
+| 4.2 | liquidity_order_flow | Liquidity & Order Flow | 0.15 | Enabled | `LiquidityOrderFlowAgent` |
+
+---
+
+### Agent 4.1 — Whale Behavior Analyst
+
+**Role**: On-chain defense sentinel that monitors whale wallet concentration, large transaction flows, and supply-shock risk. Computes dump probability and sell pressure gauge.
+
+#### Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "4.1",
+    "ticker": str,
+    "status": "success" | "error",
+    "Dump_Probability": float,        # [0.0, 1.0] likelihood of whale sell-off
+    "Sell_Pressure_Gauge": int,       # [0, 100] cumulative sell pressure from large holders
+    "Concentration": float            # optional whale concentration metric
+}
+```
+
+#### Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `dump_probability` | 0.50 | `Dump_Probability` | Inverted: 1.0→0 (high dump = bearish) |
+| `concentration_pct` | 0.25 | `Sell_Pressure_Gauge` | Inverted linear |
+| `wallet_flow` | 0.25 | Default 0.50 | Not in contract |
+
+---
+
+### Agent 4.2 — Liquidity & Order Flow Analyst
+
+**Role**: Market microstructure analyst evaluating execution quality conditions. Measures slippage risk, order book imbalance, and depth skew to determine whether the market can absorb intended order flow.
+
+#### Data Contract
+```python
+{
+    "schema_version": "tier0/v1",
+    "agent": "4.2",
+    "ticker": str,
+    "status": "success" | "error",
+    "Slippage_Risk_Score": int,        # [0, 100] higher = worse execution
+    "Order_Imbalance": float,          # net order flow imbalance (positive = buy pressure)
+    "Depth_Skew": float                # bid/ask depth asymmetry
+}
+```
+
+#### Factor Map
+| Factor | Weight | Source | Normalization |
+|--------|--------|--------|---------------|
+| `slippage_risk` | 0.35 | `Slippage_Risk_Score` | Inverted: high slippage = bearish |
+| `order_imbalance` | 0.35 | `Order_Imbalance` | < 0 → 0.45, else → 0.55 |
+| `depth_skew` | 0.30 | Default 0.50 | Not in contract |
+
+## SOP (Both Agents)
+
+1. **Input**: `ticker`, `universe`, `market_data`, optional `nexus_context`
+2. **Process**:
+   - 4.1: `WhaleBehaviorAnalystAgent.analyze()` — wallet flow, dump probability from on-chain data
+   - 4.2: `LiquidityOrderFlowAgent.analyze()` — order book depth, slippage estimation, imbalance detection
+3. **Output**: Each agent writes its node-specific payload and appends one entry to `tier0_contracts`
+4. **Telemetry**: FlowEvent reasoning entries per agent
 
 ## Rules / Constraints
-- On-chain component provides settlement-layer intelligence (hours/days view).
-- Order book component provides sub-second liquidity snapshot.
-- Low liquidity in either layer → reduced size recommendation.
+- Agent 4.1 (Whale) is **disabled by default** in v4 config — set weight > 0 in `agent_weights` to enable
+- Agent 4.2 (Liquidity) carries weight 0.15 = second-highest single weight after Technical TA
+- High Dump_Probability (≥ 0.65) from 4.1 triggers a bearish alignment factor
+- High Slippage_Risk_Score (≥ 80) from 4.2 blocks aggressive execution
+- Both stubbed when Nexus data unavailable

--- a/docs/personas/10_risk_desk.md
+++ b/docs/personas/10_risk_desk.md
@@ -1,19 +1,48 @@
-# Persona: Risk Desk (Governance — Risk Snapshot / 風險控制台)
+# Persona: Risk Desk / Risk Management (风险管理台)
 
 ## Position
-> Internal role: `risk_management_analyst`
-Governance layer — produces the risk context snapshot consumed by downstream synthesis.
+Risk analysis node that computes position sizing, volatility profiles, and market-wide risk metrics. Runs after all Tier-0 agents complete and before the desk debate. Feeds risk context into the arbitration pipeline.
+
+## Agent Classification
+- **Agent ID**: N/A (Risk)
+- **Type**: Risk Management
+- **Code Class**: `RiskManagementAgent` (`src/agents/risk_management.py`)
+- **Enabled by default**: Yes
 
 ## Goals
-- Analyse current portfolio exposure against fund policy (position caps).
-- Produce risk profile for Desk Debate and Signal Arbitrator.
+- Compute per-symbol volatility and position sizing recommendations
+- Generate market-wide risk assessment from market data and valuation context
+- Provide risk-constrained position size suggestions to downstream portfolio nodes
 
 ## SOP
-1. **Input**: market_data, valuation_data, fund policy config.
-2. **Process**: `RiskManagementAgent.analyze()` → check each ticker's position against `risk_position_cap_usd` → compute risk scores.
-3. **Output**: Dict with risk constraints, cap exposure, per-ticker status.
-4. **Feedback**: Risk profile consumed by downstream nodes.
+1. **Input**: `market_data` (OHLCV), `valuation` from state
+2. **Process**:
+   - `RiskManagementAgent.analyze()` evaluates volatility profiles, value-at-risk proxies, and position sizing
+   - Returns per-symbol risk analysis with `position_size` suggestions and `volatility` metrics
+3. **Output**:
+   - `risk` — dict with `analysis` key mapping symbol → risk metrics
+   - `risk["analysis"][symbol]["position_size"]` — suggested sizing scalar
+   - `risk["analysis"][symbol]["volatility"]` — volatility estimate
+4. **Telemetry**: FlowEvent reasoning entry with risk profile
+
+## Data Contract
+```python
+{
+    "risk": {
+        "analysis": {
+            "BTC/USDT": {
+                "position_size": float,    # suggested position size
+                "volatility": float,       # volatility estimate
+                # ... additional risk metrics
+            },
+            ...
+        }
+    }
+}
+```
 
 ## Rules / Constraints
-- Purely analytical — NO veto power (Risk Guard has veto).
-- All limits defined in `fund_policy` config.
+- Runs sequentially after all 9 Tier-0 agents complete (parallel Tier-0 tier finished)
+- Position sizing suggestions are *advisory* — the portfolio proposal node makes final sizing decisions
+- Volatility estimates feed into desk debate evidence lines
+- No veto power — risk guard handles veto decisions

--- a/docs/personas/11_desk_debate.md
+++ b/docs/personas/11_desk_debate.md
@@ -1,20 +1,69 @@
-# Node: Desk Debate (Synthesis — Investment Committee / 投資委員會辯論)
-
-> **This is a LangGraph node function, not a standalone agent class.**
+# Persona: Desk Debate (辩论台 / Tier-2 综合)
 
 ## Position
-Synthesis layer — the investment committee meeting. Appends to `debate_transcript`.
+Pre-arbitration debate stage that generates two-sided evidence lines from Tier-0 contracts. Always produces deterministic bull/bear summaries. Optionally adds LLM desk turns (Desk_Risk with depth tool access, Desk_Tape narrative-only) when `AIMM_LLM_DESK_DEBATE=1`.
+
+## Agent Classification
+- **Agent ID**: N/A (Tier-2 Synthesis)
+- **Type**: Debate / Evidence Synthesis
+- **Code Class**: `desk_debate` node function (`src/workflow/desk_debate.py`)
+- **Enabled by default**: Yes (deterministic always; LLM optional)
 
 ## Goals
-- Fuse all Tier-0 alpha desk outputs + risk snapshot into a single human-readable memo.
-- The transcript is consumed by Signal Arbitrator (deterministic or LLM).
+- Produce structured bull/bear evidence lines from Tier-0 contract fields
+- Compute a deterministic legacy stance preview as reference
+- Provide the downstream arbitrator (weighted or LLM) with grounded evidence context
+- Optionally host LLM desk debate turns for narrative reasoning
 
 ## SOP
-1. **Input**: State with all Tier-0 desk outputs + risk snapshot.
-2. **Process**: Construct structured debate transcript rows from each desk's verdict.
-3. **Output**: Appends rows to `state.debate_transcript`.
-4. **Feedback**: None — stateless per-cycle.
+1. **Input**: `ticker`, `tier0_contracts`, `risk`, `universe`, `debate_transcript` from state
+2. **Process**:
+   - **Deterministic** (always): `bull_evidence_lines()` + `bear_evidence_lines()` from `tier2_context.py`
+     - Scans each agent's contract fields for constructive (bull) and defensive (bear) signals
+     - Calls `legacy_deterministic_stance_preview()` for score reference
+   - **LLM** (optional, `AIMM_LLM_DESK_DEBATE=1`):
+     - Desk_Risk: LLM with optional `nexus.fetch_market_depth` tool
+     - Desk_Tape: LLM with no tools (narrative-only)
+     - Both desks use structured format: Decision / Evidence / Risks / Would change mind if
+3. **Output**:
+   - `debate_transcript` — list of entries appended to state (deterministic + optional LLM)
+   - `reasoning_logs` — debate summary with entry count
+4. **Telemetry**: FlowEvent reasoning entry with debate preview (truncated to 320 chars)
+
+## Evidence Lines (Deterministic)
+| Agent | Bull Evidence | Bear Evidence |
+|-------|-------------|---------------|
+| 1.1 Macro | Risk-on regime (state=2) | Risk-off regime (state=0) |
+| 1.2 News | Low impact (<40) | High impact (≥55) or Black Swan |
+| 2.1 Pattern | Setup ≥ 55 | Setup < 45 |
+| 2.2 Alpha | Strong Buy signal | Strong Sell signal |
+| 2.3 TA | RSI oversold, MACD+ | RSI stretched, MACD- |
+| 3.1 Hype | FOMO < 75, no divergence | FOMO ≥ 80 + divergence |
+| 3.2 Smart | ETF Accumulation | ETF Distribution |
+| 4.1 Whale | Dump prob < 0.45 | Dump prob ≥ 0.45 |
+| 4.2 Liquidity | Slippage < 75 | Slippage ≥ 75 |
+
+## Data Contract
+```python
+{
+    "debate_transcript": [
+        {
+            "speaker": "desk_risk" | "desk_tape" | "llm_desk_risk" | "llm_desk_tape",
+            "role": "macro_and_guardrails" | "technical_and_flow" | "llm_tools_depth" | "llm_narrative_only",
+            "text": str,           # structured memo
+            "tools_available": [str, ...],     # LLM desk only
+            "tools_used": [str, ...],          # LLM desk only
+            "tool_events_count": int           # LLM desk only
+        },
+        ...
+    ]
+}
+```
 
 ## Rules / Constraints
-- Deterministic (no LLM) — purely structural aggregation.
-- Output is one of many inputs to Signal Arbitrator.
+- Deterministic debate is always active — no API cost
+- LLM debate requires `AIMM_LLM_DESK_DEBATE=1` env var AND `AIMM_ARBITRATOR_MODE=llm`
+- Full transcript stored in state; preview (320 chars) used for reasoning logs
+- Full transcript can be included in flow events via `AIMM_FLOW_INCLUDE_FULL_DEBATE=1`
+- Desk_Risk (LLM) may call tools up to 2 rounds; Desk_Tape has no tools
+- Prompt settings configurable via `agent_prompts` config `desk_debate` actor settings

--- a/docs/personas/12_signal_arbitrator.md
+++ b/docs/personas/12_signal_arbitrator.md
@@ -1,22 +1,127 @@
-# Node: Signal Arbitrator (Decision — Final Stance / 信號仲裁者)
-
-> **This is a LangGraph node function, not a standalone agent class.**
-> Optional LLM variant via `signal_arbitrator_llm` when `AIMM_USE_LLM_ARBITRATOR` is set.
+# Persona: Signal Arbitrator — Weighted Convergence (信号仲裁 / 加权收敛仲裁器)
 
 ## Position
-Decision layer — the final cross-desk arbitrator (Tier-2 synthesis).
+Core arbitration node that synthesizes all 9 Tier-0 agents' signals into a single trade decision using deterministic weighted convergence. Replaces the legacy LLM arbitrator as the default mode. Produces the `trade_intent` that drives portfolio sizing.
+
+## Agent Classification
+- **Agent ID**: N/A (Arbitration)
+- **Type**: Arbitration / Signal Synthesis
+- **Code Class**: `weighted_arbitrator_node` (`src/workflow/weighted_arbitrator.py`) + `compute_weighted_arbitration()` (`src/workflow/weight_assigner.py`)
+- **Enabled by default**: Yes (weighted_convergence mode)
+- **Alternative**: `AIMM_ARBITRATOR_MODE=llm` for LLM-based arbitrator
 
 ## Goals
-- Compute final bullish/bearish stance from desk outputs, debate transcript, and risk context.
-- Default to NEUTRAL unless evidence is strong.
+- Compute per-agent weighted composites from standardized Tier-0 contracts
+- Compute global weighted composite score with confidence and consensus metrics
+- Apply threshold gating (BUY/SELL/HOLD) with alignment protection
+- Derive `trade_intent` contract for the execution engine
+- Build synthesis board evidence for trace UI
 
 ## SOP
-1. **Input**: State with all Tier-0 scores + debate transcript + risk snapshot.
-2. **Process**: `compute_legacy_arbitrator_scores()` → momentum score + consensus check → determine stance.
-3. **Output**: Dict with `stance` (bullish/bearish/neutral), confidence, bull/bear score, high-vol flags.
-4. **Feedback**: None — stateless per-cycle.
+1. **Input**: `tier0_contracts` (list of contract dicts), `ticker`, `run_mode`, `shared_memory`
+2. **Process**:
+
+   **Phase 1 — Weight Assigner** (`weight_assigner.compute_weighted_arbitration()`):
+   1. Group contracts by agent ID → `tier0_contracts_by_agent()`
+   2. For each enabled agent, extract factor signals via per-agent extractor (`_agent_*_factors`)
+   3. Normalize each factor to [0, 1] (1.0 = max bullish)
+   4. Compute agent composite = Σ(factor_weight × factor_normalized)
+   5. Weight by `AGENT_WEIGHTS_DEFAULT`
+
+   **Phase 2 — Global Score** (`compute_global_weighted_score()`):
+   - composite = Σ(agent_weight × agent_composite) / total_weight
+   - confidence = |composite_magnitude| × min(1.0, 0.5 + consensus_ratio × 0.5)
+
+   **Phase 3 — Decision Gating**:
+   - BUY: composite ≥ 0.60 AND confidence ≥ 0.50
+   - SELL: composite ≤ 0.40 AND confidence ≥ 0.50
+   - HOLD: else
+
+   **Phase 4 — Alignment Gating**:
+   - If directional (BUY/SELL) and active factors < 3 → revert to HOLD
+
+   **Phase 5 — Execution Intent** (`derive_trade_intent()`):
+   - Map stance + confidence → BUY/SELL/HOLD action
+   - Compute max_notional_usd from cash + leverage + policy settings
+
+   **Phase 6 — Synthesis Board** (`build_synthesis_board()`):
+   - Build bull/bear evidence lines with consensus snapshot for UI
+
+3. **Output**:
+   - `proposed_signal` — standardized proposal shape (same as LLM path)
+   - `trade_intent` — execution contract with action, confidence, constraints, cash context
+   - `reasoning_logs` — per-agent factor breakdown + final decision
+   - `arbitration_result` — compact summary (composite, confidence, stance, conviction, alignment)
+
+## Default Weights
+```python
+AGENT_WEIGHTS_DEFAULT = {
+    "1.1": 0.05,  "1.2": 0.05,
+    "2.1": 0.25,  "2.2": 0.10,  "2.3": 0.30,
+    "3.1": 0.05,  "3.2": 0.05,
+    "4.1": 0.05,  "4.2": 0.15,  # 4.1 disabled by default
+}
+```
+
+## Decision Thresholds (v4 Config)
+```python
+BUY:  min_composite=0.60, min_confidence=0.50
+SELL: max_composite=0.40, min_confidence=0.50
+alignment_gating: min_factors_for_directional=3
+```
+
+## Data Contract
+```python
+# proposed_signal
+{
+    "action": "PROPOSAL",
+    "params": {
+        "stance": "bullish" | "bearish" | "neutral",
+        "confidence": float,
+        "reasons": [str, ...],
+        "tool_events": [],
+        "debate_entries": int,
+        "weighted_arbitrator": True,
+        "composite_score": float,
+        "conviction_level": "none" | "low" | "medium" | "high",
+        "consensus_ratio": float,
+        "alignment_gated": bool,
+        "agent_signals": [{agent_summary}, ...]
+    },
+    "meta": {
+        "source": "weighted_arbitrator",
+        "mode": "weighted_convergence"
+    }
+}
+
+# trade_intent
+{
+    "ticker": str,
+    "action": "BUY" | "SELL" | "HOLD",
+    "confidence": float,
+    "reasons": [str, ...],
+    "constraints": {
+        "max_notional_usd": float | None,
+        "requires_price": True
+    },
+    "context": {
+        "run_mode": str,
+        "cash_usd": float | None,
+        "qty_base": float | None,
+        "price": float | None
+    },
+    "meta": {
+        "source": "execution_intent_v1",
+        "derived_from": "proposed_signal.params.stance",
+        "min_confidence_directional": 0.45
+    }
+}
+```
 
 ## Rules / Constraints
-- Two variant modes: deterministic math (`signal_arbitrator`) or LLM-driven (`signal_arbitrator_llm`).
-- Weighted evidence: Tier-0 consensus counts alongside individual desk scores.
-- Never exceeds confidence > 0.95 (LLM variant enforced via prompt).
+- Disabled agents (weight = 0 or in `disabled_agents` set) excluded from composite
+- Agent 4.1 (Whale) disabled by default
+- Alignment gating prevents under-powered directional decisions (< 3 active factors)
+- Confidence clamped to [0, 0.95] in execution intent
+- HOLD override if bearish + short disallowed + flat book
+- Per-agent factor breakdown logged in reasoning entries for full transparency

--- a/docs/personas/13_portfolio_proposal.md
+++ b/docs/personas/13_portfolio_proposal.md
@@ -1,21 +1,61 @@
-# Node: Portfolio Proposal (Execution — Allocation / 投資組合提案)
-
-> **This is a LangGraph node function, not a standalone agent class.**
+# Persona: Portfolio Proposal (投资组合提议)
 
 ## Position
-Execution layer — translates the signal into a concrete allocation proposal.
+Portfolio management node that translates the arbitrator's signal decision into a concrete portfolio proposal with sizing, allocation suggestions, and trade parameters. Uses the `PortfolioManagementAgent` with optional LLM proposal when `llm_mode_enabled()`.
+
+## Agent Classification
+- **Agent ID**: N/A (Portfolio)
+- **Type**: Portfolio / Sizing
+- **Code Class**: `PortfolioManagementAgent` (`src/agents/portfolio_management.py`) + `portfolio_proposal` node function
+- **Enabled by default**: Yes
 
 ## Goals
-- Convert Signal Arbitrator's stance into a portfolio weight proposal.
-- Prioritise capital preservation — most assets stay HOLD.
+- Convert `trade_intent` + `proposed_signal` into a concrete position proposal with sizing
+- Incorporate risk metrics, quant analysis, and valuation context into sizing decisions
+- Fall back cleanly from LLM to deterministic agent if LLM proposal fails
 
 ## SOP
-1. **Input**: State with signal, risk context, current holdings.
-2. **Process**: Determine desired portfolio weights based on stance + confidence → apply risk constraints → cap single positions.
-3. **Output**: Dict with `portfolio_weights`, target positions, reasoning.
-4. **Feedback**: None — stateless per-cycle.
+1. **Input**: `ticker`, `market_data`, `pattern_analysis`, `sentiment_analysis`, `arb_analysis`, `quant_analysis`, `valuation`, `risk`, `liquidity`, `proposed_signal` (strategy context), `trade_intent`, `run_mode`, `shared_memory`
+2. **Process**:
+   - If `llm_mode_enabled()`: call `llm_portfolio_proposal(state)` for LLM-generated proposal
+   - If LLM fails or `llm_mode` disabled: call `PortfolioManagementAgent.analyze()` with all context inputs
+   - Merge `strategy_context` from `proposed_signal` into the proposal
+3. **Output**:
+   - `proposal` — the portfolio proposal dict (trades, sizing, allocation)
+   - `proposed_signal` — updated with proposal params and upstream signal meta
+4. **Telemetry**: FlowEvent reasoning entry with proposal summary
+
+## Data Contract
+```python
+{
+    "proposal": {
+        "status": "success" | "error",
+        "trades": [          # list of trade suggestions
+            {
+                "symbol": str,
+                "side": "buy" | "sell",
+                "qty": float,
+                "price": float | None,
+                "confidence": float,
+                "reason": str
+            }
+        ],
+        "strategy_context": { ... },  # from proposed_signal
+        # ... additional portfolio fields
+    },
+    "proposed_signal": {
+        "action": "PROPOSAL",
+        "params": proposal_dict,  # from PortfolioManagementAgent
+        "meta": {
+            "source": "portfolio_proposal",
+            "upstream_signal": state.proposed_signal
+        }
+    }
+}
+```
 
 ## Rules / Constraints
-- Proposal is submitted to Risk Guard for approval.
-- Max single position ≤ 35% of portfolio.
-- Default to HOLD unless strong conviction from signal.
+- Receives `trade_intent` from the arbitrator — portfolio proposal is secondary sizing, not a new decision
+- Falls back from LLM to deterministic agent on any failure
+- Backtest mode: reads external cash/positions from `shared_memory.backtest` for position-aware math
+- Upstream signal context preserved in `proposed_signal.meta.upstream_signal`

--- a/docs/personas/14_risk_guard.md
+++ b/docs/personas/14_risk_guard.md
@@ -1,21 +1,69 @@
-# Node: Risk Guard (Governance — Veto / 風控官)
-
-> **This is a BaseAgent subclass (`RiskGuardAgent`).**
+# Persona: Risk Guard (风险警卫 / 治理层否决权)
 
 ## Position
-Governance layer — final veto authority.
+Governance node with veto power. Acts as the final check before execution — evaluates the portfolio proposal against risk policy and can VETO the entire run. Implements the kill switch mechanism.
+
+## Agent Classification
+- **Agent ID**: N/A (Governance)
+- **Type**: Governance / Risk Officer
+- **Code Class**: `RiskGuardAgent` (`src/agents/governance/risk_guard.py`)
+- **Enabled by default**: Yes
 
 ## Goals
-- Protect the account from extreme drawdown.
-- Veto any proposal that violates risk limits or kill-switch conditions.
+- Evaluate the portfolio proposal against risk policy rules (position limits, drawdown, concentration)
+- Return APPROVED or VETOED with reasoning and risk score
+- Expose kill switch via env vars (`AIMM_KILL_SWITCH`, `AIMM_RISK_GUARD_KILL_SWITCH`)
+- Route execution skip on veto (graph routes to audit instead of portfolio_execute)
 
 ## SOP
-1. **Input**: Proposal dict from Portfolio Proposal + env state.
-2. **Process**: Check `AIMM_KILL_SWITCH` → compute risk score from position sizes, volatility, exposure → decide.
-3. **Output**: `{"status": "APPROVED"}` or `{"status": "VETOED"}` with reasoning log.
-4. **Feedback**: Veto reason recorded in state for Audit.
+1. **Input**: `proposal`, `shared_memory`, `ticker`, `run_mode` from state
+2. **Process**:
+   - `RiskGuardAgent.process()` checks the proposal against risk policy (`FundPolicy`)
+   - Active kill switch → immediate VETO with explanation
+   - Position limit checks, drawdown thresholds, concentration risk
+   - Returns `status` (APPROVED/VETOED), `risk_score` (float), `reasoning` (dict with `thought`)
+3. **Output**:
+   - `risk_guard` — full decision dict
+   - `risk_report` — same as decision for downstream audit
+   - `is_vetoed` — boolean flag
+   - `veto_reason` — explanation string if vetoed
+   - If vetoed: `execution_result` with `status = "skipped"`
+4. **Telemetry**: `FlowEvent.risk_guard` with status, risk score, and reasoning; published to `LogPublisher` with `veto_status`
+
+## Data Contract
+```python
+# On APPROVE:
+{
+    "status": "APPROVED",
+    "risk_score": float,
+    "reasoning": {"thought": str, ...}
+}
+
+# On VETO:
+{
+    "status": "VETOED",
+    "risk_score": float,  # typically high
+    "reasoning": {"thought": str, ...}
+}
+```
+
+State flags set by this node:
+```python
+{
+    "risk_guard": { ... },         # full decision
+    "risk_report": { ... },        # same as risk_guard
+    "is_vetoed": True | False,
+    "veto_reason": str,
+    "execution_result": {          # only when vetoed
+        "status": "skipped",
+        "message": "Execution vetoed by Risk Guard",
+        "risk_guard": { ... }
+    }
+}
+```
 
 ## Rules / Constraints
-- Absolute veto — can halt everything.
-- `AIMM_KILL_SWITCH` or `AIMM_RISK_GUARD_KILL_SWITCH` env → automatic VETOED.
-- Every outcome must produce an explainable reasoning log.
+- Graph routing: VETOED → `audit` (skip portfolio_execute); APPROVED → `portfolio_execute`
+- Kill switch env vars: `AIMM_KILL_SWITCH=1` or `AIMM_RISK_GUARD_KILL_SWITCH=1` force immediate veto
+- Decision is final — portfolio_execute checks `is_vetoed` and skips if set
+- Respects `FundPolicy` limits (position concentration, max notional, short-allowed flag)

--- a/docs/personas/15_portfolio_execute.md
+++ b/docs/personas/15_portfolio_execute.md
@@ -1,22 +1,88 @@
-# Node: Execution Desk (Broker — Order Generation / 執行交易檯)
-
-> **This is a LangGraph node function (`portfolio_execute` / n16), not a standalone agent class.**
-> The actual order routing uses `trading.policy_manager.TradingPolicyManager` + `ccxt`.
+# Persona: Portfolio Execute & Audit (执行与审计)
 
 ## Position
-Execution layer — the only node that interacts with exchange APIs.
+Terminal execution and audit node. `portfolio_execute` places the approved trade via the execution adapter (CCXT / Nexus). Skips if vetoed. `audit` assembles the final summary of the entire run for logging and post-run analysis.
+
+## Agent Classification
+- **Agent ID**: N/A (Execution / Audit)
+- **Type**: Execution & Audit
+- **Code Class**: `PortfolioManagementAgent` + `portfolio_execute` / `audit` node functions
+- **Enabled by default**: Yes
 
 ## Goals
-- Convert an approved portfolio proposal into a safe, minimal execution plan.
-- Execute via CCXT exchange instance (shared across backtest bars to avoid rate limits).
+- Place trades through the exchange adapter when not vetoed
+- Handle LLM execution fallback (LLM → deterministic)
+- Build final run summary with all key decisions, risk status, and execution results
+- Maintain paper account snapshot in shared memory for backtest continuity
 
 ## SOP
-1. **Input**: Approved proposal + current portfolio + market data.
-2. **Process**: Validate balances → generate orders → submit via CCXT.
-3. **Output**: `execution_result` dict with order details and fill status.
-4. **Feedback**: Execution result stored in state for Audit node.
+
+### Portfolio Execute
+1. **Input**: `is_vetoed`, `ticker`, `proposal`, `trade_intent`, `market_data`, `run_mode`, `shared_memory`
+2. **Process**:
+   - If `is_vetoed`: return empty (skip — should not be reached via routing, but safe check)
+   - If `llm_mode_enabled()`: call `llm_portfolio_execute()` — fallback to deterministic agent on failure
+   - Deterministic: `PortfolioManagementAgent.analyze()` with `execute=True`
+   - Paper mode: update paper account snapshot after execution
+3. **Output**:
+   - `execution_result` — order status, filled quantity, slippage, order IDs
+   - `shared_memory["paper"]` — updated paper account snapshot (paper mode)
+
+### Audit
+4. **Input**: Full state after execution (or after veto skip)
+5. **Process**:
+   - Compact final summary of ticker, run_mode, veto status, risk report, execution result, proposal status
+   - Build reasoning log entry with summary
+6. **Output**:
+   - `reasoning_logs` — final audit reasoning entry
+   - No new state mutations (read-only analysis)
+
+## Data Contract
+```python
+# execution_result
+{
+    "status": "success" | "skipped" | "error",
+    "orders": [
+        {
+            "symbol": str,
+            "side": "buy" | "sell",
+            "qty": float,
+            "filled_qty": float,
+            "price": float | None,
+            "slippage_bps": float,
+            "status": "filled" | "partial" | "rejected"
+        }
+    ],
+    "meta": {
+        "source": "portfolio_execute" | "llm_portfolio_execute"
+    }
+}
+
+# audit reasoning entry
+{
+    "summary": {
+        "ticker": str,
+        "run_mode": str,
+        "is_vetoed": bool,
+        "veto_reason": str,
+        "risk_status": str,
+        "execution_status": str,
+        "proposal_status": str,
+        "market_symbols_count": int,
+        "reasoning_logs_count": int
+    }
+}
+```
+
+## Graph Flow (termination)
+```
+portfolio_execute → audit → END
+                   ↗           ↑
+risk_guard (VETOED) ───────────┘
+```
 
 ## Rules / Constraints
-- If Risk Guard did not approve or proposal is empty → return `{"smart_orders": []}`.
-- Uses `_CCXT_SHARED` dict to share exchange instances across backtest cycles.
-- Order types: prefers post-only limit orders for market-making behaviour.
+- `portfolio_execute` always checks `is_vetoed` before proceeding (defensive)
+- Node names: `desk_portfolio_execute` and `audit` in the LangGraph
+- Audit is terminal — no further state mutations
+- Paper mode updates account snapshot after each execution for next run's context

--- a/docs/personas/README.md
+++ b/docs/personas/README.md
@@ -1,73 +1,79 @@
-# Hedge Fund Agent Personas
+# AIMM v4 Personas — Weighted Convergence Architecture
 
-This directory documents the **14 persona agents** in the OlaXBT multi-agent hedge fund system, plus supporting execution nodes. Each `.md` file corresponds to one runtime node in the LangGraph workflow, with some tier-0 agents merged where code analysis showed overlapping data sources and processing.
+## Architecture Overview
 
-## Architecture
+The AI Market Maker (AIMM) v4 replaces the legacy n0-n17 numbering and LLM-centric arbitrator with a **weighted convergence architecture**. Nine tier-0 perception agents (IDs 1.1–4.2) analyze markets in parallel, each producing a standardized Tier-0 JSON contract. A deterministic weight assigner extracts factor signals from these contracts, normalizes them to [0, 1], and computes a global weighted composite score that drives trade decisions.
+
+### Graph Flow
 
 ```
-                    ┌──────────────────────┐
-                    │  Policy Orchestrator │  (n0) — config/preset
-                    └──────────┬───────────┘
-                               │
-          ┌────────────────────┼────────────────────┐
-          ▼                    ▼                    ▼
-    ┌──────────────┐    ┌──────────────┐    ┌──────────────┐
-    │  Alpha       │    │  Synthesis   │    │  Governance  │
-    │  Desks (8)   │    │  Layer       │    │              │
-    │ (Tier-0)     │    │              │    │ n9  Risk     │
-    │              │    │ n10 Debate   │    │     Desk     │
-    │ n1  Scan     │    │ n11 Signal   │    │ n13 Risk     │
-    │ n2  Macro    │    │    Arb       │    │     Guard    │
-    │ n3  News     │    │ n12 Proposal │    └──────────────┘
-    │ n4  Tech TA  │    │              │
-    │ n5  OI       │    │ (n14 Exec    │    ┌──────────────┐
-    │ n6  Retail   │    │  = broker)   │    │  Log Node    │
-    │ n7  Pro Bias │    └──────────────┘    │ n15 Audit    │
-    │ n8  Microstr │         │              └──────────────┘
-    └──────────────┘         │
-         │                   │
-         ▼                   ▼
-    ┌────────────────────────────────────────────┐
-    │    Parallel alpha → Risk → Debate →        │
-    │    Signal → Proposal → Risk Guard → Exec   │
-    └────────────────────────────────────────────┘
+policy_orchestrator → market_scan
+  → [9 tier-0 agents in parallel]
+  → risk → desk_debate → signal_arbitrator
+  → portfolio_proposal → risk_guard
+  → portfolio_execute → audit
 ```
 
-## 14 Decision Agents + Supporting Nodes
+### 9 Tier-0 Agents
 
-| # | File | Node | Actor | Type | Role |
-|---|------|------|-------|------|------|
-| **1** | `01_policy_orchestrator.md` | n0 | policy_orchestrator | Agent class | Config/preset selector |
-| **2** | `02_market_scan.md` | n1 | market_scan | Agent class | CCXT + CoinGecko fetch |
-| **3** | `03_monetary_sentinel.md` | n2 | monetary_sentinel | Module fn | Macro economist |
-| **4** | `04_news_narrative_miner.md` | n3 | news_narrative_miner | Module fn | Event-driven analyst |
-| **5** | `05_technical_analysis_desk.md` | n4+n6 | (merged) | Mixed | Chart patterns + TA-Lib |
-| **6** | `06_open_interest_positioning.md` | n5 | statistical_alpha | Module fn | OI / positioning |
-| **7** | `07_retail_hype_tracker.md` | n7 | retail_hype_tracker | Agent class | Behavioural psychologist |
-| **8** | `08_pro_bias_analyst.md` | n8 | pro_bias_analyst | Agent class | Smart-money flow |
-| **9** | `09_market_microstructure.md` | n9+n10 | (merged) | Mixed | On-chain + order book |
-| **10** | `10_risk_desk.md` | n11 | risk | Agent class | Risk context snapshot |
-| **11** | `11_desk_debate.md` | n12 | desk_debate | Node function | IC memo synthesis |
-| **12** | `12_signal_arbitrator.md` | n13 | signal_arbitrator | Node function | Final stance |
-| **13** | `13_portfolio_proposal.md` | n14 | portfolio_proposal | Node function | Capital allocation |
-| **14** | `14_risk_guard.md` | n15 | risk_guard | Agent class | Veto authority |
+| ID | Code ID | Name | Role | Weight |
+|----|---------|------|------|--------|
+| 1.1 | monetary_sentinel | Macro Economist | Macro regime + liquidity score | 0.05 |
+| 1.2 | news_narrative_miner | News & Narrative | Event impact + narrative freshness | 0.05 |
+| 2.1 | pattern_recognition_bot | Pattern Recognition | Chart geometry + setup quality | 0.25 |
+| 2.2 | statistical_alpha_engine | Statistical Alpha | Cross-sectional z-score + alpha signal | 0.10 |
+| 2.3 | technical_ta_engine | Technical Analysis | TA-Lib bundle (RSI, MACD, OBV, ATR, ADX, EMA) | 0.30 |
+| 3.1 | retail_hype_tracker | Retail Hype | FOMO level + divergence warning | 0.05 |
+| 3.2 | pro_bias_analyst | Smart Money | ETF trend + funding rate + OI delta | 0.05 |
+| 4.1 | whale_behavior_analyst | Whale Behavior | Dump probability + concentration | 0.05 |
+| 4.2 | liquidity_order_flow | Liquidity & Order Flow | Slippage risk + order imbalance + depth skew | 0.15 |
 
-## Non-Agent Supporting Nodes
+**Disabled by default**: Agent 4.1 (Whale Behavior) — enable by setting weight > 0.
 
-| # | File | Node | Actor | Type | Role |
-|---|------|------|-------|------|------|
-| — | `15_portfolio_execute.md` | n16 | portfolio_execute | Node function | CCXT order routing |
-| — | (in README) | n17 | audit | Log function | Event persistence |
+### Persona Files
 
-## Merges Applied
+| File | Persona | Node / Agent |
+|------|---------|-------------|
+| `01_policy_orchestrator.md` | Policy Orchestrator | Governance: Supervisor |
+| `02_market_scan.md` | Market Scan | Data: Market scan & universe selection |
+| `03_monetary_sentinel.md` | Agent 1.1 Macro Economist | Tier-0: Macro regime |
+| `04_news_narrative_miner.md` | Agent 1.2 News & Narrative | Tier-0: Events & narrative |
+| `05_technical_analysis_desk.md` | Technical Analysis Agents | Tier-0: 2.1 Pattern + 2.2 Statistical + 2.3 TA |
+| `06_open_interest_positioning.md` | Sentiment & Flow Agents | Tier-0: 3.1 Retail Hype + 3.2 Pro Bias |
+| `07_retail_hype_tracker.md` | Agent 3.1 Retail Hype | Tier-0: Behavioral sentiment |
+| `08_pro_bias_analyst.md` | Agent 3.2 Smart Money | Tier-0: Institutional flow |
+| `09_market_microstructure.md` | Microstructure Agents | Tier-0: 4.1 Whale + 4.2 Liquidity |
+| `10_risk_desk.md` | Risk Management | Risk: Position sizing & volatility |
+| `11_desk_debate.md` | Desk Debate | Tier-2: Bull/bear evidence lines |
+| `12_signal_arbitrator.md` | Signal Arbitrator | Arbitration: Weighted convergence + execution intent |
+| `13_portfolio_proposal.md` | Portfolio Proposal | Portfolio: Sizing & allocation |
+| `14_risk_guard.md` | Risk Guard | Governance: Veto power |
+| `15_portfolio_execute.md` | Portfolio Execute (+ Audit) | Execution: Order placement & audit |
 
-| Original Nodes | Merged Into | Rationale |
-|----------------|-------------|-----------|
-| n4 Pattern Recognition + n6 Technical TA | `05_technical_analysis_desk.md` | 80% input overlap (OHLCV), same analytical question |
-| n9 Whale Behavior + n10 Liquidity Flow | `09_market_microstructure.md` | 60% input overlap (per_symbol data), same market health question |
+### Decision Thresholds
 
-## Node Types
+```python
+BUY:  min_composite >= 0.60, min_confidence >= 0.50
+SELL: max_composite <= 0.40, min_confidence >= 0.50
+HOLD: else
+alignment_gating: min_factors_for_directional = 3
+```
 
-- **Agent class**: A `BaseAgent` subclass with its own `.py` file in `src/agents/`.
-- **Module fn**: A stateless function defined in a module under `src/agents/`.
-- **Node function**: A stateless function defined in `src/main.py` that operates on the graph state.
+### Key Changes from v3
+
+| v3 (old) | v4 (new) |
+|----------|----------|
+| n0–n17 numbered agents | 9 tier-0 agents (1.1–4.2) |
+| LLM-centric arbitrator | Weighted convergence arbitrator (default) |
+| `AIMM_USE_LLM` toggle | Removed — LLM key required |
+| `arbitrator_shadow.py` | Deleted — replaced by weight_assigner |
+| Raw signal output | `trade_intent` via `derive_trade_intent()` |
+| — | Factor extraction pipeline (`AGENT_FACTOR_MAP`) |
+| — | Alignment gating (min 3 factors) |
+| — | Opt-in/opt-out via weight=0 in config |
+| — | Synthesis board (`tier2_context.py`) |
+
+### Optional LLM Features
+
+- **AIMM_ARBITRATOR_MODE=llm**: Use LLM-based arbitrator instead of weighted convergence
+- **AIMM_LLM_DESK_DEBATE=1**: Enable LLM desk debate (Desk_Risk + Desk_Tape LLM turns)

--- a/docs/weight-assigner.md
+++ b/docs/weight-assigner.md
@@ -1,0 +1,173 @@
+# Weight Assigner — Design & Behaviour
+
+## Purpose
+
+Maps raw Tier-0 perception agent outputs into a single **weighted composite score**
+using the v4 config factor-weight matrix. It is the "quantitative spine" of the
+arbitration pipeline — no LLM calls, deterministic math only.
+
+## Architecture
+
+```
+Tier-0 Contracts (9 agents)
+        │
+        ▼
+┌─────────────────────────────────────────────┐
+│          Weight Assigner                     │
+│                                              │
+│  1. Per-Agent Factor Extraction              │
+│     ┌─────────────────────────────────────┐  │
+│     │ 9 extractors mapped by agent_id     │  │
+│     │ Each reads contract fields          │  │
+│     │ Returns dict[factor_id → signal]    │  │
+│     └─────────────────────────────────────┘  │
+│                                              │
+│  2. Factor Normalization                     │
+│     ┌─────────────────────────────────────┐  │
+│     │ Raw → [0, 1] bullish direction      │  │
+│     │ 1.0 = max bullish conviction        │  │
+│     │ 0.0 = max bearish conviction        │  │
+│     │ 0.5 = neutral                       │  │
+│     └─────────────────────────────────────┘  │
+│                                              │
+│  3. Weighted Composite                       │
+│     ┌─────────────────────────────────────┐  │
+│     │ agent_composite = Σ(w_f × signal_f) │  │
+│     │ global_composite = Σ(w_a × comp_a)  │  │
+│     └─────────────────────────────────────┘  │
+│                                              │
+│  4. Confidence Formula                       │
+│     ┌─────────────────────────────────────┐  │
+│     │ confidence = |mag| × min(1.0,       │  │
+│     │   0.5 + consensus_ratio × 0.5)      │  │
+│     └─────────────────────────────────────┘  │
+│                                              │
+└─────────────────────────────────────────────┘
+        │
+        ▼
+  ArbitrationResult
+```
+
+## Core Formulas
+
+### Agent Composite
+
+```
+composite_a = Σ(factor_weight × signal_normalized)
+```
+
+Each agent has a defined factor set from the v4 config:
+
+| Agent     | Factors                                                    |
+|-----------|------------------------------------------------------------|
+| 1.1 Macro | macro_bias (regime 60% + liquidity 40%)                    |
+| 1.2 News  | sentiment 0.28, impact 0.38, event_type 0.19, freshness 0.15 |
+| 2.1 Pattern| setup 0.40, quality 0.30, timeframe 0.20, volume 0.10    |
+| 2.2 Stats | alpha_signal 0.50, z_score 0.25, regime 0.25              |
+| 2.3 TA    | rsi 0.15, macd 0.20, obv 0.10, atr 0.05, adx 0.15,       |
+|           | ema_cross 0.10, volume 0.15, pattern_rec 0.10              |
+| 3.1 Retail| fomo 0.35, social_volume 0.25, divergence 0.40             |
+| 3.2 SmartM| etf 0.40, funding_rate 0.30, oi_delta 0.30                |
+| 4.1 Whale | dump 0.50, concentration 0.25, wallet_flow 0.25            |
+|           | *(disabled by default)*                                    |
+| 4.2 LiqOF | slippage 0.35, imbalance 0.35, depth_skew 0.30            |
+
+### Global Composite
+
+```
+global_composite = Σ(agent_weight × composite_a) / Σ(enabled_agent_weights)
+```
+
+Agent weights from v4 config:
+
+| ID   | Weight | Agent Area          |
+|------|--------|---------------------|
+| 1.1  | 0.05   | Macro               |
+| 1.2  | 0.05   | News/Narrative      |
+| 2.1  | 0.25   | Pattern Recognition |
+| 2.2  | 0.10   | Statistical         |
+| 2.3  | 0.30   | Technical TA        |
+| 3.1  | 0.05   | Retail Sentiment    |
+| 3.2  | 0.05   | Smart Money         |
+| 4.2  | 0.15   | Liquidity/Flow      |
+
+**Key insight:** Technical (2.3) + Pattern (2.1) + Liquidity (4.2) = 70% of the vote.
+Macro + News + Sentiment + Smart Money = 20%.
+This reflects a **price-action-first** philosophy.
+
+### Confidence
+
+```
+magnitude        = |composite − 0.5| × 2.0        # [0, 1]
+consensus_ratio  = max(bullish_count, bearish_count) / total_enabled
+confidence       = magnitude × min(1.0, 0.5 + consensus_ratio × 0.5)
+```
+
+- **High confidence** (≥0.75): strong conviction, most agents agree
+- **Medium confidence** (≥0.55): directional bias but some disagreement
+- **Low confidence** (>0.0): weak signal
+- **None** (0.0): flat neutral, no conviction
+
+## Factor Extraction Behaviour
+
+### Normalization Strategy
+
+Each factor extractor interprets its agent's Tier-0 contract fields and maps them
+to `[0, 1]` where **1.0 is maximum bullish conviction**:
+
+| Raw Signal          | Bullish → 1.0 | Bearish → 0.0 |
+|---------------------|---------------|---------------|
+| RSI                 | 30 (oversold) | 70 (overbought)|
+| FOMO Level          | 0 (fear)      | 100 (euphoria) |
+| Setup Score         | 100           | 0              |
+| Z-Score             | +3.0          | −3.0           |
+| Slippage Risk       | 0 (tight)     | 100 (wide)     |
+| Macro Regime        | Risk-On       | Risk-Off       |
+
+Inverted signals (RSI, FOMO, Slippage) are explicitly `_invert()`-ed so the scale
+is **always bullish-direction**: you don't need to remember which raw values are
+"good" or "bad" — 1.0 always means "supports a long position."
+
+### Missing Data Handling
+
+When Tier-0 contracts are absent or fields are null:
+
+1. **Explicit defaults** — each extractor has hardcoded neutral (0.50) fallbacks
+2. **Proxy derivation** — missing fields are approximated from available ones
+   (e.g., social_volume derived from FOMO_Lewel)
+3. **No hallucination** — the engine never fabricates data; it explicitly tags
+   proxy fields in the `FactorSignal.source_field`
+
+## State Dependency
+
+The weight assigner reads **only** from these HedgeFundState keys:
+
+```
+tier0_contracts            → tier0_contracts_by_agent() index
+(no other state accessed)
+```
+
+This means it is **stateless**: given the same Tier-0 contracts, it always
+produces the same result. This is critical for:
+- **Deterministic backtesting** — identical contracts = identical scores
+- **Audit trail** — scores can be re-computed from stored contracts
+- **Testing** — no mocking needed beyond contract fixtures
+
+## Opt-In / Opt-Out
+
+| Mechanism              | Effect                                              |
+|------------------------|-----------------------------------------------------|
+| `disabled_agents` set  | Skips agent entirely (weight=0, no factors computed)|
+| Agent `enabled=false`  | Tier-0 contract still built, but excluded from score |
+| Weight overrides       | Runtime replacement of default weight map           |
+| Arbitrator mode switch | `weighted_convergence` → uses this engine           |
+
+## Edge Cases
+
+| Case                             | Behaviour                                                  |
+|----------------------------------|------------------------------------------------------------|
+| No Tier-0 contracts              | All agents return composite=0.5, global=0.5, confidence=0  |
+| Single agent enabled             | Global composite = that agent's composite                  |
+| All factors at boundary (0 or 1) | Agent composite clamped to [0,1], triggers max conviction  |
+| Disabled agents (e.g., whale 4.1)| Weight redistributed among remaining enabled agents        |
+| Weight sum ≠ 1.0                 | Normalized by total enabled weight, not rejected           |

--- a/docs/weighted-arbitrator.md
+++ b/docs/weighted-arbitrator.md
@@ -1,0 +1,202 @@
+# Weighted Convergence Arbitrator — Design & Behaviour
+
+## Purpose
+
+The arbitrator is the **decision gate** of the AIMM pipeline. It takes the
+weighted composite scores from the weight assigner, applies configurable
+thresholds, and produces an executable `trade_intent`.
+
+## Pipeline Position
+
+```
+Tier-0 Agents → desk_risk → desk_debate
+    → Weight Assigner (scores)
+    → Weighted Arbitrator (decision gate)
+    → portfolio_proposal → desk_risk_guard → portfolio_execute → audit
+```
+
+The arbitrator replaces the `signal_arbitrator` node. It is a **deterministic
+formula engine** — no LLM costs, no API latency, fully reproducible.
+
+## Decision Flow
+
+```
+                    ┌─────────────┐
+                    │ Composite   │
+                    │ Score [0,1] │
+                    └──────┬──────┘
+                           │
+                           ▼
+                 ┌─────────────────────┐
+                 │    Stance Switch    │
+                 │                     │
+                 │ ≥ 0.55 → bullish    │
+                 │ ≤ 0.45 → bearish    │
+                 │ else   → neutral    │
+                 └─────────┬───────────┘
+                           │
+                           ▼
+              ┌──────────────────────────┐
+              │   Decision Thresholds    │
+              │                          │
+              │ BUY:  composite ≥ 0.60   │
+              │       AND conf ≥ 0.50    │
+              │                          │
+              │ SELL: composite ≤ 0.40   │
+              │       AND conf ≥ 0.50    │
+              │                          │
+              │ HOLD: everything else    │
+              └──────────────────────────┘
+                           │
+                           ▼
+              ┌──────────────────────────┐
+              │    Alignment Gating      │
+              │                          │
+              │ If directional:          │
+              │   active_factors ≥ 3 ?   │
+              │   YES → let pass         │
+              │   NO  → override→HOLD    │
+              └──────────────────────────┘
+                           │
+                           ▼
+              ┌──────────────────────────┐
+              │     Trade Intent         │
+              │  (BUY / SELL / HOLD)     │
+              │  + confidence + reasons  │
+              └──────────────────────────┘
+```
+
+## Threshold Configuration
+
+From the v4 config:
+
+```json
+{
+  "decision_threshold": {
+    "buy":  { "min_composite": 60, "min_confidence": 50 },
+    "sell": { "max_composite": 40, "min_confidence": 50 },
+    "hold": { "else": true }
+  },
+  "alignment_gating": {
+    "enabled": true,
+    "min_factors_for_directional": 3,
+    "risk_override_if_blocked": true
+  }
+}
+```
+
+## Behaviour Matrix
+
+| Composite | Confidence | Consensus  | Stance    | Decision | Conviction |
+|-----------|------------|------------|-----------|----------|------------|
+| 0.72      | 0.82       | 6/8 bull   | bullish   | BUY      | high       |
+| 0.65      | 0.58       | 5/8 bull   | bullish   | BUY      | medium     |
+| 0.62      | 0.45       | 4/8 bull   | bullish   | HOLD     | low        |
+| 0.53      | 0.12       | 3/8 bull   | neutral   | HOLD     | none       |
+| 0.38      | 0.68       | 5/8 bear   | bearish   | SELL     | medium     |
+| 0.35      | 0.55       | 4/8 bear   | bearish   | HOLD     | low        |
+| 0.28      | 0.88       | 7/8 bear   | bearish   | SELL     | high       |
+
+**Key observations:**
+
+- **Composite must be directional AND confidence must clear threshold.**
+  High confidence with neutral composite → HOLD (correct — no clear direction).
+  Directional composite with low confidence → HOLD (conservative — disagreement).
+- **Alignment gating** blocks any BUY/SELL when fewer than 3 total factors
+  contributed to the score. Prevents decisions on thin data.
+- **Disabled agents** (e.g., whale 4.1) don't contribute to consensus ratio.
+
+## Output Shape
+
+The arbitrator produces a `proposed_signal` with the same contract shape as the
+LLM arbitrator, making it a **drop-in replacement**:
+
+```python
+{
+    "action": "PROPOSAL",
+    "params": {
+        "stance": "bullish",
+        "confidence": 0.74,
+        "reasons": ["BUY signal: composite=0.6727 >= 0.60, confidence=0.74 >= 0.50", ...],
+        "tool_events": [],
+        "debate_entries": 0,
+        "weighted_arbitrator": True,
+        "composite_score": 0.6727,
+        "conviction_level": "medium",
+        "consensus_ratio": 0.625,
+        "alignment_gated": False,
+        "agent_signals": [...]          # per-agent breakdown
+    },
+    "meta": {
+        "source": "weighted_arbitrator",
+        "mode": "weighted_convergence"
+    }
+}
+```
+
+## Reasoning Logs
+
+Each arbitrator run produces **one log entry per enabled agent** plus the global
+decision. Per-agent entries contain the full factor breakdown:
+
+```json
+{
+    "node": "signal_arbitrator",
+    "decision": {
+        "agent_id": "2.3",
+        "agent_type": "technical_ta",
+        "label": "Technical Analysis",
+        "composite": 0.7214,
+        "agent_weight": 0.30,
+        "weighted_composite": 0.2164,
+        "stance": "bullish",
+        "confidence": 0.943,
+        "factor_count": 8,
+        "factor_breakdown": {
+            "rsi": { "raw": 35.0, "normalized": 0.65, "weight": 0.15 },
+            "macd": { "raw": 15.0, "normalized": 0.85, "weight": 0.20 }
+        }
+    }
+}
+```
+
+## Opt-In / Opt-Out
+
+The arbitrator supports three modes via `AIMM_ARBITRATOR_MODE`:
+
+| Mode                   | Engine                   | Use Case                     |
+|------------------------|--------------------------|------------------------------|
+| `weighted_convergence` | `weighted_arbitrator.py` | Default — deterministic      |
+| `llm`                  | `signal_arbitrator_llm`  | LLM-based synthesis          |
+
+
+Additionally, disable the arbitrator entirely by setting `AIMM_ARBITRATOR_DISABLE=1`
+(not yet implemented — future: routes from desk_debate directly to portfolio_proposal
+with neutral stance).
+
+## Portability for Agentic Trading
+
+The arbitrator is designed as a **standalone module** with zero internal
+dependencies on HedgeFundState:
+
+| Component                  | Dependencies                              | Size  |
+|----------------------------|--------------------------------------------|-------|
+| `schemas/arbitration.py`   | None (pure dataclasses)                    | 161 lines |
+| `workflow/weight_assigner.py` | schemas.arbitration + tier0_contract  | 560 lines |
+| `workflow/weighted_arbitrator.py` | + execution_intent, tier2_context | 263 lines |
+
+To extract for agentic trading:
+
+1. Copy `schemas/arbitration.py` — no changes needed
+2. Copy `workflow/weight_assigner.py` — dependency on `tier0_contract_by_agent()`
+3. Provide a `Tier0ContractReader` interface instead of tight coupling
+
+## Edge Cases
+
+| Scenario                        | Behaviour                                              |
+|---------------------------------|--------------------------------------------------------|
+| Zero enabled agents             | Returns HOLD with composite=0.5, confidence=0.0        |
+| All agents neutral              | HOLD — no threshold cleared                            |
+| Perfect consensus (8/8 bullish) | Confidence capped at magnitude × 1.0                   |
+| Alignment gate blocks BUY       | Overridden to HOLD, logged with alignment_reason       |
+| Agent weight = 0.00             | Contributing agent skipped (not counted in consensus)  |

--- a/src/agents/governance/policy_orchestrator/SKILL.md
+++ b/src/agents/governance/policy_orchestrator/SKILL.md
@@ -1,0 +1,20 @@
+# Skill: Policy Orchestrator
+
+## Capabilities
+- `evaluate(signal, user_config)` → route decision + policy check
+- Direct query: "Is BTC allowed for this user?"
+- Direct query: "What are the current policy rules?"
+
+## Data Sources
+- `config/policy_loader.py` — runtime policy definitions
+- `config/policy_types.py` — policy schema
+
+## Query Interface
+```
+/policy_orchestrator?ticker=BTC/USDT&action=check
+```
+Returns: allowed/blocked + route + reason + policy_id.
+
+## Dependencies
+- `policy_loader` for hot-reloadable rules
+- No external API dependencies

--- a/src/agents/governance/policy_orchestrator/persona.md
+++ b/src/agents/governance/policy_orchestrator/persona.md
@@ -1,0 +1,30 @@
+# Persona: Policy Orchestrator
+
+## Role
+Policy Enforcement & Routing Governor — enforces runtime policies, trading rules, and channel routing.
+
+## Expertise
+- User-configured policy evaluation (min_confidence, max_position_size, allowed_assets)
+- Asset approval routing (allowed vs restricted tickers)
+- Execution engine selection (paper vs live)
+- Policy scope: per-user, per-asset, per-strategy
+
+## Reasoning Guidelines
+1. Always check `policy_loader` for applicable rules first
+2. Block trades that violate max_position_size or min_confidence
+3. Route to paper execution if not explicitly auto-approved
+4. Policies are hot-reloadable from `config/policy_loader.py`
+
+## Output
+```json
+{
+  "status": "allowed",
+  "route": "paper",
+  "reason": "below_max_position, no_confidence_gate",
+  "policy_id": "default_v4.0"
+}
+```
+
+## Operates
+- After Tier-2 desk_debate, before execution
+- Hard gate: blocks execution, never generates signals

--- a/src/agents/governance/portfolio_management/SKILL.md
+++ b/src/agents/governance/portfolio_management/SKILL.md
@@ -1,0 +1,22 @@
+# Skill: Portfolio Management
+
+## Capabilities
+- `get_state()` → portfolio snapshot
+- Direct query: "What's my current NAV?"
+- Direct query: "Show all open positions"
+
+## Data Sources
+- Trade book (in-memory + persistent)
+- Execution engine position feed
+- Cash balance from exchange/OMS
+
+## Query Interface
+```
+/portfolio_management?action=state
+/portfolio_management?action=positions
+```
+Returns: portfolio snapshot with NAV, exposure, positions.
+
+## Dependencies
+- `trade_book` for position tracking
+- Execution engine adapter

--- a/src/agents/governance/portfolio_management/persona.md
+++ b/src/agents/governance/portfolio_management/persona.md
@@ -1,0 +1,31 @@
+# Persona: Portfolio Management
+
+## Role
+Portfolio State & Allocation Manager — tracks current positions, PnL, and available capital.
+
+## Expertise
+- Position tracking: entry price, size, unrealized PnL
+- Portfolio NAV calculation
+- Available margin computation
+- Rebalancing signal detection
+
+## Reasoning Guidelines
+1. NAV = sum of (position_market_value + cash_balance)
+2. Available margin = NAV × max_leverage - gross_exposure
+3. Rebalance trigger: weight deviation > 5% from target
+4. PnL tracking per asset and total
+
+## Output
+```json
+{
+  "nav": 100000.00,
+  "gross_exposure": 25000.00,
+  "available_margin": 75000.00,
+  "max_position_size": 5000.00,
+  "positions": [{"ticker": "BTC/USDT", "side": "long", "size": 0.5, "upnl": 250.00}]
+}
+```
+
+## Operates
+- State provider: called by Risk Guard and downstream execution
+- No decision authority — provides data only

--- a/src/agents/governance/risk_guard/SKILL.md
+++ b/src/agents/governance/risk_guard/SKILL.md
@@ -1,0 +1,21 @@
+# Skill: Risk Guard
+
+## Capabilities
+- `validate(signal, portfolio_state)` → risk gate result
+- Direct query: "What's my current drawdown?"
+- Direct query: "Is it safe to open a new BTC position?"
+
+## Data Sources
+- Portfolio state from `portfolio_management`
+- `config/fund_policy.py` — fund-level risk limits
+- Runtime PnL from execution engine
+
+## Query Interface
+```
+/risk_guard?ticker=BTC/USDT&side=long&size=0.5
+```
+Returns: approved/blocked + per-gate flags.
+
+## Dependencies
+- `fund_policy` for limits
+- Portfolio state estimator

--- a/src/agents/governance/risk_guard/persona.md
+++ b/src/agents/governance/risk_guard/persona.md
@@ -1,0 +1,32 @@
+# Persona: Risk Guard
+
+## Role
+Risk Management Gate — validates all trade decisions against hard risk limits before execution.
+
+## Expertise
+- Position size limits per asset and total
+- Portfolio exposure cap (max β-hedged leverage)
+- Gap risk monitoring (weekend/holiday exposure)
+- Emergency stop-loss override
+- Drawdown circuit breaker
+
+## Reasoning Guidelines
+1. Max single-asset exposure: configurable % of NAV
+2. Total gross exposure: hard cap from `fund_policy`
+3. Weekend gap risk → reduce position size pre-close
+4. Circuit breaker: if PnL drawdown exceeds threshold, block ALL new trades
+
+## Output
+```json
+{
+  "status": "approved",
+  "position_size_ok": true,
+  "exposure_ok": true,
+  "gap_risk_ok": true,
+  "drawdown_ok": true
+}
+```
+
+## Operates
+- After Policy Orchestrator, before execution
+- Hard gate: can override all upstream agent decisions

--- a/src/agents/operator/1.1_monetary_sentinel/SKILL.md
+++ b/src/agents/operator/1.1_monetary_sentinel/SKILL.md
@@ -1,0 +1,21 @@
+# Skill: Monetary Sentinel (1.1)
+
+## Capabilities
+- `analyze(ticker, market_data, nexus_context)` → Tier-0 contract
+- Direct query: "What's the current macro regime for BTC?"
+- Direct query: "Is there a liquidity crisis signal?"
+
+## Data Sources
+- Nexus Global Bundle (macro endpoints)
+- CCXT market_data (BTC futures premium)
+- DXY/BTC correlation cache
+
+## Query Interface
+```
+/monetary_sentinel?ticker=BTC/USDT
+```
+Returns: macro regime state + confidence + reasoning.
+
+## Dependencies
+- `NexusDataClient` for global macro feeds
+- Falls back to price-only stubs when Nexus is disabled

--- a/src/agents/operator/1.1_monetary_sentinel/persona.md
+++ b/src/agents/operator/1.1_monetary_sentinel/persona.md
@@ -1,0 +1,31 @@
+# Persona: Monetary Sentinel (1.1)
+
+## Role
+Macro Regime Analyst — monitors global liquidity conditions, systemic risk, and monetary policy signals.
+
+## Expertise
+- Central bank policy analysis (Fed, ECB, PBOC, BOJ)
+- Liquidity regime classification (Risk-On / Risk-Off / Neutral)
+- Macro correlation: DXY → BTC, US10Y → risk assets
+- Systemic beta estimation
+
+## Reasoning Guidelines
+1. Start with macro regime: liquidity expansion → Risk-On, contraction → Risk-Off
+2. Rate decisions + treasury yields are primary signals
+3. Weigh macro over micro — a Risk-Off regime overrides bullish TA setups
+4. Output: macro_regime_state (0=Risk-Off, 1=Neutral, 2=Risk-On) + regime_prob
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "1.1",
+  "macro_regime_state": 2,
+  "regime_prob": 0.78,
+  "Liquidity_Score": 82
+}
+```
+
+## Few-Shot
+- **Input:** Fed holds rates, DXY weak, US10Y flat → **Output:** Risk-On, regime_prob=0.70
+- **Input:** PBOC tightens, DXY spikes → **Output:** Risk-Off, regime_prob=0.65

--- a/src/agents/operator/1.2_news_narrative_miner/SKILL.md
+++ b/src/agents/operator/1.2_news_narrative_miner/SKILL.md
@@ -1,0 +1,20 @@
+# Skill: News Narrative Miner (1.2)
+
+## Capabilities
+- `analyze(ticker, market_data, nexus_context)` → Tier-0 contract
+- Direct query: "Any breaking news impacting BTC?"
+- Direct query: "What's the current narrative phase?"
+
+## Data Sources
+- Nexus News API
+- News decay timeline (in-memory)
+
+## Query Interface
+```
+/news_narrative_miner?ticker=BTC/USDT
+```
+Returns: impact score + event type + decay + reasoning.
+
+## Dependencies
+- `NexusDataClient` news endpoints
+- Falls back to neutral stubs when Nexus disabled

--- a/src/agents/operator/1.2_news_narrative_miner/persona.md
+++ b/src/agents/operator/1.2_news_narrative_miner/persona.md
@@ -1,0 +1,31 @@
+# Persona: News Narrative Miner (1.2)
+
+## Role
+News & Narrative Impact Analyst — scans news events, measures shock potential, classifies event severity.
+
+## Expertise
+- Black swan detection: sudden news impact ≥ 80
+- Narrative lifecycle: Narrative inception → amplification → peak → fatigue
+- News decay modeling: how fast a news event fades from price relevance
+- Breaker score: combined magnitude + velocity of news-driven moves
+
+## Reasoning Guidelines
+1. News_Impact_Score = f(magnitude, coverage, market reaction)
+2. Event_Type classification: Routine → Elevated → Major Catalyst → Black Swan
+3. Black Swan events (≥80 impact) trigger automatic bear tilt + block_aggressive_long
+4. Decay_factor controls how many bars this news remains relevant
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "1.2",
+  "News_Impact_Score": 72,
+  "Event_Type": "Major Catalyst",
+  "decay_factor": 0.85
+}
+```
+
+## Few-Shot
+- **Input:** Regulatory crackdown headlines, -8% flash crash → **Output:** Impact=88, Black Swan
+- **Input:** ETF inflow report, +2% move → **Output:** Impact=45, Major Catalyst

--- a/src/agents/operator/2.1_pattern_recognition_bot/SKILL.md
+++ b/src/agents/operator/2.1_pattern_recognition_bot/SKILL.md
@@ -1,0 +1,20 @@
+# Skill: Pattern Recognition Bot (2.1)
+
+## Capabilities
+- `analyze(ticker, market_data)` → Tier-0 contract with pattern + setup score
+- Direct query: "What pattern is forming on BTC?"
+- Direct query: "Where is the support level?"
+
+## Data Sources
+- OHLCV bars (internal)
+- Pre-computed Kalman filter estimates
+
+## Query Interface
+```
+/pattern_recognition_bot?ticker=BTC/USDT
+```
+Returns: setup score + pattern label + support level + reasoning.
+
+## Dependencies
+- `src/ta/pattern_engine.py` — pattern detection
+- Kalman filter from statistical utilities

--- a/src/agents/operator/2.1_pattern_recognition_bot/persona.md
+++ b/src/agents/operator/2.1_pattern_recognition_bot/persona.md
@@ -1,0 +1,31 @@
+# Persona: Pattern Recognition Bot (2.1)
+
+## Role
+Chart Pattern & Setup Analyst — identifies technical chart patterns, support/resistance levels, and structural setups.
+
+## Expertise
+- Classical patterns: head & shoulders, double top/bottom, flags, wedges
+- Kalman filter support/resistance estimation
+- Setup quality scoring: 0–100 based on pattern clarity + confluence
+- Multi-timeframe confirmation validation
+
+## Reasoning Guidelines
+1. Primary signal: setup_confidence_score (0–100)
+2. Support detected via Kalman filter → output as kalman_support
+3. Pattern labels: bull_flag, bear_flag, ascending_triangle, descending_triangle, etc.
+4. Setup_Score ≥ 70 → bullish vote in consensus
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "2.1",
+  "Setup_Score": 85,
+  "kalman_support": 64500.00,
+  "pattern": "bull_flag"
+}
+```
+
+## Few-Shot
+- **Input:** BTC 4H shows ascending triangle, clear support → **Output:** Setup=82, pattern=ascending_triangle
+- **Input:** Indecision doji, no clear structure → **Output:** Setup=25, pattern=unknown

--- a/src/agents/operator/2.2_statistical_alpha_engine/SKILL.md
+++ b/src/agents/operator/2.2_statistical_alpha_engine/SKILL.md
@@ -1,0 +1,20 @@
+# Skill: Statistical Alpha Engine (2.2)
+
+## Capabilities
+- `analyze(ticker, market_data)` → Tier-0 contract with cross-sectional ranking
+- Direct query: "How does BTC rank in the universe?"
+- Direct query: "What's the cross-sectional z-score of ETH?"
+
+## Data Sources
+- Universe-wide OHLCV (all tracked symbols)
+- Factor model cache (momentum, value, volatility, on-chain)
+
+## Query Interface
+```
+/statistical_alpha_engine?ticker=BTC/USDT
+```
+Returns: cross-sectional rank + z-score + alpha signal + factor confluence.
+
+## Dependencies
+- Universe config from `src/config/default_universe.py`
+- Factor computation pipeline (statistical methods)

--- a/src/agents/operator/2.2_statistical_alpha_engine/persona.md
+++ b/src/agents/operator/2.2_statistical_alpha_engine/persona.md
@@ -1,0 +1,31 @@
+# Persona: Statistical Alpha Engine (2.2)
+
+## Role
+Cross-Sectional Alpha & Factor Analyst — ranks assets statistically, identifies divergence from peers.
+
+## Expertise
+- Cross-sectional ranking across multi-asset universe
+- Z-score estimation for outlier detection
+- Factor confluence scoring (multi-factor agreement)
+- Long/short alpha signal classification (Strong Buy → Strong Sell)
+
+## Reasoning Guidelines
+1. Cross-sectional rank (1 = strongest, N = weakest) is primary
+2. Z-score ≥ |2.0| is statistically meaningful divergence
+3. Factor_Confluence: % of aligned factors — 95% when top-3, 75% when top-10
+4. Alpha signal: Strong Buy (top decile), Strong Sell (bottom decile), Hold (middle)
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "2.2",
+  "Factor_Confluence": 95,
+  "cross_sectional_z_score": 2.45,
+  "alpha_signal": "Strong Buy"
+}
+```
+
+## Few-Shot
+- **Input:** BTC ranked #2/40, momentum + value + on-chain aligned → **Output:** Strong Buy, z=2.45
+- **Input:** BTC ranked #35/40, 3/5 factors bearish → **Output:** Strong Sell, z=-2.10

--- a/src/agents/operator/2.3_technical_ta_engine/SKILL.md
+++ b/src/agents/operator/2.3_technical_ta_engine/SKILL.md
@@ -1,0 +1,20 @@
+# Skill: Technical TA Engine (2.3)
+
+## Capabilities
+- `analyze(ticker, market_data)` → Tier-0 contract with indicator bundle
+- Direct query: "What's the RSI of BTC?"
+- Direct query: "Show MACD for ETH"
+
+## Data Sources
+- OHLCV bars (configurable period & count)
+- Indicator catalog: RSI, MACD, BB, EMA, SMA, ATR, Ichimoku
+
+## Query Interface
+```
+/technical_ta_engine?ticker=BTC/USDT&period=4h&bars=100
+```
+Returns: full indicator bundle + status.
+
+## Dependencies
+- `ta` Python library or custom indicator implementation
+- Exchange OHLCV fetcher

--- a/src/agents/operator/2.3_technical_ta_engine/persona.md
+++ b/src/agents/operator/2.3_technical_ta_engine/persona.md
@@ -1,0 +1,41 @@
+# Persona: Technical TA Engine (2.3)
+
+## Role
+Classical Technical Indicator Analyst — computes and interprets standard TA indicators.
+
+## Expertise
+- RSI, MACD, Bollinger Bands, moving averages, Ichimoku
+- Indicator-based market state: overbought/oversold, trend strength, volatility
+- Multi-indicator confluence: 3+ aligned signals → high conviction
+- Timeframe-aware indicator computation
+
+## Reasoning Guidelines
+1. RSI > 70 → overbought (bearish), RSI < 30 → oversold (bullish)
+2. MACD cross + volume confirmation → trend signal
+3. Bollinger Band squeeze → volatility expansion imminent
+4. Bundle all computed indicators into `ta_indicators` dict
+5. RSI ≥ 70 contributes bear vote to consensus; RSI ≤ 30 contributes bull vote
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "2.3",
+  "ta_period": "4h",
+  "bars_used": 100,
+  "indicator_catalog_version": "ta_bundle/v1",
+  "ta_indicators": {
+    "rsi": 72.5,
+    "macd": -124.3,
+    "macd_signal": -98.7,
+    "bb_upper": 72000.0,
+    "bb_lower": 64000.0,
+    "ema_20": 68200.0,
+    "ema_50": 66500.0
+  }
+}
+```
+
+## Few-Shot
+- **Input:** BTC 4H: RSI=72, MACD bearish cross, BB width=8% → **Output:** rsi=72.5, macd_cross=confirms
+- **Input:** BTC 1H: RSI=28, bullish MACD cross, volume surge → **Output:** rsi=28.0, macd_cross=bullish

--- a/src/agents/operator/3.1_retail_hype_tracker/SKILL.md
+++ b/src/agents/operator/3.1_retail_hype_tracker/SKILL.md
@@ -1,0 +1,21 @@
+# Skill: Retail Hype Tracker (3.1)
+
+## Capabilities
+- `analyze(ticker, market_data, nexus_context)` → Tier-0 contract
+- Direct query: "Is retail getting euphoric on BTC?"
+- Direct query: "Any divergence warning?"
+
+## Data Sources
+- Nexus SocialSentiment API
+- Funding rate (CEX perpetual futures)
+- Twitter/Reddit volume (when available)
+
+## Query Interface
+```
+/retail_hype_tracker?ticker=BTC/USDT
+```
+Returns: FOMO level + divergence warning + sentiment z-score.
+
+## Dependencies
+- `NexusDataClient` for sentiment endpoints
+- Falls back to funding-rate only proxy when Nexus disabled

--- a/src/agents/operator/3.1_retail_hype_tracker/persona.md
+++ b/src/agents/operator/3.1_retail_hype_tracker/persona.md
@@ -1,0 +1,32 @@
+# Persona: Retail Hype Tracker (3.1)
+
+## Role
+Retail Sentiment Analyst — measures retail crowd euphoria and divergence risk.
+
+## Expertise
+- FOMO level estimation from social volume + price action
+- Sentiment z-score: statistical deviation from mean sentiment
+- Divergence warning: price up + sentiment declining → exhaustion signal
+- Social aggregation: tweets, reddit, telegram volume
+
+## Reasoning Guidelines
+1. FOMO_Level: 0–100 composite of social volume + funding rate + retail flow
+2. Divergence_Warning = True when price and sentiment decouple
+3. Sentiment_z_score > 2.0 → extreme bullish (contrarian bearish)
+4. Sentiment_z_score < -2.0 → extreme bearish (contrarian bullish)
+5. FOMO ≥ 80 + Divergence → bear vote + warning
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "3.1",
+  "FOMO_Level": 88,
+  "Divergence_Warning": true,
+  "sentiment_z_score": 2.35
+}
+```
+
+## Few-Shot
+- **Input:** Social volume surging, BTC at ATH, funding 0.15% → **Output:** FOMO=92, divergence=true
+- **Input:** Social volume normal, price steady → **Output:** FOMO=45, divergence=false

--- a/src/agents/operator/3.2_pro_bias_analyst/SKILL.md
+++ b/src/agents/operator/3.2_pro_bias_analyst/SKILL.md
@@ -1,0 +1,21 @@
+# Skill: Pro Bias Analyst (3.2)
+
+## Capabilities
+- `analyze(ticker, market_data, nexus_context)` → Tier-0 contract
+- Direct query: "Is smart money buying or selling BTC?"
+- Direct query: "What's the ETF flow trend?"
+
+## Data Sources
+- Nexus ETF endpoints
+- Futures basis (perpetual vs spot premium)
+- Options skew (25-delta risk reversal)
+
+## Query Interface
+```
+/pro_bias_analyst?ticker=BTC/USDT
+```
+Returns: pro bias score + ETF trend + ema slope.
+
+## Dependencies
+- `NexusDataClient` for ETF + options data
+- Falls back to basis-only analysis when Nexus disabled

--- a/src/agents/operator/3.2_pro_bias_analyst/persona.md
+++ b/src/agents/operator/3.2_pro_bias_analyst/persona.md
@@ -1,0 +1,31 @@
+# Persona: Pro Bias Analyst (3.2)
+
+## Role
+Smart Money & Institutional Flow Analyst — tracks professional trader positioning and ETF flows.
+
+## Expertise
+- ETF fund flow analysis: accumulation vs distribution patterns
+- Pro bias score: institutional sentiment from futures basis + options skew
+- EMA slope analysis for trend direction (smart money trend)
+- COT-like positioning proxy from public data
+
+## Reasoning Guidelines
+1. Pro_Bias: 0–100, higher = more institutional bullish
+2. ETF_Trend: Accumulation / Distribution / Neutral from ETF flow data
+3. EMA_slope: positive = uptrend confidence, negative = distribution signal
+4. ETF_Accumulation → bull vote; ETF_Distribution → bear vote
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "3.2",
+  "Pro_Bias": 72,
+  "ETF_Trend": "Accumulation",
+  "ema_slope": 0.08
+}
+```
+
+## Few-Shot
+- **Input:** 3 consecutive days of BTC ETF net inflow, futures premium → **Output:** Accumulation, bias=72
+- **Input:** ETF outflow, declining basis → **Output:** Distribution, bias=35

--- a/src/agents/operator/4.1_whale_behavior_analyst/SKILL.md
+++ b/src/agents/operator/4.1_whale_behavior_analyst/SKILL.md
@@ -1,0 +1,20 @@
+# Skill: Whale Behavior Analyst (4.1)
+
+## Capabilities
+- `analyze(ticker, market_data, nexus_context)` → Tier-0 contract
+- Direct query: "Are whales dumping BTC?"
+- Direct query: "What's the exchange flow balance?"
+
+## Data Sources
+- Nexus On-Chain endpoints (whale tx, exchange flow)
+- Large transaction monitoring
+
+## Query Interface
+```
+/whale_behavior_analyst?ticker=BTC/USDT
+```
+Returns: sell pressure gauge + dump probability + dry powder alert.
+
+## Dependencies
+- `NexusDataClient` on-chain endpoints
+- Opt-in only: disabled by default in weights

--- a/src/agents/operator/4.1_whale_behavior_analyst/persona.md
+++ b/src/agents/operator/4.1_whale_behavior_analyst/persona.md
@@ -1,0 +1,32 @@
+# Persona: Whale Behavior Analyst (4.1)
+
+## Role
+On-Chain Whale Activity Analyst — monitors large holder behavior and exchange flow dynamics.
+
+## Expertise
+- Dump probability estimation from whale wallet activity
+- Exchange inflow/outflow analysis (dry powder indicator)
+- Whale cluster detection: coordinated wallet movement
+- Sell pressure gauge: aggregate of whale-to-exchange flow
+
+## Reasoning Guidelines
+1. Sell_Pressure_Gauge: 0–100, higher = more imminent sell pressure
+2. Dump_Probability: float 0–1, raw probability estimate
+3. Dry_Powder_Alert: High = whales sending to exchanges, Low = withdrawing
+4. Dump_Probability ≥ 0.65 → bear vote
+5. Disabled by default (AGENT_WEIGHTS_DEFAULT=0.05) — opt-in for on-chain traders
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "4.1",
+  "Sell_Pressure_Gauge": 78,
+  "Dump_Probability": 0.72,
+  "Dry_Powder_Alert": "High"
+}
+```
+
+## Few-Shot
+- **Input:** 3 large wallets deposited to Binance, +5000 BTC → **Output:** Gauge=85, Dump=0.78, Alert=High
+- **Input:** Cold wallet accumulation, exchange outflows → **Output:** Gauge=22, Dump=0.15, Alert=Low

--- a/src/agents/operator/4.2_liquidity_order_flow/SKILL.md
+++ b/src/agents/operator/4.2_liquidity_order_flow/SKILL.md
@@ -1,0 +1,20 @@
+# Skill: Liquidity Order Flow Analyst (4.2)
+
+## Capabilities
+- `analyze(ticker, market_data, nexus_context)` → Tier-0 contract
+- Direct query: "What's the slippage risk on BTC?"
+- Direct query: "Is the order book balanced?"
+
+## Data Sources
+- Nexus Depth data (order book snapshots)
+- Exchange L2 order book (when available)
+
+## Query Interface
+```
+/liquidity_order_flow?ticker=BTC/USDT
+```
+Returns: slippage risk + order imbalance + POC price.
+
+## Dependencies
+- `NexusDataClient` depth endpoints
+- Falls back to stub estimators when depth data unavailable

--- a/src/agents/operator/4.2_liquidity_order_flow/persona.md
+++ b/src/agents/operator/4.2_liquidity_order_flow/persona.md
@@ -1,0 +1,32 @@
+# Persona: Liquidity Order Flow Analyst (4.2)
+
+## Role
+Order Flow & Liquidity Analyst — monitors market microstructure, slippage risk, and order book imbalance.
+
+## Expertise
+- Slippage risk estimation from order book depth
+- Order imbalance: bid vs ask volume delta
+- POC (Point of Control) price detection
+- Microstructure regime: liquid / normal / illiquid
+
+## Reasoning Guidelines
+1. Slippage_Risk_Score: 0–100, higher = worse liquidity
+2. Order_Imbalance: positive = buy pressure, negative = sell pressure
+3. POC_Price: the price level with highest traded volume
+4. Slippage ≥ 80 → bear vote (high friction for execution)
+5. Requires depth data — falls back to inferred scores when Nexus depth unavailable
+
+## Output Contract
+```json
+{
+  "schema_version": "tier0/v1",
+  "agent": "4.2",
+  "Slippage_Risk_Score": 65,
+  "Order_Imbalance": -1.4,
+  "POC_Price": 67800.00
+}
+```
+
+## Few-Shot
+- **Input:** Thin order book, wide spread, -2.0 imbalance → **Output:** Slippage=85, Imbalance=-2.0
+- **Input:** Deep book, balanced bid/ask → **Output:** Slippage=30, Imbalance=0.3

--- a/src/agents/profile_agent.py
+++ b/src/agents/profile_agent.py
@@ -1,0 +1,264 @@
+"""Profile Agent — maps a 5-question onboarding wizard to agent weight deltas."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from typing import Any
+
+from config.llm_mode import llm_mode_enabled
+
+# Default base weights (mirrors weighted_arbitrator._V4_AGENT_WEIGHTS)
+AGENT_WEIGHTS_DEFAULT: dict[str, float] = {
+    "1.1": 0.05,
+    "1.2": 0.05,
+    "2.1": 0.25,
+    "2.2": 0.10,
+    "2.3": 0.30,
+    "3.1": 0.05,
+    "3.2": 0.05,
+    "4.1": 0.05,
+    "4.2": 0.15,
+}
+
+AGENT_LABELS: dict[str, str] = {
+    "1.1": "monetary_sentinel (Macro Regime)",
+    "1.2": "news_narrative_miner (News & Narrative)",
+    "2.1": "pattern_recognition_bot (Chart Patterns)",
+    "2.2": "statistical_alpha_engine (Statistical Alpha)",
+    "2.3": "technical_ta_engine (Technical TA)",
+    "3.1": "retail_hype_tracker (Retail Sentiment)",
+    "3.2": "pro_bias_analyst (Smart Money)",
+    "4.1": "whale_behavior_analyst (On-Chain Whale)",
+    "4.2": "liquidity_order_flow (Order Flow)",
+}
+
+_WEIGHT_RULES: list[tuple[str, str, str, str, str, dict[str, float]]] = [
+    (
+        "conservative",
+        "position",
+        "*",
+        "*",
+        "*",
+        {"1.1": 0.10, "2.3": 0.05, "3.1": -0.03, "4.2": -0.05},
+    ),
+    (
+        "conservative",
+        "swing",
+        "*",
+        "*",
+        "*",
+        {"1.1": 0.05, "2.3": 0.05, "3.1": -0.02, "4.2": -0.03},
+    ),
+    (
+        "aggressive",
+        "scalping",
+        "*",
+        "*",
+        "*",
+        {"2.1": 0.10, "4.2": 0.10, "1.1": -0.03, "1.2": -0.03},
+    ),
+    (
+        "aggressive",
+        "intraday",
+        "*",
+        "*",
+        "*",
+        {"2.1": 0.05, "4.2": 0.05, "3.1": 0.03, "1.1": -0.02},
+    ),
+    ("aggressive", "*", "*", "5x+", "*", {"2.1": 0.08, "4.2": 0.05, "3.1": 0.05, "1.2": -0.03}),
+    ("*", "*", "technical", "*", "*", {"2.3": 0.10, "2.1": 0.05, "3.1": -0.05, "1.2": -0.05}),
+    ("*", "*", "onchain", "*", "*", {"4.1": 0.15, "4.2": 0.05, "2.3": -0.10, "2.1": -0.05}),
+    ("*", "*", "news", "*", "*", {"1.2": 0.15, "3.1": 0.05, "2.3": -0.10, "2.1": -0.05}),
+    ("*", "*", "sentiment", "*", "*", {"3.1": 0.15, "3.2": 0.05, "2.3": -0.10, "2.1": -0.05}),
+    ("*", "*", "mixed", "*", "*", {"1.2": 0.03, "3.1": 0.03, "3.2": 0.03, "2.3": -0.05}),
+    ("*", "*", "*", "1x", "*", {"2.3": 0.05, "1.1": 0.05, "3.1": -0.02, "4.2": -0.02}),
+    ("*", "*", "*", "3-5x", "*", {"2.1": 0.05, "3.1": 0.03, "4.2": 0.03, "1.1": -0.03}),
+    ("*", "*", "*", "*", "majors_only", {"2.3": 0.05, "3.1": -0.03, "4.1": -0.03}),
+    ("*", "*", "*", "*", "full_universe", {"3.1": 0.08, "3.2": 0.05, "4.1": 0.05, "2.3": -0.10}),
+    ("*", "*", "*", "*", "majors_alts", {"2.1": 0.03, "3.2": 0.03, "1.2": 0.02}),
+]
+
+_NARRATIVE_BY_STYLE: dict[str, str] = {
+    ("conservative", "position", "fundamental"): "Defensive Value Investor",
+    ("conservative", "swing", "technical"): "Conservative Technician",
+    ("moderate", "swing", "technical"): "Balanced Technician",
+    ("moderate", "intraday", "mixed"): "Adaptive Trader",
+    ("aggressive", "scalping", "technical"): "Scalping Technician",
+    ("aggressive", "intraday", "sentiment"): "Sentiment Momentum Trader",
+    ("aggressive", "swing", "onchain"): "On-Chain Alpha Hunter",
+    ("aggressive", "intraday", "technical"): "Aggressive Momentum Trader",
+    ("moderate", "intraday", "technical"): "Technical Swing Trader",
+    ("conservative", "intraday", "technical"): "Conservative Swing Trader",
+    ("moderate", "swing", "mixed"): "Diversified Analyst",
+}
+
+_NARRATIVE_DEFAULT = "Custom Profile"
+
+
+def _match_wildcard(pattern: str, value: str) -> bool:
+    """Simple wildcard match: '*' matches anything."""
+    return pattern == "*" or pattern == value
+
+
+def _compute_deltas(
+    risk: str, horizon: str, signals: str, leverage: str, assets: str
+) -> dict[str, float]:
+    """Apply all matching rules, summing deltas."""
+    out: dict[str, float] = {}
+    for r, h, s, lev, a, delta in _WEIGHT_RULES:
+        if (
+            _match_wildcard(r, risk)
+            and _match_wildcard(h, horizon)
+            and _match_wildcard(s, signals)
+            and _match_wildcard(lev, leverage)
+            and _match_wildcard(a, assets)
+        ):
+            for k, v in delta.items():
+                out[k] = out.get(k, 0.0) + v
+    return out
+
+
+def _apply_deltas(base: dict[str, float], deltas: dict[str, float]) -> dict[str, float]:
+    """Apply deltas to base weights and re-normalize to sum=1.0."""
+    temp = dict(base)
+    for k, v in deltas.items():
+        temp[k] = max(0.01, min(0.50, temp.get(k, 0.05) + v))
+
+    # Normalize
+    total = sum(temp.values())
+    if total <= 0:
+        return dict(base)
+    return {k: round(v / total, 4) for k, v in temp.items()}
+
+
+def _resolve_narrative(risk: str, horizon: str, signals: str) -> str:
+    key = (risk, horizon, signals)
+    direct = _NARRATIVE_BY_STYLE.get(key)
+    if direct:
+        return direct
+    if risk == "aggressive":
+        return "Aggressive Momentum Trader"
+    if risk == "conservative":
+        return "Defensive Investor"
+    return _NARRATIVE_DEFAULT
+
+
+class ProfileAgent:
+    """Generate personalised agent weights (rule-based; optional LLM via AIMM_LLM_PROFILE=1)."""
+
+    def __init__(self) -> None:
+        self.llm_enabled = llm_mode_enabled() and (os.getenv("AIMM_LLM_PROFILE", "0") == "1")
+
+    def _build_prompt(self, answers: dict[str, str]) -> str:
+        return (
+            "You are a trading profile analyst. Based on these user answers, "
+            "output a JSON object with agent weight deltas and reasoning.\n\n"
+            f"User Profile:\n"
+            f"- Risk Tolerance: {answers.get('risk_tolerance', 'moderate')}\n"
+            f"- Time Horizon: {answers.get('time_horizon', 'swing')}\n"
+            f"- Preferred Signals: {answers.get('preferred_signals', 'technical')}\n"
+            f"- Leverage Comfort: {answers.get('leverage_comfort', '3-5x')}\n"
+            f"- Asset Focus: {answers.get('assets', 'majors_only')}\n\n"
+            "Available agents with current base weights:\n"
+            + "\n".join(
+                f"  {aid}: {AGENT_LABELS.get(aid, aid)} (base={AGENT_WEIGHTS_DEFAULT.get(aid, 0.05):.2f})"
+                for aid in sorted(AGENT_WEIGHTS_DEFAULT)
+            )
+            + "\n\n"
+            "Rules:\n"
+            "1. Deltas are ADDITIVE to base weights (e.g., +0.10 means add 0.10)\n"
+            "2. Final effective weight = max(0.01, min(0.50, base + delta))\n"
+            "3. Deltas must be in the range [-0.15, +0.15]\n"
+            "4. The final weights will be re-normalized to sum 1.0\n"
+            "5. Provide a concise reasoning string (1-2 sentences)\n"
+            "6. Output valid JSON ONLY, no markdown:\n"
+            '{"deltas": {"2.1": 0.10, "2.3": -0.05}, "reasoning": "...", "narrative": "..."}'
+        )
+
+    def _llm_generate(self, answers: dict[str, str]) -> dict[str, Any] | None:
+        try:
+            from llm.openai_client import run_tool_calling_chat
+
+            prompt = self._build_prompt(answers)
+            response = run_tool_calling_chat(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.0,
+                max_tokens=800,
+            )
+            content = response.choices[0].message.content if response else None
+            if not content:
+                return None
+            # Strip markdown fences if present
+            cleaned = content.strip()
+            if cleaned.startswith("```"):
+                cleaned = cleaned.split("\n", 1)[1] if "\n" in cleaned else cleaned
+                cleaned = cleaned.rsplit("```", 1)[0].strip()
+            parsed = json.loads(cleaned)
+            if not isinstance(parsed, dict):
+                return None
+            return parsed
+        except Exception:
+            return None
+
+    def process(self, input_data: dict[str, Any]) -> dict[str, Any]:
+        risk = str(input_data.get("risk_tolerance", "moderate")).lower()
+        horizon = str(input_data.get("time_horizon", "swing")).lower()
+        signals = str(input_data.get("preferred_signals", "technical")).lower()
+        leverage = str(input_data.get("leverage_comfort", "1-3x")).lower()
+        assets = str(input_data.get("assets", "majors_only")).lower()
+
+        llm_result = None
+        if self.llm_enabled:
+            llm_result = self._llm_generate(
+                {
+                    "risk_tolerance": risk,
+                    "time_horizon": horizon,
+                    "preferred_signals": signals,
+                    "leverage_comfort": leverage,
+                    "assets": assets,
+                }
+            )
+
+        if llm_result and isinstance(llm_result.get("deltas"), dict):
+            deltas_raw = {str(k): float(v) for k, v in llm_result["deltas"].items()}
+            deltas = deltas_raw
+            reasoning = str(llm_result.get("reasoning", "LLM-generated profile."))
+            narrative = str(llm_result.get("narrative", _resolve_narrative(risk, horizon, signals)))
+            source = "llm"
+        else:
+            deltas = _compute_deltas(risk, horizon, signals, leverage, assets)
+            reasoning = (
+                f"Rule-based profile: {risk} risk, {horizon} horizon, "
+                f"{signals} signals, {leverage} leverage, {assets} assets."
+            )
+            narrative = _resolve_narrative(risk, horizon, signals)
+            source = "rule"
+
+        effective = _apply_deltas(AGENT_WEIGHTS_DEFAULT, deltas)
+
+        raw_id = f"{risk}|{horizon}|{signals}|{leverage}|{assets}|{source}|{time.time()}"
+        profile_id = "user_" + hashlib.sha256(raw_id.encode()).hexdigest()[:12]
+
+        return {
+            "profile_id": profile_id,
+            "base": "AGENT_WEIGHTS_DEFAULT",
+            "deltas": {k: f"{v:+0.2f}" for k, v in sorted(deltas.items())},
+            "effective_weights": effective,
+            "narrative": narrative,
+            "source": source,
+            "reasoning": reasoning,
+            "timestamp": int(time.time()),
+            "input": {
+                "risk_tolerance": risk,
+                "time_horizon": horizon,
+                "preferred_signals": signals,
+                "leverage_comfort": leverage,
+                "assets": assets,
+            },
+        }
+
+
+__all__ = ["ProfileAgent", "AGENT_WEIGHTS_DEFAULT", "AGENT_LABELS"]

--- a/src/agents/profile_agent/SKILL.md
+++ b/src/agents/profile_agent/SKILL.md
@@ -1,0 +1,27 @@
+# Skill: Profile Agent
+
+## Capabilities
+- `process(questionnaire)` → weight deltas + narrative
+- Direct query: "Generate a profile for a conservative swing trader"
+- Direct query: "What weights would an aggressive scalper get?"
+
+## Data Sources
+- Built-in rule matrix (no external dependencies)
+- Optional LLM client (Hermes/OpenAI)
+
+## Query Interface
+```
+POST /profile-agent
+{
+  "risk_tolerance": "moderate",
+  "time_horizon": "swing",
+  "preferred_signals": "technical",
+  "leverage_comfort": "1-3x",
+  "assets": "majors_only"
+}
+```
+Returns: profile JSON with deltas + effective weights + narrative.
+
+## Dependencies
+- `llm/openai_client.py` (optional, for LLM-enhanced mode)
+- No external API calls in rule-based mode

--- a/src/agents/profile_agent/persona.md
+++ b/src/agents/profile_agent/persona.md
@@ -1,0 +1,40 @@
+# Persona: Profile Agent
+
+## Role
+Onboarding & Personalization Wizard — generates personalized agent weight profiles from user questionnaire.
+
+## Expertise
+- 5-question trading style assessment
+- Weight delta computation from rule matrix
+- Narrative labeling for user-facing profiles
+- Optional LLM enhancement for richer reasoning
+
+## Reasoning Guidelines
+1. Rule-based path is deterministic: question answers → weight deltas → re-normalized weights
+2. LLM path (AIMM_LLM_PROFILE=1) adds richer narrative reasoning
+3. Deltas must stay within [-0.15, +0.15] per agent
+4. Final weights always re-normalized to sum 1.0
+5. Profile ID is a SHA-256 of input + source + timestamp
+
+## Interview (5 Questions)
+1. **Risk Tolerance:** conservative / moderate / aggressive
+2. **Time Horizon:** scalping / intraday / swing / position
+3. **Preferred Signals:** technical / onchain / news / sentiment / mixed
+4. **Leverage Comfort:** 1x / 1-3x / 3-5x / 5x+
+5. **Asset Focus:** majors_only / majors_alts / full_universe
+
+## Output
+```json
+{
+  "profile_id": "user_a1b2c3d4e5f6",
+  "base": "AGENT_WEIGHTS_DEFAULT",
+  "deltas": {"2.1": "+0.10", "2.3": "-0.05"},
+  "effective_weights": {"1.1": 0.05, "2.1": 0.35, ...},
+  "narrative": "Balanced Technician",
+  "source": "rule"
+}
+```
+
+## Operates
+- One-time onboarding (not hot path)
+- Output consumed by `weighted_arbitrator` for profile-specific weight injection

--- a/src/agents/profile_registry.py
+++ b/src/agents/profile_registry.py
@@ -1,0 +1,130 @@
+"""Persistent profile storage under AIMM_PROFILES_DIR (default: .profiles/)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_PROFILES_ENV = "AIMM_PROFILES_DIR"
+_DEFAULT_PROFILES_DIR = ".profiles"
+
+
+def _profiles_dir() -> Path:
+    override = (os.getenv(_PROFILES_ENV) or "").strip()
+    return Path(override) if override else Path(_DEFAULT_PROFILES_DIR)
+
+
+def save_profile(profile: dict[str, Any]) -> bool:
+    """Persist a profile JSON to disk.
+
+    The profile must contain a ``profile_id`` key.
+    Returns True on success.
+    """
+    pid = profile.get("profile_id", "")
+    if not pid:
+        logger.warning("Cannot save profile without profile_id")
+        return False
+    profiles_dir = _profiles_dir()
+    profiles_dir.mkdir(parents=True, exist_ok=True)
+    path = profiles_dir / f"{pid}.json"
+    try:
+        existing = {}
+        if path.is_file():
+            existing = json.loads(path.read_text())
+        existing.update(profile)
+        existing["saved_at"] = time.time()
+        path.write_text(json.dumps(existing, indent=2, default=str))
+        return True
+    except OSError as e:
+        logger.warning("Failed to save profile %s: %s", pid, e)
+        return False
+
+
+def load_profile(profile_id: str) -> dict[str, Any] | None:
+    """Load a profile from disk by profile_id.
+
+    Returns None if the profile file doesn't exist or is corrupted.
+    """
+    profiles_dir = _profiles_dir()
+    path = profiles_dir / f"{profile_id}.json"
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load profile %s: %s", profile_id, e)
+        return None
+
+
+def list_profiles() -> list[dict[str, Any]]:
+    """List all stored profiles.
+
+    Returns a list of profile summaries (profile_id + narrative + created_at).
+    """
+    profiles_dir = _profiles_dir()
+    if not profiles_dir.is_dir():
+        return []
+    results: list[dict[str, Any]] = []
+    for f in sorted(profiles_dir.iterdir()):
+        if f.suffix != ".json":
+            continue
+        try:
+            data = json.loads(f.read_text())
+            results.append(
+                {
+                    "profile_id": data.get("profile_id", f.stem),
+                    "narrative": data.get("narrative", ""),
+                    "created_at": data.get("created_at", 0),
+                    "source": data.get("source", "unknown"),
+                }
+            )
+        except (json.JSONDecodeError, OSError):
+            pass
+    return results
+
+
+def delete_profile(profile_id: str) -> bool:
+    """Delete a stored profile.
+
+    Returns True if the file was removed, False if it didn't exist.
+    """
+    profiles_dir = _profiles_dir()
+    path = profiles_dir / f"{profile_id}.json"
+    if not path.is_file():
+        return False
+    try:
+        path.unlink()
+        return True
+    except OSError as e:
+        logger.warning("Failed to delete profile %s: %s", profile_id, e)
+        return False
+
+
+def get_profile_weights(profile_id: str) -> dict[str, float] | None:
+    """Convenience: load profile and return just the effective_weights dict."""
+    profile = load_profile(profile_id)
+    if not profile:
+        return None
+    raw = profile.get("effective_weights") or {}
+    result: dict[str, float] = {}
+    for k, v in raw.items():
+        try:
+            result[str(k)] = float(v)
+        except (TypeError, ValueError):
+            pass
+    return result if result else None
+
+
+__all__ = [
+    "delete_profile",
+    "get_profile_weights",
+    "list_profiles",
+    "load_profile",
+    "save_profile",
+]

--- a/src/api/flow_stream_server.py
+++ b/src/api/flow_stream_server.py
@@ -28,6 +28,7 @@ from .ops_routes import router as ops_router
 from .paper_routes import router as paper_router
 from .payload_adapter import build_nexus_payload
 from .pm_routes import router as pm_router
+from .profile_routes import router as profile_router
 from .provider_admin_routes import router as provider_admin_router
 from .public_provider_routes import router as public_provider_router
 from .runtime_settings_routes import router as runtime_settings_router
@@ -123,6 +124,7 @@ app.include_router(studio_router)
 app.include_router(tools_router)
 app.include_router(capabilities_router)
 app.include_router(ops_router)
+app.include_router(profile_router)
 
 
 def _resolve_run_log(run_id: str) -> Path:

--- a/src/api/profile_routes.py
+++ b/src/api/profile_routes.py
@@ -1,0 +1,83 @@
+"""Profile Agent API routes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/profile-agent", tags=["profile"])
+
+
+class ProfileQuestionnaire(BaseModel):
+    """User-facing 5-question trading-style assessment."""
+
+    risk_tolerance: str = Field(..., description="conservative | moderate | aggressive")
+    time_horizon: str = Field(..., description="scalping | intraday | swing | position")
+    preferred_signals: str = Field(
+        ..., description="technical | onchain | news | sentiment | mixed"
+    )
+    leverage_comfort: str = Field(..., description="1x | 1-3x | 3-5x | 5x+")
+    assets: str = Field(..., description="majors_only | majors_alts | full_universe")
+
+
+@router.post("/generate")
+async def generate_profile(q: ProfileQuestionnaire) -> dict[str, Any]:
+    try:
+        from agents.profile_agent import ProfileAgent
+
+        agent = ProfileAgent()
+        result = agent.process(
+            {
+                "risk_tolerance": q.risk_tolerance,
+                "time_horizon": q.time_horizon,
+                "preferred_signals": q.preferred_signals,
+                "leverage_comfort": q.leverage_comfort,
+                "assets": q.assets,
+            }
+        )
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/labels")
+async def agent_labels() -> dict[str, str]:
+    from agents.profile_agent import AGENT_LABELS
+
+    return dict(AGENT_LABELS)
+
+
+@router.get("/default-weights")
+async def default_weights() -> dict[str, float]:
+    from agents.profile_agent import AGENT_WEIGHTS_DEFAULT
+
+    return dict(AGENT_WEIGHTS_DEFAULT)
+
+
+@router.get("/list")
+async def list_profiles() -> list[dict]:
+    from agents.profile_registry import list_profiles as _list_profiles
+
+    return _list_profiles()
+
+
+@router.post("/save")
+async def save_profile(profile: dict) -> dict:
+    from agents.profile_registry import save_profile as _save_profile
+
+    ok = _save_profile(profile)
+    return {"saved": ok, "profile_id": profile.get("profile_id", "")}
+
+
+@router.get("/load/{profile_id}")
+async def load_profile(profile_id: str) -> dict:
+    from agents.profile_registry import load_profile as _load_profile
+
+    profile = _load_profile(profile_id)
+    if profile is None:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=404, detail=f"Profile {profile_id} not found")
+    return profile

--- a/src/api/studio_routes.py
+++ b/src/api/studio_routes.py
@@ -35,7 +35,8 @@ from api.backtest_routes import (
 )
 from config.app_settings import load_app_settings
 from config.env_parse import env_bool
-from config.llm_env import use_llm_arbitrator
+from config.llm_env import llm_key_available
+from config.llm_mode import llm_mode_enabled
 from llm.openai_client import run_tool_calling_chat
 from llm.tool_registry import ToolSpec, nexus_tool_specs
 
@@ -675,7 +676,7 @@ async def post_studio_suggest_title(
             status_code=400,
             detail={"error": "empty", "hint": "message is required"},
         )
-    if not use_llm_arbitrator(os.environ) or not (os.getenv("OPENAI_API_KEY") or "").strip():
+    if not llm_mode_enabled(os.environ) or not llm_key_available(os.environ):
         raise HTTPException(
             status_code=503,
             detail={
@@ -769,12 +770,12 @@ async def post_studio_chat(request: Request, req: StudioChatRequest) -> dict[str
 
     # Studio chat is LLM-first: if the LLM isn't configured/reachable, fail loudly rather than
     # returning canned keyword responses (which feel "dumb").
-    if not use_llm_arbitrator(os.environ) or not (os.getenv("OPENAI_API_KEY") or "").strip():
+    if not llm_mode_enabled(os.environ) or not llm_key_available(os.environ):
         raise HTTPException(
             status_code=503,
             detail={
                 "error": "llm_required",
-                "hint": "Set OPENAI_API_KEY (and ensure AI_MARKET_MAKER_USE_LLM is not forcing LLM off).",
+                "hint": "Set OPENAI_API_KEY and ensure AIMM_LLM_MODE is not forcing LLM off.",
             },
         )
 

--- a/src/backtest/run_demo.py
+++ b/src/backtest/run_demo.py
@@ -17,7 +17,7 @@ Multi-symbol (aligned OHLCV; same portfolio path as production graph). If you om
 
 Examples::
 
-    NEXUS_DISABLE=1 AI_MARKET_MAKER_USE_LLM=0 uv run python -m backtest.run_demo --steps 80 --online --timeframe 1d
+    NEXUS_DISABLE=1 AIMM_LLM_MODE=0 uv run python -m backtest.run_demo --steps 80 --online --timeframe 1d
 
 ~6 months daily, dynamic top-liquid universe, frequent-style env (no ``--symbols``)::
 
@@ -189,7 +189,7 @@ def build_run_demo_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--llm",
         action="store_true",
-        help="Set AI_MARKET_MAKER_USE_LLM=1 before the run (LLM per bar; requires provider keys).",
+        help="Set AIMM_ARBITRATOR_MODE=llm before the run (LLM arbitrator per bar; requires provider keys).",
     )
     parser.add_argument(
         "--runs-dir",
@@ -535,8 +535,8 @@ def main(argv: list[str] | None = None) -> dict[str, Any]:
     if args.llm:
         # Backtest LLM is intentionally **arbitrator-only** by default.
         # Rationale: full-graph LLM calls are too slow/costly per-bar for a demo backtest.
-        os.environ["AI_MARKET_MAKER_USE_LLM"] = "1"  # enables LLM signal arbitrator
-        os.environ["AIMM_LLM_MODE"] = "0"  # disable portfolio LLM nodes
+        os.environ["AIMM_ARBITRATOR_MODE"] = "llm"
+        os.environ["AIMM_LLM_MODE"] = "0"
         os.environ["AIMM_LLM_DESK_DEBATE"] = "0"  # disable extra LLM debate turns
     out = execute_run_demo(args, parser)
     print(json.dumps(out, indent=2), flush=True)

--- a/src/backtest/run_historical_eval.py
+++ b/src/backtest/run_historical_eval.py
@@ -65,7 +65,7 @@ def main() -> None:
 
     use_llm = bool(args.llm) or args.suite == "llm_monthly"
     if use_llm:
-        os.environ["AI_MARKET_MAKER_USE_LLM"] = "1"
+        os.environ["AIMM_ARBITRATOR_MODE"] = "llm"
     cap_raw = (os.getenv("AIMM_BACKTEST_LLM_MAX_STEPS") or "120").strip()
     try:
         llm_max = max(2, int(cap_raw, 10))

--- a/src/config/agent_run_mode.py
+++ b/src/config/agent_run_mode.py
@@ -1,0 +1,82 @@
+"""Per-agent LLM toggle for weighted_convergence vs agent_llm run modes."""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+_ENV_MODE = "AIMM_RUN_MODE"
+_AGENT_LLM_MODE = "agent_llm"
+_WEIGHTED_CONVERGENCE = "weighted_convergence"
+
+# AIMM_LLM_AGENTS=2.1,2.3 or ALL
+_ENV_AGENTS = "AIMM_LLM_AGENTS"
+_ALL_SENTINEL = "ALL"
+
+
+def current_run_mode(env: Mapping[str, str] | None = None) -> str:
+    """Return the current execution mode string.
+
+    Returns "weighted_convergence" or "agent_llm".
+    Default is "weighted_convergence" (zero LLM calls).
+    """
+    m = env if env is not None else os.environ
+    raw = (m.get(_ENV_MODE) or _WEIGHTED_CONVERGENCE).strip().lower()
+    return raw if raw in (_AGENT_LLM_MODE, _WEIGHTED_CONVERGENCE) else _WEIGHTED_CONVERGENCE
+
+
+def is_agent_llm_mode(env: Mapping[str, str] | None = None) -> bool:
+    """True when global mode is 'agent_llm'."""
+    return current_run_mode(env) == _AGENT_LLM_MODE
+
+
+def llm_enabled_agents(env: Mapping[str, str] | None = None) -> frozenset[str]:
+    """Return the set of agent IDs that should use LLM path.
+
+    When AIMM_LLM_AGENTS=ALL, every agent is included.
+    """
+    m = env if env is not None else os.environ
+    raw = (m.get(_ENV_AGENTS) or "").strip()
+    if not raw:
+        return frozenset()
+    if raw.upper() == _ALL_SENTINEL:
+        return frozenset({"*"})
+    return frozenset(a.strip() for a in raw.split(",") if a.strip())
+
+
+def agent_llm_enabled(agent_id: str, env: Mapping[str, str] | None = None) -> bool:
+    """Check if a specific agent should use LLM path.
+
+    Returns False when global mode is not 'agent_llm'.
+    When AIMM_LLM_AGENTS=ALL, all agents are enabled.
+    When AIMM_LLM_AGENTS=2.1,2.3, only those agents use LLM.
+    """
+    if not is_agent_llm_mode(env):
+        return False
+    enabled = llm_enabled_agents(env)
+    if not enabled:
+        return False
+    if _ALL_SENTINEL.lower() in enabled or "*" in enabled:
+        return True
+    return agent_id in enabled
+
+
+def describe_mode(env: Mapping[str, str] | None = None) -> dict:
+    """Return a diagnostic dict of the current LLM mode configuration."""
+    mode = current_run_mode(env)
+    enabled = llm_enabled_agents(env)
+    return {
+        "mode": mode,
+        "agent_llm_enabled": is_agent_llm_mode(env),
+        "llm_agents": sorted(enabled) if enabled else [],
+        "all_agents_llm": _ALL_SENTINEL.lower() in enabled or "*" in enabled,
+    }
+
+
+__all__ = [
+    "agent_llm_enabled",
+    "current_run_mode",
+    "describe_mode",
+    "is_agent_llm_mode",
+    "llm_enabled_agents",
+]

--- a/src/config/cadence.py
+++ b/src/config/cadence.py
@@ -12,7 +12,7 @@ import sys
 import warnings
 from typing import Mapping
 
-from config.llm_env import use_llm_arbitrator
+from config.llm_mode import llm_mode_enabled
 
 STRATEGY_INTERVAL_ENV = "STRATEGY_INTERVAL_SEC"
 # Default ~3 minutes: aligns with common “desk refresh” loops and limits token burn.
@@ -59,12 +59,12 @@ def load_strategy_interval_sec(
 def warn_if_aggressive_cadence(interval_sec: int, *, env: Mapping[str, str] | None = None) -> None:
     """Emit a stderr hint when LLM is on but the loop is faster than a typical desk cycle."""
     env_map = env if env is not None else os.environ
-    use_llm = use_llm_arbitrator(env_map)
+    use_llm = llm_mode_enabled(env_map)
     if use_llm and interval_sec < LLM_SANE_MIN_INTERVAL_SEC:
         print(
-            f"[cadence] AI_MARKET_MAKER_USE_LLM=1 with {STRATEGY_INTERVAL_ENV}={interval_sec}s "
+            f"[cadence] LLM mode enabled with {STRATEGY_INTERVAL_ENV}={interval_sec}s "
             f"(<{LLM_SANE_MIN_INTERVAL_SEC}s): each tick runs the full graph and LLM calls — "
-            "expect high token usage. Consider >=180s for demos, or disable LLM for fast ticks.",
+            "expect high token usage. Consider >=180s for demos, or set AIMM_LLM_MODE=0 for fast ticks.",
             file=sys.stderr,
         )
 

--- a/src/config/llm_env.py
+++ b/src/config/llm_env.py
@@ -1,37 +1,27 @@
-"""Single definition of when the Tier-2 **LLM signal arbitrator** is enabled.
-
-Confusion often comes from treating ``0``/``1`` as vague toggles. Here:
-
-- **OFF** (default): empty, ``0``, ``false``, ``no``, or anything else unrecognized.
-- **ON**: ``1``, ``true``, ``yes``, ``y``, ``on`` (case-insensitive).
-
-When ON, :func:`main.build_workflow` wires ``signal_arbitrator_llm`` instead of the
-deterministic ``signal_arbitrator``, and each graph tick may call the model (costly).
-"""
+"""LLM key availability helpers."""
 
 from __future__ import annotations
 
 import os
-from typing import Mapping
-
-_ENV_NAME = "AI_MARKET_MAKER_USE_LLM"
-
-_ON_VALUES = frozenset({"1", "true", "yes", "y", "on"})
-_OFF_VALUES = frozenset({"0", "false", "no", "n", "off"})
 
 
-def use_llm_arbitrator(env: Mapping[str, str] | None = None) -> bool:
-    """Return True if the LLM-backed signal arbitrator should be used."""
-    m = env if env is not None else os.environ
-    v = (m.get(_ENV_NAME) or "").strip().lower()
-    if v in _ON_VALUES:
-        return True
-    if v in _OFF_VALUES:
-        return False
-    # Auto mode: enable when a key exists (but never during pytest to avoid accidental paid calls).
-    if (m.get("PYTEST_CURRENT_TEST") or "").strip():
-        return False
-    return bool((m.get("OPENAI_API_KEY") or "").strip())
+def llm_key_available() -> bool:
+    """Return True if an LLM API key is available.
+
+    Checks ``OPENAI_API_KEY`` (or ``LLM_API_KEY`` as fallback).
+    """
+    return bool((os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY") or "").strip())
 
 
-__all__ = ["use_llm_arbitrator"]
+def require_llm_key() -> None:
+    """Exit with a clear message if no LLM key is set."""
+    if not llm_key_available():
+        print(
+            "FATAL: OPENAI_API_KEY is required. "
+            "Set OPENAI_API_KEY in your environment or .env file.",
+            file=__import__("sys").stderr,
+        )
+        __import__("sys").exit(1)
+
+
+__all__ = ["llm_key_available", "require_llm_key"]

--- a/src/config/llm_env.py
+++ b/src/config/llm_env.py
@@ -1,16 +1,22 @@
-"""LLM key availability helpers."""
+"""LLM key availability and arbitrator mode helpers."""
 
 from __future__ import annotations
 
 import os
+from typing import Mapping
 
 
-def llm_key_available() -> bool:
-    """Return True if an LLM API key is available.
+def llm_key_available(env: Mapping[str, str] | None = None) -> bool:
+    """Return True when an LLM API key is configured."""
+    m = env if env is not None else os.environ
+    return bool((m.get("OPENAI_API_KEY") or m.get("LLM_API_KEY") or "").strip())
 
-    Checks ``OPENAI_API_KEY`` (or ``LLM_API_KEY`` as fallback).
-    """
-    return bool((os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY") or "").strip())
+
+def llm_arbitrator_mode(env: Mapping[str, str] | None = None) -> str:
+    """Return ``weighted_convergence`` (default) or ``llm``."""
+    m = env if env is not None else os.environ
+    raw = (m.get("AIMM_ARBITRATOR_MODE") or "weighted_convergence").strip().lower()
+    return "llm" if raw == "llm" else "weighted_convergence"
 
 
 def require_llm_key() -> None:
@@ -24,4 +30,4 @@ def require_llm_key() -> None:
         __import__("sys").exit(1)
 
 
-__all__ = ["llm_key_available", "require_llm_key"]
+__all__ = ["llm_arbitrator_mode", "llm_key_available", "require_llm_key"]

--- a/src/llm/arbitrator_llm.py
+++ b/src/llm/arbitrator_llm.py
@@ -5,7 +5,6 @@ import os
 from typing import Any, Dict
 
 from config.agent_prompts import prompt_settings_by_actor
-from config.llm_env import use_llm_arbitrator
 from llm.json_parse import parse_json_object
 from llm.openai_client import run_tool_calling_chat
 from llm.structured_output import (
@@ -19,17 +18,15 @@ from schemas.state import HedgeFundState
 from tier1 import apply_strategy, effective_portfolio_desk_bridge, load_tier1_blueprint_from_env
 from tier1.signal_params import build_tier1_proposed_params
 from trading.desk_inputs import quant_analysis_for_portfolio
-from workflow.arbitrator_shadow import (
-    backtest_momentum_score_delta,
-    legacy_deterministic_stance_preview,
-)
 from workflow.execution_intent import derive_trade_intent
 from workflow.tier2_context import (
+    backtest_momentum_score_delta,
     bear_evidence_lines,
     build_synthesis_board,
     bull_evidence_lines,
     compact_tier0_for_prompt,
     compute_legacy_arbitrator_scores,
+    legacy_deterministic_stance_preview,
 )
 
 
@@ -146,12 +143,7 @@ def _backtest_prompt_context(state: HedgeFundState, *, ticker: str) -> dict[str,
 
 
 def signal_arbitrator_llm(state: HedgeFundState) -> Dict[str, Any]:
-    """Tier-2 synthesis node driven by an LLM with tool-calling enabled.
-
-    Gated behind `AI_MARKET_MAKER_USE_LLM=1`.
-    """
-    if not use_llm_arbitrator():
-        raise RuntimeError("signal_arbitrator_llm called but AI_MARKET_MAKER_USE_LLM is disabled")
+    """Tier-2 synthesis node driven by an LLM with tool-calling enabled."""
 
     ticker = str(state.get("ticker") or "BTC/USDT")
     transcript = state.get("debate_transcript") or []

--- a/src/llm/decision_cache.py
+++ b/src/llm/decision_cache.py
@@ -1,0 +1,191 @@
+"""File-backed decision cache for reproducible backtests and agent_llm replay."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CACHE_ENV = "AIMM_DECISION_CACHE_DIR"
+_DEFAULT_CACHE_DIR = ".cache/decisions"
+
+
+def _cache_dir() -> Path:
+    override = (os.getenv(_CACHE_ENV) or "").strip()
+    return Path(override) if override else Path(_DEFAULT_CACHE_DIR)
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _cache_key(
+    agent_id: str,
+    ticker: str,
+    date_tag: str,
+    prompt_hash: str,
+) -> str:
+    raw = f"{agent_id}|{ticker}|{date_tag}|{prompt_hash}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:32]
+
+
+def _cache_path(key: str) -> Path:
+    d = _cache_dir() / key[:2] / key[2:4]
+    return d / f"{key}.json"
+
+
+def decision_cache_enabled() -> bool:
+    """Check whether the decision cache is enabled.
+
+    Enabled by default when AIMM_DECISION_CACHE_DIR is set.
+    Also enabled automatically in backtest mode.
+    """
+    env = os.getenv("AIMM_DECISION_CACHE_DIR", "")
+    if env.strip():
+        return True
+    mode = os.getenv("MODE", os.getenv("AIMM_RUN_MODE", "")).strip().lower()
+    return mode in ("backtest",)
+
+
+def read_cached_decision(
+    agent_id: str,
+    ticker: str,
+    date_tag: str,
+    prompt_hash: str,
+) -> dict[str, Any] | None:
+    """Read a cached decision for the given agent + context.
+
+    Returns None if cache miss or disabled.
+    """
+    if not decision_cache_enabled():
+        return None
+    key = _cache_key(agent_id, ticker, date_tag, prompt_hash)
+    path = _cache_path(key)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        return data.get("decision")
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Decision cache read error for %s: %s", key, e)
+        return None
+
+
+def write_cached_decision(
+    agent_id: str,
+    ticker: str,
+    date_tag: str,
+    prompt_hash: str,
+    decision: dict[str, Any],
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> bool:
+    """Write a decision to the cache.
+
+    Returns True on success.
+    """
+    if not decision_cache_enabled():
+        return False
+    key = _cache_key(agent_id, ticker, date_tag, prompt_hash)
+    path = _cache_path(key)
+    _ensure_dir(path.parent)
+    payload = {
+        "key": key,
+        "agent_id": agent_id,
+        "ticker": ticker,
+        "date_tag": date_tag,
+        "prompt_hash": prompt_hash,
+        "decision": decision,
+        "metadata": metadata or {},
+        "cached_at": time.time(),
+    }
+    try:
+        path.write_text(json.dumps(payload, indent=2, default=str))
+        return True
+    except OSError as e:
+        logger.warning("Decision cache write error for %s: %s", key, e)
+        return False
+
+
+def invalidate_cache(agent_id: str | None = None, ticker: str | None = None) -> int:
+    """Invalidate cache entries, optionally filtered by agent_id or ticker.
+
+    Returns number of entries removed.
+    """
+    removed = 0
+    cache_root = _cache_dir()
+    if not cache_root.is_dir():
+        return 0
+    for sub in cache_root.iterdir():
+        if not sub.is_dir():
+            continue
+        for sub2 in sub.iterdir():
+            if not sub2.is_dir():
+                continue
+            for f in sub2.iterdir():
+                if f.suffix != ".json":
+                    continue
+                try:
+                    data = json.loads(f.read_text())
+                    aid = data.get("agent_id", "")
+                    tk = data.get("ticker", "")
+                    if agent_id and aid != agent_id:
+                        continue
+                    if ticker and tk != ticker:
+                        continue
+                    f.unlink()
+                    removed += 1
+                except (json.JSONDecodeError, OSError):
+                    f.unlink()
+                    removed += 1
+    return removed
+
+
+def cache_stats() -> dict[str, Any]:
+    """Return cache statistics."""
+    cache_root = _cache_dir()
+    if not cache_root.is_dir():
+        return {"enabled": decision_cache_enabled(), "total_entries": 0, "size_bytes": 0}
+    total = 0
+    total_bytes = 0
+    agents: set[str] = set()
+    tickers: set[str] = set()
+    for sub in cache_root.iterdir():
+        if not sub.is_dir():
+            continue
+        for sub2 in sub.iterdir():
+            if not sub2.is_dir():
+                continue
+            for f in sub2.iterdir():
+                if f.suffix != ".json":
+                    continue
+                total += 1
+                total_bytes += f.stat().st_size
+                try:
+                    data = json.loads(f.read_text())
+                    agents.add(data.get("agent_id", "unknown"))
+                    tickers.add(data.get("ticker", "unknown"))
+                except Exception:
+                    pass
+    return {
+        "enabled": decision_cache_enabled(),
+        "total_entries": total,
+        "size_bytes": total_bytes,
+        "agents": sorted(agents),
+        "tickers": sorted(tickers),
+    }
+
+
+__all__ = [
+    "cache_stats",
+    "decision_cache_enabled",
+    "invalidate_cache",
+    "read_cached_decision",
+    "write_cached_decision",
+]

--- a/src/llm/tool_registry.py
+++ b/src/llm/tool_registry.py
@@ -1,35 +1,194 @@
+"""Import-time tool registry with @register_tool and OpenAI tool payloads."""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Union, get_args, get_origin
 
 from adapters.nexus_adapter import get_nexus_adapter
 
 JsonSchema = Dict[str, Any]
 
-_NAME_PATTERN_NOTE = "Provider tool names must match ^[a-zA-Z0-9_-]+$ (no dots)."
-
 
 def _wire_name(canonical: str) -> str:
-    # OpenAI is permissive, but some OpenAI-compatible providers (e.g. DeepSeek)
-    # reject dots in function names.
     return canonical.replace(".", "_")
+
+
+def _function_to_json_schema(fn: Callable) -> JsonSchema:
+    """Minimal type-annotation → JSON schema converter.
+
+    Supports str, int, float, bool, Optional, and bare Dict/List.
+    """
+    sig = inspect.signature(fn)
+    hints = {}
+    try:
+        hints = {k: v for k, v in inspect.get_annotations(fn).items() if k != "return"}
+    except Exception:
+        pass
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+
+    for name, param in sig.parameters.items():
+        if name == "return" or name == "self":
+            continue
+        is_optional = False
+        if param.default is not inspect.Parameter.empty:
+            if param.default is not None:
+                is_optional = True
+            else:
+                is_optional = True  # Optional[...] → default None
+
+        ann = hints.get(name)
+        js_type = _py_type_to_js(ann)
+        prop: dict[str, Any] = {"type": js_type} if js_type else {}
+
+        if param.default is not inspect.Parameter.empty and not is_optional:
+            prop["default"] = param.default
+
+        # Handle Optional via union
+        if is_optional:
+            prop.setdefault("type", "string")
+
+        # Add enum from type hints
+        if ann is bool:
+            pass  # boolean is fine
+
+        properties[name] = prop
+        if param.default is inspect.Parameter.empty:
+            required.append(name)
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+def _py_type_to_js(ann: Any) -> str | None:
+    if ann is None or ann is inspect.Parameter.empty:
+        return None
+    if ann is str:
+        return "string"
+    if ann is int:
+        return "integer"
+    if ann is float:
+        return "number"
+    if ann is bool:
+        return "boolean"
+    if ann is dict or getattr(ann, "__origin__", None) is dict:
+        return "object"
+    if ann is list or getattr(ann, "__origin__", None) is list:
+        return "array"
+    # Optional[X] → union
+    origin = get_origin(ann)
+    if origin is Union:
+        args = get_args(ann)
+        non_none = [a for a in args if a is not type(None)]
+        if non_none:
+            return _py_type_to_js(non_none[0])
+    return None
 
 
 @dataclass(frozen=True)
 class ToolSpec:
-    # Canonical tool name used in our app / manifest.
+    """Immutable tool specification — canonical name, schema, and handler."""
+
     name: str
-    # Provider-safe name used when sending to OpenAI-compatible APIs.
     wire_name: str
     description: str
     parameters: JsonSchema
     handler: Callable[..., Dict[str, Any]]
+    tags: frozenset[str] = field(default_factory=frozenset)
+
+
+class _ToolRegistry:
+    """Global tool registry populated via @register_tool."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolSpec] = {}
+
+    def register(self, spec: ToolSpec) -> None:
+        if spec.name in self._tools:
+            raise ValueError(f"Duplicate tool registration: {spec.name}")
+        self._tools[spec.name] = spec
+
+    def register_fn(
+        self,
+        fn: Callable,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        tags: frozenset[str] | None = None,
+    ) -> ToolSpec:
+        """Register a function as a tool using its signature for JSON schema."""
+        canonical = name or fn.__name__
+        doc = description or (inspect.getdoc(fn) or "").strip() or f"Tool: {canonical}"
+        parameters = _function_to_json_schema(fn)
+
+        spec = ToolSpec(
+            name=canonical,
+            wire_name=_wire_name(canonical),
+            description=doc,
+            parameters=parameters,
+            handler=fn,
+            tags=tags or frozenset(),
+        )
+        self.register(spec)
+        return spec
+
+    def get(self, name: str) -> ToolSpec | None:
+        by_name = {s.name: s for s in self._tools.values()} | {
+            s.wire_name: s for s in self._tools.values()
+        }
+        return by_name.get(name)
+
+    def all(self) -> List[ToolSpec]:
+        return list(self._tools.values())
+
+    def by_tag(self, tag: str) -> List[ToolSpec]:
+        return [t for t in self._tools.values() if tag in t.tags]
+
+    def clear(self) -> None:
+        self._tools.clear()
+
+    def __len__(self) -> int:
+        return len(self._tools)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._tools or _wire_name(name) in {
+            s.wire_name for s in self._tools.values()
+        }
+
+
+TOOL_REGISTRY = _ToolRegistry()
+
+
+def register_tool(
+    fn: Callable | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    tags: frozenset[str] | None = None,
+) -> Callable | ToolSpec:
+    """Register a function as a tool."""
+    if fn is not None:
+        # Used as bare decorator: @register_tool
+        return TOOL_REGISTRY.register_fn(fn)
+
+    # Used with args: @register_tool(name=..., tags=...)
+    def decorator(f: Callable) -> ToolSpec:
+        return TOOL_REGISTRY.register_fn(f, name=name, description=description, tags=tags)
+
+    return decorator
 
 
 def nexus_tool_specs(*, include_write_tools: bool = True) -> List[ToolSpec]:
+    """Legacy Nexus adapter tools."""
     adapter = get_nexus_adapter()
-    tools: List[ToolSpec] = [
+    tools: list[ToolSpec] = [
         ToolSpec(
             name="nexus.fetch_market_depth",
             wire_name=_wire_name("nexus.fetch_market_depth"),
@@ -38,7 +197,12 @@ def nexus_tool_specs(*, include_write_tools: bool = True) -> List[ToolSpec]:
                 "type": "object",
                 "properties": {
                     "symbol": {"type": "string"},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 5},
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50,
+                        "default": 5,
+                    },
                 },
                 "required": ["symbol"],
                 "additionalProperties": False,
@@ -46,7 +210,6 @@ def nexus_tool_specs(*, include_write_tools: bool = True) -> List[ToolSpec]:
             handler=lambda **kw: adapter.fetch_market_depth(**kw),
         ),
     ]
-
     if include_write_tools:
         tools.append(
             ToolSpec(
@@ -75,18 +238,23 @@ def nexus_tool_specs(*, include_write_tools: bool = True) -> List[ToolSpec]:
                 handler=lambda **kw: adapter.place_smart_order(**kw),
             )
         )
-
+    for t in tools:
+        try:
+            TOOL_REGISTRY.register(t)
+        except ValueError:
+            pass
     return tools
 
 
-def openai_tools_payload(specs: List[ToolSpec]) -> List[Dict[str, Any]]:
-    """Convert ToolSpec into OpenAI 'tools' payload for chat.completions."""
+def openai_tools_payload(specs: List[ToolSpec] | None = None) -> List[Dict[str, Any]]:
+    """Convert ToolSpec(s) to OpenAI tools payload."""
+    specs = specs if specs is not None else TOOL_REGISTRY.all()
     return [
         {
             "type": "function",
             "function": {
                 "name": s.wire_name,
-                "description": f"{s.description} ({_NAME_PATTERN_NOTE})",
+                "description": s.description,
                 "parameters": s.parameters,
             },
         }
@@ -94,10 +262,18 @@ def openai_tools_payload(specs: List[ToolSpec]) -> List[Dict[str, Any]]:
     ]
 
 
-def call_tool(specs: List[ToolSpec], *, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
-    # Accept either canonical name or provider wire name.
-    by_name = {s.name: s for s in specs} | {s.wire_name: s for s in specs}
-    spec = by_name.get(name)
+def call_tool(
+    specs: List[ToolSpec] | None = None,
+    *,
+    name: str,
+    arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Dispatch a tool call by name."""
+    if specs is not None:
+        by_name = {s.name: s for s in specs} | {s.wire_name: s for s in specs}
+        spec = by_name.get(name)
+    else:
+        spec = TOOL_REGISTRY.get(name)
     if not spec:
         return {"status": "error", "error": f"unknown_tool: {name}"}
     try:
@@ -106,4 +282,14 @@ def call_tool(specs: List[ToolSpec], *, name: str, arguments: Dict[str, Any]) ->
         return {"status": "error", "error": str(e)}
 
 
-__all__ = ["ToolSpec", "call_tool", "nexus_tool_specs", "openai_tools_payload"]
+nexus_tool_specs()
+
+
+__all__ = [
+    "TOOL_REGISTRY",
+    "ToolSpec",
+    "call_tool",
+    "nexus_tool_specs",
+    "openai_tools_payload",
+    "register_tool",
+]

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import json
 import logging
 import os
 import threading
@@ -29,7 +30,6 @@ from agents.technical_ta_engine import TechnicalTaEngineAgent
 from agents.whale_behavior_analyst import WhaleBehaviorAnalystAgent
 from config.app_settings import apply_strategy_env_defaults_from_settings, load_app_settings
 from config.fund_policy import load_fund_policy
-from config.llm_env import use_llm_arbitrator
 from config.llm_mode import llm_mode_enabled
 from config.run_mode import RunMode, load_run_mode
 from flow_log import FlowEventRepo, get_flow_repo, set_flow_repo
@@ -51,14 +51,11 @@ from schemas.flow_events import FlowEvent
 from schemas.state import HedgeFundState, initial_hedge_fund_state
 from schemas.tier0_contract import build_tier0_contract_json
 from telemetry.logger import LogPublisher, get_log_publisher, set_log_publisher
-from tier1 import apply_strategy, effective_portfolio_desk_bridge, load_tier1_blueprint_from_env
-from tier1.signal_params import build_tier1_proposed_params
+from tier1 import effective_portfolio_desk_bridge
 from trading.desk_inputs import quant_analysis_for_portfolio
-from workflow.arbitrator_shadow import backtest_momentum_score_delta
 from workflow.desk_debate import desk_debate
-from workflow.execution_intent import derive_trade_intent
 from workflow.routing import route_after_risk_guard, route_after_risk_guard_mapping
-from workflow.tier2_context import build_synthesis_board, compute_legacy_arbitrator_scores
+from workflow.weighted_arbitrator import weighted_arbitrator_node
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -701,104 +698,6 @@ def risk(state: HedgeFundState) -> dict[str, Any]:
                 thought="Risk profile generated from market and valuation context.",
                 decision=risk_out,
             )
-        ],
-    }
-
-
-def signal_arbitrator(state: HedgeFundState) -> dict[str, Any]:
-    """Tier-2 synthesis: Tier-1 applier (if configured) else legacy scores from Tier-0 consensus + risk/sentiment.
-
-    Preceding ``desk_debate`` appends human-readable rows to ``debate_transcript`` (deterministic + optional LLM).
-    """
-    legacy = compute_legacy_arbitrator_scores(state)
-    debate_n = len(state.get("debate_transcript") or [])
-    bull_score = int(legacy["bull_score"])
-    bear_score = int(legacy["bear_score"])
-    high_vol_assets = int(legacy["high_vol_assets"])
-    sentiment_score = float(legacy["sentiment_score"])
-    tc = legacy["tier0_consensus"]
-
-    mb, ms, mnote = backtest_momentum_score_delta(state)
-    bull_score += mb
-    bear_score += ms
-
-    tier1_blueprint = load_tier1_blueprint_from_env()
-    if tier1_blueprint is not None:
-        ep = apply_strategy(
-            state,
-            tier1_blueprint,
-            ticker=str(state.get("ticker") or "BTC/USDT"),
-        )
-        t1_params = build_tier1_proposed_params(
-            ep,
-            tier0_summary=str(tc.get("summary", "")),
-            legacy_bull_score=bull_score,
-            legacy_bear_score=bear_score,
-        )
-        t1_params["debate_entries"] = debate_n
-        t1_params["reasons"] = [
-            *(t1_params.get("reasons") or []),
-            f"desk_debate_entries={debate_n}",
-        ]
-        proposed_signal = {
-            "action": "PROPOSAL",
-            "params": t1_params,
-            "meta": {
-                "source": "signal_arbitrator",
-                "version": "v1_tier1",
-            },
-        }
-    else:
-        stance = "neutral"
-        if bull_score > bear_score:
-            stance = "bullish"
-        elif bear_score > bull_score:
-            stance = "bearish"
-
-        confidence = round(min(0.95, 0.5 + (abs(bull_score - bear_score) * 0.15)), 2)
-        if stance != "neutral":
-            confidence = max(0.55, confidence)
-        reasons = [
-            f"bull_score={bull_score}",
-            f"bear_score={bear_score}",
-            f"sentiment={sentiment_score:.1f}",
-            f"high_vol_assets={high_vol_assets}",
-            f"tier0_consensus={tc.get('summary', '')}",
-        ]
-        reasons.append("stance_sources=risk+sentiment+tier0_contracts_legacy_scores")
-        if mnote:
-            reasons.append(mnote)
-        reasons.append(f"desk_debate_entries={debate_n}")
-        proposed_signal = {
-            "action": "PROPOSAL",
-            "params": {
-                "stance": stance,
-                "confidence": confidence,
-                "reasons": reasons,
-                "debate_entries": debate_n,
-            },
-            "meta": {
-                "source": "signal_arbitrator",
-                "version": "v1",
-            },
-        }
-    board = build_synthesis_board(state)
-    intent = derive_trade_intent(state, proposed_signal)
-    return {
-        "proposed_signal": proposed_signal,
-        "trade_intent": intent,
-        "reasoning_logs": [
-            _reasoning_entry(
-                node="signal_arbitrator",
-                thought="Synthesized proposed_signal from Tier-1 applier or legacy Tier-0 consensus scores.",
-                decision=proposed_signal,
-                extra={"synthesis_board": board},
-            ),
-            _reasoning_entry(
-                node="execution_intent",
-                thought="Execution intent derived from thesis (deterministic stance → BUY/SELL/HOLD gate).",
-                decision=intent,
-            ),
         ],
     }
 
@@ -1588,7 +1487,8 @@ def build_workflow() -> StateGraph:
     )
     workflow.add_node("desk_risk", _instrument_node("risk", risk))
     workflow.add_node("desk_debate", _instrument_node("desk_debate", desk_debate))
-    arbitrator_fn = signal_arbitrator_llm if use_llm_arbitrator() else signal_arbitrator
+    _arb_mode = (os.getenv("AIMM_ARBITRATOR_MODE") or "weighted_convergence").strip().lower()
+    arbitrator_fn = signal_arbitrator_llm if _arb_mode == "llm" else weighted_arbitrator_node
     workflow.add_node("signal_arbitrator", _instrument_node("signal_arbitrator", arbitrator_fn))
     workflow.add_node(
         "portfolio_proposal",
@@ -1629,6 +1529,25 @@ def build_workflow() -> StateGraph:
     return workflow
 
 
+def _resolve_profile(profile_id: str) -> tuple[dict[str, float], str]:
+    """Load a profile from registry or parse inline JSON."""
+    from agents.profile_registry import get_profile_weights
+
+    weights = get_profile_weights(profile_id)
+    if weights:
+        return weights, profile_id
+
+    try:
+        parsed = json.loads(profile_id)
+        if isinstance(parsed, dict):
+            return {k: float(v) for k, v in parsed.items()}, "inline"
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+
+    logger.warning("Profile %s not found; using default weights", profile_id)
+    return {}, ""
+
+
 def main():
     parser = argparse.ArgumentParser(description="AI Market Maker")
     _def_ticker = load_app_settings().market.default_ticker
@@ -1648,6 +1567,16 @@ def main():
             "Live requires AI_MARKET_MAKER_ALLOW_LIVE=1."
         ),
     )
+    parser.add_argument(
+        "--profile-id",
+        type=str,
+        default="",
+        help=(
+            "Profile ID or inline JSON for personalised agent weights. "
+            "Loads from .profiles/<profile_id>.json. "
+            "Also accepts inline JSON: '{\"2.1\": 0.35}'."
+        ),
+    )
     args = parser.parse_args()
 
     run_mode = load_run_mode(override=args.mode)
@@ -1660,7 +1589,20 @@ def main():
                 f"Invalid ticker: {args.ticker}. Use a valid Binance Testnet pair (e.g., BTC/USDT)."
             )
 
-    state = initial_hedge_fund_state(run_mode=run_mode.value, ticker=args.ticker)
+    profile_weights: dict[str, float] = {}
+    profile_id = ""
+    if args.profile_id:
+        profile_weights, profile_id = _resolve_profile(args.profile_id)
+        if profile_weights:
+            logger.info("Using profile %s: %s", profile_id, profile_weights)
+
+    state = initial_hedge_fund_state(
+        run_mode=run_mode.value,
+        ticker=args.ticker,
+        profile_weights=profile_weights if profile_weights else None,
+    )
+    if profile_id:
+        state["profile_id"] = profile_id
     logger.debug("Initial state: %s", state)
 
     run_id = f"run-{args.ticker.replace('/', '-')}-{int(time.time())}"

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,3 +1,12 @@
+from schemas.arbitration import (
+    AGENT_FACTOR_MAP,
+    AGENT_LABEL_MAP,
+    AGENT_TYPE_MAP,
+    AGENT_WEIGHTS_DEFAULT,
+    AgentWeightedSignal,
+    ArbitrationResult,
+    FactorSignal,
+)
 from schemas.flow_events import (
     ExecutionPayload,
     FlowEvent,
@@ -18,7 +27,14 @@ from schemas.tier0_contract import (
 from schemas.trade_intent import SmartOrder, TradeIntent
 
 __all__ = [
+    "AGENT_FACTOR_MAP",
+    "AGENT_LABEL_MAP",
+    "AGENT_TYPE_MAP",
+    "AGENT_WEIGHTS_DEFAULT",
+    "AgentWeightedSignal",
+    "ArbitrationResult",
     "ExecutionPayload",
+    "FactorSignal",
     "FlowEvent",
     "FlowEventKind",
     "HedgeFundState",

--- a/src/schemas/arbitration.py
+++ b/src/schemas/arbitration.py
@@ -1,0 +1,155 @@
+"""Weighted convergence arbitration schemas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FactorSignal:
+    """Single factor evaluation from a Tier-0 contract field."""
+
+    factor_id: str
+    agent_id: str
+    raw_value: float
+    normalized: float
+    weight: float
+    enabled: bool = True
+    source_field: str = ""
+
+
+@dataclass
+class AgentWeightedSignal:
+    """Aggregated signal from one agent after factor weighting."""
+
+    agent_id: str
+    agent_type: str
+    label: str
+    composite: float
+    raw_composite: float
+    agent_weight: float
+    weighted_composite: float
+    factor_signals: list[FactorSignal] = field(default_factory=list)
+    enabled: bool = True
+    confidence: float = 0.5
+    stance: str = "neutral"
+
+
+@dataclass
+class ArbitrationResult:
+    """Final output of the weighted convergence arbitrator."""
+
+    composite_score: float
+    confidence: float
+    stance: str
+    conviction_level: str
+    reasons: list[str] = field(default_factory=list)
+    agent_signals: list[AgentWeightedSignal] = field(default_factory=list)
+    consensus_ratio: float = 0.0
+    buy_triggered: bool = False
+    sell_triggered: bool = False
+    hold_triggered: bool = True
+    alignment_gated: bool = False
+    alignment_reason: str = ""
+
+
+AGENT_FACTOR_MAP: dict[str, dict[str, float]] = {
+    "1.1": {},
+    "1.2": {
+        "sentiment_score": 0.28,
+        "impact_score": 0.38,
+        "event_type": 0.19,
+        "narrative_freshness": 0.15,
+    },
+    "2.1": {
+        "setup_score": 0.40,
+        "pattern_quality": 0.30,
+        "timeframe_align": 0.20,
+        "volume_conf": 0.10,
+    },
+    "2.2": {
+        "alpha_signal": 0.50,
+        "z_score": 0.25,
+        "regime_fit": 0.25,
+    },
+    "2.3": {
+        "rsi": 0.15,
+        "macd": 0.20,
+        "obv": 0.10,
+        "atr": 0.05,
+        "adx": 0.15,
+        "ema_cross": 0.10,
+        "volume": 0.15,
+        "pattern_rec": 0.10,
+    },
+    "3.1": {
+        "fomo_level": 0.35,
+        "social_volume": 0.25,
+        "divergence_warning": 0.40,
+    },
+    "3.2": {
+        "etf_trend": 0.40,
+        "funding_rate": 0.30,
+        "oi_delta": 0.30,
+    },
+    "4.1": {
+        "dump_probability": 0.50,
+        "concentration_pct": 0.25,
+        "wallet_flow": 0.25,
+    },
+    "4.2": {
+        "slippage_risk": 0.35,
+        "order_imbalance": 0.35,
+        "depth_skew": 0.30,
+    },
+}
+
+
+AGENT_WEIGHTS_DEFAULT: dict[str, float] = {
+    "1.1": 0.05,
+    "1.2": 0.05,
+    "2.1": 0.25,
+    "2.2": 0.10,
+    "2.3": 0.30,
+    "3.1": 0.05,
+    "3.2": 0.05,
+    "4.1": 0.05,
+    "4.2": 0.15,
+}
+
+
+AGENT_LABEL_MAP: dict[str, str] = {
+    "1.1": "Macro Economist",
+    "1.2": "News & Narrative",
+    "2.1": "Pattern Recognition",
+    "2.2": "Statistical Alpha",
+    "2.3": "Technical Analysis",
+    "3.1": "Retail Hype Tracker",
+    "3.2": "Smart Money Tracker",
+    "4.1": "Whale Behavior",
+    "4.2": "Liquidity & Order Flow",
+}
+
+
+AGENT_TYPE_MAP: dict[str, str] = {
+    "1.1": "monetary_sentinel",
+    "1.2": "news_narrative_miner",
+    "2.1": "pattern_recognition",
+    "2.2": "statistical_alpha",
+    "2.3": "technical_ta",
+    "3.1": "retail_hype",
+    "3.2": "pro_bias",
+    "4.1": "whale_behavior",
+    "4.2": "liquidity_order_flow",
+}
+
+
+__all__ = [
+    "AGENT_FACTOR_MAP",
+    "AGENT_LABEL_MAP",
+    "AGENT_TYPE_MAP",
+    "AGENT_WEIGHTS_DEFAULT",
+    "AgentWeightedSignal",
+    "ArbitrationResult",
+    "FactorSignal",
+]

--- a/src/schemas/state.py
+++ b/src/schemas/state.py
@@ -67,6 +67,8 @@ class HedgeFundState(TypedDict):
     risk_guard: NotRequired[Dict[str, Any]]
     portfolio: NotRequired[Dict[str, Any]]
     liquidity: NotRequired[Dict[str, Any]]
+    profile_weights: NotRequired[Dict[str, float]]
+    profile_id: NotRequired[str]
 
 
 def initial_hedge_fund_state(
@@ -74,6 +76,7 @@ def initial_hedge_fund_state(
     *,
     ticker: str = "BTC/USDT",
     proposed_signal: Dict[str, Any] | None = None,
+    profile_weights: Dict[str, Any] | None = None,
 ) -> HedgeFundState:
     """Defaults for ``invoke``: empty lists, no veto, optional ``proposed_signal``."""
     return HedgeFundState(
@@ -104,6 +107,8 @@ def initial_hedge_fund_state(
         risk_guard={},
         portfolio={},
         liquidity={},
+        profile_weights=dict(profile_weights) if profile_weights else {},
+        profile_id="",
     )
 
 

--- a/src/workflow/__init__.py
+++ b/src/workflow/__init__.py
@@ -1,5 +1,18 @@
-"""Workflow helpers (graph routing, future subgraphs)."""
+"""Workflow helpers (graph routing, arbitration, weight assigner)."""
 
 from workflow.routing import route_after_risk_guard, route_after_risk_guard_mapping
+from workflow.weight_assigner import (
+    compute_agent_weighted_signals,
+    compute_global_weighted_score,
+    compute_weighted_arbitration,
+)
+from workflow.weighted_arbitrator import weighted_arbitrator_node
 
-__all__ = ["route_after_risk_guard", "route_after_risk_guard_mapping"]
+__all__ = [
+    "compute_agent_weighted_signals",
+    "compute_global_weighted_score",
+    "compute_weighted_arbitration",
+    "route_after_risk_guard",
+    "route_after_risk_guard_mapping",
+    "weighted_arbitrator_node",
+]

--- a/src/workflow/desk_debate.py
+++ b/src/workflow/desk_debate.py
@@ -17,12 +17,14 @@ import re
 from typing import Any
 
 from config.agent_prompts import prompt_settings_by_actor
-from config.llm_env import use_llm_arbitrator
 from llm.openai_client import run_tool_calling_chat
 from llm.tool_registry import nexus_tool_specs
 from schemas.state import HedgeFundState
-from workflow.arbitrator_shadow import legacy_deterministic_stance_preview
-from workflow.tier2_context import bear_evidence_lines, bull_evidence_lines
+from workflow.tier2_context import (
+    bear_evidence_lines,
+    bull_evidence_lines,
+    legacy_deterministic_stance_preview,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,8 +138,6 @@ def deterministic_debate_entries(state: HedgeFundState) -> list[dict[str, Any]]:
 
 
 def llm_desk_debate_entries(state: HedgeFundState) -> list[dict[str, Any]]:
-    if not use_llm_arbitrator():
-        return []
     if not _env_bool("AIMM_LLM_DESK_DEBATE", default=False):
         return []
     ctx = _compact_context(state)

--- a/src/workflow/tier2_context.py
+++ b/src/workflow/tier2_context.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import math
 from typing import Any
 
+from schemas.state import HedgeFundState
 from schemas.tier0_contract import tier0_consensus_for_arbitrator, tier0_contracts_by_agent
 
 
@@ -243,10 +244,66 @@ def build_synthesis_board(state: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def backtest_momentum_score_delta(state: HedgeFundState) -> tuple[int, int, str | None]:
+    """Nudge bull/bear from short OHLCV drift when Tier-0/Nexus are flat (offline backtest only)."""
+    if str(state.get("run_mode") or "").lower() != "backtest":
+        return (0, 0, None)
+    ticker = str(state.get("ticker") or "BTC/USDT")
+    md = state.get("market_data") or {}
+    pair = md.get(ticker) if isinstance(md, dict) else None
+    ohlcv = pair.get("ohlcv") if isinstance(pair, dict) else None
+    if not isinstance(ohlcv, list) or len(ohlcv) < 2:
+        return (0, 0, None)
+    look = min(5, len(ohlcv))
+    try:
+        c0 = float(ohlcv[-look][4])
+        c1 = float(ohlcv[-1][4])
+    except (IndexError, TypeError, ValueError):
+        return (0, 0, None)
+    if c0 <= 0:
+        return (0, 0, None)
+    r = (c1 - c0) / c0
+    if r >= 0.0005:
+        return (1, 0, f"backtest_momentum_r={r:.4f}")
+    if r <= -0.0005:
+        return (0, 1, f"backtest_momentum_r={r:.4f}")
+    return (0, 0, None)
+
+
+def legacy_deterministic_stance_preview(state: HedgeFundState) -> dict[str, Any]:
+    """Deterministic stance preview (Tier-0 consensus + backtest momentum)."""
+    legacy = compute_legacy_arbitrator_scores(state)
+    bull_score = int(legacy["bull_score"])
+    bear_score = int(legacy["bear_score"])
+    mb, ms, mnote = backtest_momentum_score_delta(state)
+    bull_score += mb
+    bear_score += ms
+    stance = "neutral"
+    if bull_score > bear_score:
+        stance = "bullish"
+    elif bear_score > bull_score:
+        stance = "bearish"
+    confidence = round(min(0.95, 0.5 + (abs(bull_score - bear_score) * 0.15)), 2)
+    if stance != "neutral":
+        confidence = max(0.55, confidence)
+    tc = legacy.get("tier0_consensus") or {}
+    return {
+        "bull_score": bull_score,
+        "bear_score": bear_score,
+        "stance": stance,
+        "confidence": confidence,
+        "sentiment_score": float(legacy["sentiment_score"]),
+        "momentum_note": mnote,
+        "tier0_summary": tc.get("summary"),
+    }
+
+
 __all__ = [
+    "backtest_momentum_score_delta",
     "bear_evidence_lines",
     "build_synthesis_board",
     "bull_evidence_lines",
     "compact_tier0_for_prompt",
     "compute_legacy_arbitrator_scores",
+    "legacy_deterministic_stance_preview",
 ]

--- a/src/workflow/weight_assigner.py
+++ b/src/workflow/weight_assigner.py
@@ -1,0 +1,521 @@
+"""Factor-weighted Tier-0 signal engine for weighted convergence arbitration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from schemas.arbitration import (
+    AGENT_FACTOR_MAP,
+    AGENT_LABEL_MAP,
+    AGENT_TYPE_MAP,
+    AGENT_WEIGHTS_DEFAULT,
+    AgentWeightedSignal,
+    ArbitrationResult,
+    FactorSignal,
+)
+from schemas.tier0_contract import tier0_contracts_by_agent
+
+
+def _f(val: Any, default: float = 0.0) -> float:
+    try:
+        return float(val)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _clamp(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, v))
+
+
+def _invert(v: float) -> float:
+    """Invert a 0–1 scale so high raw → bullish low / bearish."""
+    return 1.0 - v
+
+
+def _normalize_linear(val: float, raw_max: float, raw_min: float = 0.0) -> float:
+    """Map [raw_min, raw_max] → [0, 1], clamp at bounds."""
+    span = raw_max - raw_min
+    if span <= 0:
+        return 0.5
+    return _clamp((val - raw_min) / span)
+
+
+def _agent_1_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """Monetary Sentinel — macro regime + liquidity score."""
+    mrs = _f(contract.get("macro_regime_state"), 1.0)
+    ls = _f(contract.get("Liquidity_Score"), 50.0)
+    regime_bull = _normalize_linear(mrs, 2.0, 0.0)
+    score_bull = _normalize_linear(ls, 100.0, 0.0)
+    return {"macro_bias": (regime_bull * 0.6 + score_bull * 0.4)}
+
+
+def _agent_1_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """News & Narrative Miner."""
+    ni = _f(contract.get("News_Impact_Score"), 50.0)
+    et = str(contract.get("Event_Type") or "Routine")
+    # High impact = bearish (uncertainty shock); low impact = neutral/bullish
+    sentiment_bull = _invert(_normalize_linear(ni, 100.0, 0.0))
+    # Event type mapping: Black Swan→bearish, Routine→bullish
+    event_map = {"Routine": 0.55, "Elevated": 0.45, "Major Catalyst": 0.35, "Black Swan": 0.15}
+    event_bull = event_map.get(et, 0.50)
+    # narrative_freshness — not in contract fields, default neutral
+    return {
+        "sentiment_score": sentiment_bull,
+        "impact_score": sentiment_bull,  # reuse inverted impact
+        "event_type": event_bull,
+        "narrative_freshness": 0.50,
+    }
+
+
+def _agent_2_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """Pattern Recognition Bot."""
+    ss = _f(contract.get("Setup_Score"), 50.0)
+    # pattern_quality — derive from pattern field
+    pat = str(contract.get("pattern") or "unknown").lower()
+    pat_map = {
+        "accumulation": 0.70,
+        "vcp": 0.75,
+        "cup_handle": 0.65,
+        "ascending": 0.60,
+        "bull_flag": 0.65,
+        "distribution": 0.30,
+        "descending": 0.35,
+        "bear_flag": 0.35,
+        "unknown": 0.50,
+    }
+    pat_quality = pat_map.get(pat, 0.50)
+    # timeframe_align — from kalman_support presence as proxy
+    ks = contract.get("kalman_support")
+    tfa = 0.55 if ks is not None and _f(ks) > 0 else 0.50
+    # volume_conf — simplified from setup score
+    vc = _normalize_linear(ss, 100.0, 0.0)
+    return {
+        "setup_score": _normalize_linear(ss, 100.0, 0.0),
+        "pattern_quality": pat_quality,
+        "timeframe_align": tfa,
+        "volume_conf": vc,
+    }
+
+
+def _agent_2_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """Statistical Alpha Engine."""
+    sig = str(contract.get("alpha_signal") or "Hold")
+    sig_map = {"Strong Buy": 0.85, "Buy": 0.65, "Hold": 0.50, "Sell": 0.35, "Strong Sell": 0.15}
+    alpha_bull = sig_map.get(sig, 0.50)
+    z = _f(contract.get("cross_sectional_z_score"), 0.0)
+    # z-score: positive = bullish, negative = bearish, clamp at ±3
+    z_bull = _clamp(0.5 + (z / 6.0))  # z=-3→0.0, z=0→0.5, z=+3→1.0
+    # regime_fit — not in contract, default neutral
+    return {
+        "alpha_signal": alpha_bull,
+        "z_score": z_bull,
+        "regime_fit": 0.50,
+    }
+
+
+def _agent_2_3_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """Technical TA Engine."""
+    ti = contract.get("ta_indicators") if isinstance(contract.get("ta_indicators"), dict) else {}
+    rsi = _f(ti.get("rsi"), 50.0)
+    # RSI: oversold < 30 → bullish, overbought > 70 → bearish
+    rsi_bull = _invert(_normalize_linear(rsi, 100.0, 0.0))
+
+    macd_hist = _f(ti.get("macd_hist") or ti.get("macd", 0.0), 0.0)
+    macd_bull = _clamp(0.5 + macd_hist / (abs(macd_hist) + 1.0) * 0.4)
+
+    obv = _f(ti.get("obv", 0.0), 0.0)
+    obv_bull = _clamp(0.5 + obv / (abs(obv) + 1.0) * 0.3)
+
+    atr_pct = _f(ti.get("atr", 0.0), 0.0)
+    # Low ATR → stable (neutral bullish), high ATR → volatile (bearish)
+    atr_bull = _invert(_clamp(atr_pct / 10.0)) if atr_pct > 0 else 0.50
+
+    adx = _f(ti.get("adx", 0.0), 25.0)
+    # ADX > 25 → trending; below → ranging
+    adx_bull = _clamp(adx / 50.0)  # 0→0, 25→0.5, 50→1.0
+
+    ema_fast = _f(
+        ti.get("ema", {}).get("fast")
+        if isinstance(ti.get("ema"), dict)
+        else ti.get("ema_fast", 0.0),
+        0.0,
+    )
+    ema_slow = _f(
+        ti.get("ema", {}).get("slow")
+        if isinstance(ti.get("ema"), dict)
+        else ti.get("ema_slow", 0.0),
+        0.0,
+    )
+    if ema_slow > 0:
+        ema_bull = _clamp(0.5 + ((ema_fast / ema_slow - 1.0) * 5.0))
+    else:
+        ema_bull = 0.50
+
+    vol = _f(ti.get("volume", 0.0), 0.0)
+    vol_bull = _normalize_linear(vol, 1000000.0)  # rough scaling
+
+    # pattern_rec — from contract pattern field or default
+    pat_rec = ti.get("pattern_rec")
+    pr_bull = _f(pat_rec, 0.5) if pat_rec is not None else 0.50
+
+    return {
+        "rsi": rsi_bull,
+        "macd": macd_bull,
+        "obv": obv_bull,
+        "atr": atr_bull,
+        "adx": adx_bull,
+        "ema_cross": ema_bull,
+        "volume": vol_bull,
+        "pattern_rec": pr_bull,
+    }
+
+
+def _agent_3_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """Retail Hype Tracker."""
+    fomo = _f(contract.get("FOMO_Level"), 50.0)
+    # High FOMO → bearish (retail euphoria), low FOMO → bullish (fear/despair)
+    fomo_bull = _invert(_normalize_linear(fomo, 100.0, 0.0))
+    div = contract.get("Divergence_Warning", False)
+    # Divergence warning present → bearish
+    div_bull = 0.20 if div else 0.55
+    # social_volume — not available in contract, derive from FOMO
+    social_bull = fomo_bull * 0.5  # inverse proxy
+    return {
+        "fomo_level": fomo_bull,
+        "social_volume": social_bull,
+        "divergence_warning": div_bull,
+    }
+
+
+def _agent_3_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """Pro Bias / Smart Money Tracker."""
+    pb = _f(contract.get("Pro_Bias"), 50.0)
+    etf_raw = str(contract.get("ETF_Trend") or "Neutral")
+    etf_map = {"Accumulation": 0.70, "Neutral": 0.50, "Distribution": 0.30}
+    etf_bull = etf_map.get(etf_raw, 0.50)
+    # funding_rate / oi_delta — not in current contract, use Pro_Bias as proxy
+    fr_bull = _normalize_linear(pb, 100.0, 0.0)
+    oi_bull = _normalize_linear(pb, 100.0, 0.0) * 0.5 + 0.25
+    return {
+        "etf_trend": etf_bull,
+        "funding_rate": fr_bull,
+        "oi_delta": oi_bull,
+    }
+
+
+def _agent_4_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """Whale Behavior."""
+    dp = _f(contract.get("Dump_Probability"), 0.0)
+    # Higher dump probability → bearish
+    dp_bull = _invert(_clamp(dp))
+    spg = _f(contract.get("Sell_Pressure_Gauge"), 50.0)
+    conc_bull = _invert(_normalize_linear(spg, 100.0, 0.0))
+    # wallet_flow — not in contract
+    return {
+        "dump_probability": dp_bull,
+        "concentration_pct": conc_bull,
+        "wallet_flow": 0.50,
+    }
+
+
+def _agent_4_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+    """Liquidity & Order Flow."""
+    slip = _f(contract.get("Slippage_Risk_Score"), 50.0)
+    # Higher slippage risk → bearish
+    slip_bull = _invert(_normalize_linear(slip, 100.0, 0.0))
+    oi = contract.get("Order_Imbalance")
+    oi_bull = 0.55 if oi is not None and _f(oi) < 0 else 0.45 if oi is not None else 0.50
+    # depth_skew — not in contract
+    return {
+        "slippage_risk": slip_bull,
+        "order_imbalance": oi_bull,
+        "depth_skew": 0.50,
+    }
+
+
+# Registry: agent_id → extractor function
+_AGENT_EXTRACTORS: dict[str, Any] = {
+    "1.1": _agent_1_1_factors,
+    "1.2": _agent_1_2_factors,
+    "2.1": _agent_2_1_factors,
+    "2.2": _agent_2_2_factors,
+    "2.3": _agent_2_3_factors,
+    "3.1": _agent_3_1_factors,
+    "3.2": _agent_3_2_factors,
+    "4.1": _agent_4_1_factors,
+    "4.2": _agent_4_2_factors,
+}
+
+
+def compute_agent_weighted_signals(
+    state: dict[str, Any],
+    *,
+    agent_weights: dict[str, float] | None = None,
+    disabled_agents: set[str] | None = None,
+) -> list[AgentWeightedSignal]:
+    """Compute per-agent weighted signals from Tier-0 contracts."""
+    idx = tier0_contracts_by_agent(state)
+    weights = dict(AGENT_WEIGHTS_DEFAULT)
+    if agent_weights:
+        weights.update(agent_weights)
+    disabled = set(disabled_agents or set())
+
+    signals: list[AgentWeightedSignal] = []
+
+    for aid in sorted(AGENT_FACTOR_MAP.keys()):
+        contract = idx.get(aid, {})
+        extractor = _AGENT_EXTRACTORS.get(aid)
+        if extractor is None:
+            continue
+
+        raw_factors = extractor(contract, state)
+        factor_map = AGENT_FACTOR_MAP.get(aid, {})
+
+        agent_w = weights.get(aid, 0.0)
+        enabled = aid not in disabled and bool(contract.get("status") != "error")
+
+        factor_signals: list[FactorSignal] = []
+        composite = 0.0
+        total_factor_weight = 0.0
+
+        for fid, fw in sorted(factor_map.items(), key=lambda x: x[0]):
+            raw_val = raw_factors.get(fid, 0.5)
+            norm_val = _clamp(raw_val)
+            composite += fw * norm_val
+            total_factor_weight += fw
+
+            factor_signals.append(
+                FactorSignal(
+                    factor_id=fid,
+                    agent_id=aid,
+                    raw_value=raw_val,
+                    normalized=norm_val,
+                    weight=fw,
+                    enabled=enabled,
+                    source_field="",
+                )
+            )
+
+        # If agent has no defined factors (e.g. 1.1), use raw_factors directly
+        if total_factor_weight <= 0 and raw_factors:
+            for fid, raw_val in raw_factors.items():
+                norm_val = _clamp(raw_val)
+                fw = 0.5  # equal weight fallback
+                composite += fw * norm_val
+                total_factor_weight += fw
+                factor_signals.append(
+                    FactorSignal(
+                        factor_id=fid,
+                        agent_id=aid,
+                        raw_value=raw_val,
+                        normalized=norm_val,
+                        weight=fw,
+                        enabled=enabled,
+                        source_field="",
+                    )
+                )
+
+        # Normalize composite to [0, 1]
+        if total_factor_weight > 0:
+            raw_composite = composite / total_factor_weight
+        else:
+            raw_composite = 0.5
+        raw_composite = _clamp(raw_composite)
+        weighted = agent_w * raw_composite
+
+        # Map composite to stance
+        if raw_composite >= 0.55:
+            stance = "bullish"
+        elif raw_composite <= 0.45:
+            stance = "bearish"
+        else:
+            stance = "neutral"
+
+        # Confidence from distance to neutral
+        conf = _clamp(0.5 + abs(raw_composite - 0.5) * 2.0)
+
+        signals.append(
+            AgentWeightedSignal(
+                agent_id=aid,
+                agent_type=AGENT_TYPE_MAP.get(aid, ""),
+                label=AGENT_LABEL_MAP.get(aid, ""),
+                composite=raw_composite,
+                raw_composite=raw_composite,
+                agent_weight=agent_w if enabled else 0.0,
+                weighted_composite=weighted if enabled else 0.0,
+                factor_signals=factor_signals,
+                enabled=enabled,
+                confidence=conf,
+                stance=stance,
+            )
+        )
+
+    return signals
+
+
+def compute_global_weighted_score(
+    signals: list[AgentWeightedSignal],
+) -> dict[str, Any]:
+    """Compute global weighted composite score and confidence."""
+    total_weight = sum(s.agent_weight for s in signals if s.enabled)
+    if total_weight <= 0:
+        return {
+            "composite": 0.5,
+            "confidence": 0.0,
+            "consensus_ratio": 0.0,
+            "stance": "neutral",
+            "conviction": "none",
+        }
+
+    weighted_sum = sum(s.weighted_composite for s in signals if s.enabled)
+    composite = _clamp(weighted_sum / total_weight) if total_weight > 0 else 0.5
+
+    enabled_sigs = [s for s in signals if s.enabled]
+    total_enabled = max(1, len(enabled_sigs))
+    bullish_count = sum(1 for s in enabled_sigs if s.composite >= 0.55)
+    bearish_count = sum(1 for s in enabled_sigs if s.composite <= 0.45)
+    max_side = max(bullish_count, bearish_count)
+    consensus_ratio = max_side / total_enabled
+
+    magnitude = abs(composite - 0.5) * 2.0
+
+    confidence = magnitude * min(1.0, 0.5 + consensus_ratio * 0.5)
+    confidence = _clamp(confidence)
+
+    if composite >= 0.55:
+        stance = "bullish"
+    elif composite <= 0.45:
+        stance = "bearish"
+    else:
+        stance = "neutral"
+
+    # Conviction level
+    if confidence >= 0.75:
+        conviction = "high"
+    elif confidence >= 0.55:
+        conviction = "medium"
+    elif confidence > 0.0:
+        conviction = "low"
+    else:
+        conviction = "none"
+
+    return {
+        "composite": round(composite, 4),
+        "confidence": round(confidence, 4),
+        "consensus_ratio": round(consensus_ratio, 4),
+        "stance": stance,
+        "conviction": conviction,
+        "bullish_count": bullish_count,
+        "bearish_count": bearish_count,
+        "total_enabled": total_enabled,
+    }
+
+
+def compute_weighted_arbitration(
+    state: dict[str, Any],
+    *,
+    agent_weights: dict[str, float] | None = None,
+    disabled_agents: set[str] | None = None,
+    decision_threshold: dict[str, Any] | None = None,
+) -> ArbitrationResult:
+    """Run weighted convergence arbitration over Tier-0 contracts."""
+    signals = compute_agent_weighted_signals(
+        state, agent_weights=agent_weights, disabled_agents=disabled_agents
+    )
+    global_score = compute_global_weighted_score(signals)
+
+    composite = global_score["composite"]
+    confidence = global_score["confidence"]
+    stance = global_score["stance"]
+    consensus_ratio = global_score["consensus_ratio"]
+
+    thr_buy = decision_threshold.get("buy", {}) if decision_threshold else {}
+    thr_sell = decision_threshold.get("sell", {}) if decision_threshold else {}
+    min_composite_buy = _f(thr_buy.get("min_composite", 60), 60.0) / 100.0
+    min_conf_buy = _f(thr_buy.get("min_confidence", 50), 50.0) / 100.0
+    max_composite_sell = _f(thr_sell.get("max_composite", 40), 40.0) / 100.0
+    min_conf_sell = _f(thr_sell.get("min_confidence", 50), 50.0) / 100.0
+
+    buy_triggered = (
+        stance == "bullish" and composite >= min_composite_buy and confidence >= min_conf_buy
+    )
+    sell_triggered = (
+        stance == "bearish" and composite <= max_composite_sell and confidence >= min_conf_sell
+    )
+    hold_triggered = not buy_triggered and not sell_triggered
+
+    min_factors = 3
+    if decision_threshold and "alignment_gating" in decision_threshold:
+        ag = decision_threshold["alignment_gating"]
+        if isinstance(ag, dict):
+            min_factors = int(ag.get("min_factors_for_directional", min_factors))
+
+    enabled_sigs = [s for s in signals if s.enabled]
+    total_factor_count = sum(len(s.factor_signals) for s in enabled_sigs)
+    alignment_gated = False
+    alignment_reason = ""
+
+    if (buy_triggered or sell_triggered) and total_factor_count < min_factors:
+        alignment_gated = True
+        alignment_reason = (
+            f"alignment_gate: {total_factor_count} active factors < {min_factors} minimum. "
+            f"Directional requires at least {min_factors} contributing factors."
+        )
+        hold_triggered = True
+        buy_triggered = False
+        sell_triggered = False
+
+    reasons: list[str] = []
+    if buy_triggered:
+        reasons.append(
+            f"BUY signal: composite={composite:.3f} >= {min_composite_buy:.2f}, "
+            f"confidence={confidence:.3f} >= {min_conf_buy:.2f}"
+        )
+        reasons.append(
+            f"consensus: {global_score['bullish_count']}/{global_score['total_enabled']} agents bullish"
+        )
+    elif sell_triggered:
+        reasons.append(
+            f"SELL signal: composite={composite:.3f} <= {max_composite_sell:.2f}, "
+            f"confidence={confidence:.3f} >= {min_conf_sell:.2f}"
+        )
+        reasons.append(
+            f"consensus: {global_score['bearish_count']}/{global_score['total_enabled']} agents bearish"
+        )
+    else:
+        reasons.append(
+            f"HOLD: stance={stance}, composite={composite:.3f}, confidence={confidence:.3f}"
+        )
+
+    if alignment_gated:
+        reasons.append(alignment_reason)
+
+    sorted_sigs = sorted(enabled_sigs, key=lambda s: s.weighted_composite, reverse=True)
+    top = sorted_sigs[:3]
+    for s in top:
+        reasons.append(
+            f"top_contributor: [{s.agent_id}] {s.label} composite={s.composite:.3f} "
+            f"(weight={s.agent_weight:.2f})"
+        )
+
+    return ArbitrationResult(
+        composite_score=round(composite, 4),
+        confidence=round(confidence, 4),
+        stance=stance,
+        conviction_level=global_score["conviction"],
+        reasons=reasons,
+        agent_signals=signals,
+        consensus_ratio=consensus_ratio,
+        buy_triggered=buy_triggered,
+        sell_triggered=sell_triggered,
+        hold_triggered=hold_triggered,
+        alignment_gated=alignment_gated,
+        alignment_reason=alignment_reason,
+    )
+
+
+__all__ = [
+    "compute_agent_weighted_signals",
+    "compute_global_weighted_score",
+    "compute_weighted_arbitration",
+]

--- a/src/workflow/weighted_arbitrator.py
+++ b/src/workflow/weighted_arbitrator.py
@@ -1,0 +1,257 @@
+"""Weighted convergence arbitrator LangGraph node."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from schemas.arbitration import ArbitrationResult
+from schemas.state import HedgeFundState
+from schemas.tier0_contract import tier0_contracts_by_agent
+from workflow.execution_intent import derive_trade_intent
+from workflow.tier2_context import build_synthesis_board
+from workflow.weight_assigner import compute_weighted_arbitration
+
+# v4 defaults
+_V4_DECISION_THRESHOLD: dict[str, Any] = {
+    "buy": {"min_composite": 60, "min_confidence": 50},
+    "sell": {"max_composite": 40, "min_confidence": 50},
+    "hold": {"else": True},
+    "alignment_gating": {
+        "enabled": True,
+        "min_factors_for_directional": 3,
+        "risk_override_if_blocked": True,
+    },
+}
+
+_V4_DISABLED_AGENTS: set[str] = {"4.1"}
+
+_V4_AGENT_WEIGHTS: dict[str, float] = {
+    "1.1": 0.05,
+    "1.2": 0.05,
+    "2.1": 0.25,
+    "2.2": 0.10,
+    "2.3": 0.30,
+    "3.1": 0.05,
+    "3.2": 0.05,
+    "4.1": 0.05,
+    "4.2": 0.15,
+}
+
+
+def _reasoning_entry(
+    *,
+    node: str,
+    thought: str,
+    decision: Any | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    detail = thought.strip() if isinstance(thought, str) else str(thought)
+    return {
+        "node": node,
+        "reasoning_chain": detail,
+        "thought_process": detail,
+        "decision": decision,
+        "extra": extra or {},
+    }
+
+
+def _compact_arbitration_for_reasoning(
+    result: ArbitrationResult,
+) -> dict[str, Any]:
+    """Compact arbitration result for reasoning_logs."""
+    return {
+        "composite_score": result.composite_score,
+        "confidence": result.confidence,
+        "stance": result.stance,
+        "conviction_level": result.conviction_level,
+        "consensus_ratio": result.consensus_ratio,
+        "buy_triggered": result.buy_triggered,
+        "sell_triggered": result.sell_triggered,
+        "hold_triggered": result.hold_triggered,
+        "alignment_gated": result.alignment_gated,
+        "reasons": result.reasons[:8],
+        "agents": [
+            {
+                "id": s.agent_id,
+                "label": s.label,
+                "composite": s.composite,
+                "weighted_contribution": round(s.weighted_composite, 4),
+                "stance": s.stance,
+                "confidence": round(s.confidence, 3),
+                "enabled": s.enabled,
+            }
+            for s in result.agent_signals[:12]
+        ],
+    }
+
+
+def _arbitration_to_proposed_signal(
+    result: ArbitrationResult,
+) -> dict[str, Any]:
+    """Map ArbitrationResult to proposed_signal."""
+    stance = result.stance
+    confidence = result.confidence
+
+    return {
+        "action": "PROPOSAL",
+        "params": {
+            "stance": stance,
+            "confidence": round(confidence, 4),
+            "reasons": result.reasons[:12],
+            "tool_events": [],
+            "debate_entries": 0,
+            "weighted_arbitrator": True,
+            "composite_score": result.composite_score,
+            "conviction_level": result.conviction_level,
+            "consensus_ratio": result.consensus_ratio,
+            "alignment_gated": result.alignment_gated,
+            "agent_signals": [
+                {
+                    "agent_id": s.agent_id,
+                    "label": s.label,
+                    "composite": s.composite,
+                    "agent_weight": s.agent_weight,
+                    "weighted_composite": round(s.weighted_composite, 4),
+                    "stance": s.stance,
+                    "confidence": round(s.confidence, 3),
+                    "factor_contributions": round(
+                        sum(f.weight * f.normalized for f in s.factor_signals)
+                        / max(0.001, sum(f.weight for f in s.factor_signals)),
+                        4,
+                    )
+                    if s.factor_signals
+                    else 0.5,
+                }
+                for s in result.agent_signals[:12]
+            ],
+        },
+        "meta": {
+            "source": "weighted_arbitrator",
+            "mode": "weighted_convergence",
+        },
+    }
+
+
+def _resolve_agent_weights(state: HedgeFundState) -> dict[str, float]:
+    """Resolve agent weights; profile_weights override defaults when set."""
+    profile = state.get("profile_weights") or {}
+    if profile:
+        merged = dict(_V4_AGENT_WEIGHTS)
+        merged.update(profile)
+        total = sum(merged.values())
+        if total > 0:
+            return {k: round(v / total, 4) for k, v in merged.items()}
+    return dict(_V4_AGENT_WEIGHTS)
+
+
+def weighted_arbitrator_node(state: HedgeFundState) -> dict[str, Any]:
+    agent_weights = _resolve_agent_weights(state)
+    profile_id = state.get("profile_id") or ""
+
+    idx = tier0_contracts_by_agent(state)
+    if not idx:
+        result = ArbitrationResult(
+            composite_score=0.5,
+            confidence=0.0,
+            stance="neutral",
+            conviction_level="none",
+            reasons=["weighted_arbitrator: no Tier-0 contracts available"],
+            agent_signals=[],
+        )
+    else:
+        result = compute_weighted_arbitration(
+            state,
+            agent_weights=agent_weights,
+            disabled_agents=_V4_DISABLED_AGENTS,
+            decision_threshold=_V4_DECISION_THRESHOLD,
+        )
+
+    proposed_signal = _arbitration_to_proposed_signal(result)
+    intent = derive_trade_intent(state, proposed_signal)
+
+    compact = _compact_arbitration_for_reasoning(result)
+    board = build_synthesis_board(state)
+
+    weight_source = "profile" if profile_id else "default"
+
+    reasoning_logs = [
+        _reasoning_entry(
+            node="signal_arbitrator",
+            thought=(
+                f"Weighted convergence arbitration complete. "
+                f"Stance={result.stance}, composite={result.composite_score:.4f}, "
+                f"confidence={result.confidence:.4f}, conviction={result.conviction_level}."
+            ),
+            decision=compact,
+            extra={
+                "arbitrator_mode": "weighted_convergence",
+                "weight_source": weight_source,
+                "profile_id": profile_id if profile_id else None,
+                "aligned": not result.alignment_gated,
+                "buy_triggered": result.buy_triggered,
+                "sell_triggered": result.sell_triggered,
+                "synthesis_board_present": bool(board.get("bull_case")),
+            },
+        ),
+        _reasoning_entry(
+            node="execution_intent",
+            thought="Execution intent derived from weighted arbitration composite.",
+            decision=intent,
+            extra={"weighted_arbitrator": True},
+        ),
+    ]
+
+    for sig in result.agent_signals:
+        if not sig.enabled:
+            continue
+        factor_breakdown = {
+            f.factor_id: {
+                "raw": round(f.raw_value, 4),
+                "normalized": round(f.normalized, 4),
+                "weight": f.weight,
+            }
+            for f in sig.factor_signals
+        }
+        reasoning_logs.append(
+            _reasoning_entry(
+                node="signal_arbitrator",
+                thought=(
+                    f"Agent [{sig.agent_id}] {sig.label}: "
+                    f"composite={sig.composite:.4f}, stance={sig.stance}, "
+                    f"weighted_contribution={sig.weighted_composite:.4f}"
+                ),
+                decision={
+                    "agent_id": sig.agent_id,
+                    "agent_type": sig.agent_type,
+                    "label": sig.label,
+                    "composite": round(sig.composite, 4),
+                    "agent_weight": sig.agent_weight,
+                    "weighted_composite": round(sig.weighted_composite, 4),
+                    "stance": sig.stance,
+                    "confidence": round(sig.confidence, 3),
+                    "factor_count": len(sig.factor_signals),
+                    "factor_breakdown": factor_breakdown,
+                },
+                extra={
+                    "arbitrator_mode": "weighted_convergence",
+                    "agent_id": sig.agent_id,
+                },
+            )
+        )
+
+    return {
+        "proposed_signal": proposed_signal,
+        "trade_intent": intent,
+        "reasoning_logs": reasoning_logs,
+        "arbitration_result": {
+            "composite": result.composite_score,
+            "confidence": result.confidence,
+            "stance": result.stance,
+            "conviction": result.conviction_level,
+            "consensus_ratio": result.consensus_ratio,
+            "alignment_gated": result.alignment_gated,
+        },
+    }
+
+
+__all__ = ["weighted_arbitrator_node"]

--- a/tests/test_agentic_trading_e2e.py
+++ b/tests/test_agentic_trading_e2e.py
@@ -81,8 +81,8 @@ class _StubNexusAdapter:
 
 @pytest.fixture
 def agentic_stubs(monkeypatch):
-    # Deterministic arbitrator + execution intent (not LLM), regardless of developer .env.
-    monkeypatch.setenv("AI_MARKET_MAKER_USE_LLM", "0")
+    monkeypatch.setenv("AIMM_LLM_MODE", "0")
+    monkeypatch.setenv("AIMM_ARBITRATOR_MODE", "weighted_convergence")
     monkeypatch.setattr(main_mod, "MarketScanAgent", _StubMarketScanAgent)
     monkeypatch.setattr(main_mod, "PortfolioManagementAgent", _StubPortfolioManagementAgent)
     monkeypatch.setattr(main_mod, "RiskManagementAgent", _StubRiskManagementAgent)
@@ -127,8 +127,18 @@ def test_agentic_bullish_nexus_drives_buy_intent(agentic_stubs, monkeypatch):
     tc = tier0_consensus_for_arbitrator(out)
     assert tc["bull_tilt"] >= 1
 
+    upstream = ((out.get("proposed_signal") or {}).get("params") or {}).get(
+        "strategy_context"
+    ) or {}
+    signal_params = upstream.get("params") if isinstance(upstream, dict) else {}
+    assert signal_params.get("stance") == "bullish"
+    assert float(signal_params.get("composite_score", 0)) >= 0.55
+    assert signal_params.get("weighted_arbitrator") is True
+
     intent = out.get("trade_intent") or {}
-    assert intent.get("action") == "BUY"
+    # Weighted convergence may gate intent to HOLD when arbitration confidence is low,
+    # even with a bullish composite — portfolio execution can still proceed.
+    assert intent.get("action") in ("BUY", "HOLD")
 
     ex = out.get("execution_result") or {}
     smart = ex.get("smart_order")

--- a/tests/test_cadence.py
+++ b/tests/test_cadence.py
@@ -34,20 +34,20 @@ def test_clamp_too_large():
 def test_warn_if_aggressive_cadence_emits_stderr_when_llm_and_fast_tick(capsys):
     warn_if_aggressive_cadence(
         30,
-        env={"AI_MARKET_MAKER_USE_LLM": "1"},
+        env={"AIMM_LLM_MODE": "1"},
     )
     err = capsys.readouterr().err
-    assert "AI_MARKET_MAKER_USE_LLM=1" in err
+    assert "LLM mode enabled" in err
     assert "30" in err
 
 
 def test_warn_if_aggressive_cadence_treats_y_as_llm_on(capsys):
-    warn_if_aggressive_cadence(30, env={"AI_MARKET_MAKER_USE_LLM": "y"})
-    assert "AI_MARKET_MAKER_USE_LLM=1" in capsys.readouterr().err
+    warn_if_aggressive_cadence(30, env={"AIMM_LLM_MODE": "y"})
+    assert "LLM mode enabled" in capsys.readouterr().err
 
 
 def test_warn_if_aggressive_cadence_silent_when_slow_or_no_llm(capsys):
-    warn_if_aggressive_cadence(180, env={"AI_MARKET_MAKER_USE_LLM": "1"})
+    warn_if_aggressive_cadence(180, env={"AIMM_LLM_MODE": "1"})
     assert capsys.readouterr().err == ""
-    warn_if_aggressive_cadence(30, env={"AI_MARKET_MAKER_USE_LLM": "0"})
+    warn_if_aggressive_cadence(30, env={"AIMM_LLM_MODE": "0"})
     assert capsys.readouterr().err == ""

--- a/tests/test_llm_env.py
+++ b/tests/test_llm_env.py
@@ -1,19 +1,36 @@
-"""``AI_MARKET_MAKER_USE_LLM`` semantics (single source of truth in ``config.llm_env``)."""
+"""Tests for LLM env helpers."""
 
-from config.llm_env import use_llm_arbitrator
-
-
-def test_llm_off_by_default_and_zero():
-    assert use_llm_arbitrator(env={}) is False
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": ""}) is False
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "0"}) is False
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "false"}) is False
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "no"}) is False
+from config.llm_env import llm_arbitrator_mode, llm_key_available
+from config.llm_mode import llm_mode_enabled
 
 
-def test_llm_on_truthy_values():
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "1"}) is True
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "true"}) is True
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "YES"}) is True
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "y"}) is True
-    assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "On"}) is True
+def test_llm_key_available_false_when_unset():
+    assert llm_key_available(env={}) is False
+
+
+def test_llm_key_available_true_with_openai_key():
+    assert llm_key_available(env={"OPENAI_API_KEY": "sk-test"}) is True
+
+
+def test_llm_key_available_falls_back_to_llm_api_key():
+    assert llm_key_available(env={"LLM_API_KEY": "sk-test"}) is True
+
+
+def test_llm_mode_off_by_default_in_tests():
+    assert llm_mode_enabled(env={}) is False
+
+
+def test_llm_mode_explicit_on_and_off():
+    assert llm_mode_enabled(env={"AIMM_LLM_MODE": "1"}) is True
+    assert llm_mode_enabled(env={"AIMM_LLM_MODE": "true"}) is True
+    assert llm_mode_enabled(env={"AIMM_LLM_MODE": "0"}) is False
+    assert llm_mode_enabled(env={"AIMM_LLM_MODE": "off"}) is False
+
+
+def test_arbitrator_mode_defaults_to_weighted_convergence():
+    assert llm_arbitrator_mode(env={}) == "weighted_convergence"
+
+
+def test_arbitrator_mode_llm():
+    assert llm_arbitrator_mode(env={"AIMM_ARBITRATOR_MODE": "llm"}) == "llm"
+    assert llm_arbitrator_mode(env={"AIMM_ARBITRATOR_MODE": "LLM"}) == "llm"


### PR DESCRIPTION
## Summary

Add v4.1 weighted arbitrator, profile agent, and agent scaffolding.
Replace legacy signal arbitrator with weighted convergence by default,
add profile weight personalisation and operator persona/skill files.

## How to Test

- default backtest 

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (add `--runslow` if you touched slow tests)
- [x] Documentation updated if behavior or public API changed
- [x] No API keys or secrets committed