### PR TITLE
Add optional Adanos crypto sentiment feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,18 @@ NEXUS_JWT=
 NEXUS_API_BASE=
 NEXUS_TIMEOUT_S=30
 
+# Optional Adanos Market Sentiment API feed for crypto retail sentiment.
+# When ADANOS_API_KEY is set, AIMM adds Reddit crypto sentiment from Adanos
+# to the Tier-0 retail_hype_tracker context. Leave blank to disable.
+ADANOS_API_KEY=
+ADANOS_DISABLE=0
+ADANOS_API_BASE=https://api.adanos.org/reddit/crypto/v1
+ADANOS_TIMEOUT_S=5
+ADANOS_TOTAL_TIMEOUT_S=20
+ADANOS_LOOKBACK_DAYS=7
+ADANOS_SYMBOL_MAX=8
+ADANOS_MAX_WORKERS=4
+
 # Optional Nexus data URL for depth tools
 OLAXBT_NEXUS_DATA_BASE_URL=
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,8 +130,27 @@ This is useful for:
 ```
 BINANCE_API_KEY / SECRET   ← OHLCV data
 NEXUS_API_KEY              ← Nexus/Olaxbt data (news, KOL, OI, funding)
+ADANOS_API_KEY             ← Optional Adanos crypto sentiment for retail_hype_tracker
 TWITTER_BEARER_TOKEN        ← Social sentiment (optional, experimental)
 ```
+
+### Optional Adanos Market Sentiment
+
+Set `ADANOS_API_KEY` to enrich the Tier-0 `retail_hype_tracker` with Adanos
+crypto sentiment for the active universe. The integration calls the Adanos
+crypto Reddit sentiment endpoint, maps CCXT pairs such as `BTC/USDT` to `BTC`,
+and degrades gracefully if Adanos is unavailable or a token has no data.
+
+| Variable               | Default                                   | Purpose                   |
+|------------------------|-------------------------------------------|---------------------------|
+| `ADANOS_API_KEY`       | unset                                     | Enables the Adanos feed   |
+| `ADANOS_DISABLE`       | `0`                                       | Set to `1` to force off   |
+| `ADANOS_API_BASE`      | `https://api.adanos.org/reddit/crypto/v1` | Override API base URL     |
+| `ADANOS_TIMEOUT_S`     | `5`                                       | Per-request timeout       |
+| `ADANOS_TOTAL_TIMEOUT_S`| `20`                                      | Total feed time budget    |
+| `ADANOS_LOOKBACK_DAYS` | `7`                                       | Sentiment window length   |
+| `ADANOS_SYMBOL_MAX`    | `8`                                       | Max symbols per graph run |
+| `ADANOS_MAX_WORKERS`   | `4`                                       | Concurrent symbol fetches |
 
 ### Layer 1 — Agents (optional toggles)
 ```
@@ -153,5 +172,3 @@ AI_MARKET_MAKER_ALLOW_LIVE ← double-gate for live
 ```
 AIMM_RISK_GUARD_KILL_SWITCH ← emergency stop
 ```
-
-

--- a/src/agents/retail_hype_tracker.py
+++ b/src/agents/retail_hype_tracker.py
@@ -14,6 +14,31 @@ def _ep(nexus_context: dict[str, Any] | None, name: str) -> dict[str, Any]:
     return block if isinstance(block, dict) else {}
 
 
+def _adanos_row_for_ticker(
+    block: dict[str, Any],
+    *,
+    ticker: str,
+    base: str,
+    nexus_id: str,
+) -> dict[str, Any] | None:
+    if not block.get("ok"):
+        return None
+    payload = unwrap_data(block.get("data"))
+    if not isinstance(payload, dict):
+        return None
+    rows = payload.get("rows") or payload.get("data") or []
+    if not isinstance(rows, list):
+        return None
+    wanted = {ticker.upper(), base.upper(), nexus_id.upper()}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        sym = str(row.get("symbol") or row.get("ticker") or "").upper()
+        if sym in wanted:
+            return row
+    return None
+
+
 class RetailHypeTrackerAgent:
     """Tier-0 AIMM: retail FOMO/panic + hype-price divergence."""
 
@@ -32,17 +57,25 @@ class RetailHypeTrackerAgent:
         sent = _ep(nexus_context, "sentiment")
         st = _ep(nexus_context, "sentiment_trends")
         heat_blk = _ep(nexus_context, "kol_heatmap")
+        adanos_blk = _ep(nexus_context, "adanos_crypto_sentiment")
         heat_raw = heat_blk.get("data") if heat_blk.get("ok") else {}
         row = (
             heatmap_row_for_ticker(as_dict(heat_raw), ticker, b, nid)
             if isinstance(heat_raw, dict)
             else None
         )
+        adanos_row = _adanos_row_for_ticker(
+            adanos_blk,
+            ticker=ticker,
+            base=b,
+            nexus_id=nid,
+        )
 
         mention_z = 0.0
         mention_count = 0
         bullish_ratio = 0.0
         price_momentum = 0.0
+        source = "nexus"
         if isinstance(row, dict):
             mention_count = int(
                 first_float(row, "mention_count", "mentions", "mentionCount", default=0.0)
@@ -58,10 +91,24 @@ class RetailHypeTrackerAgent:
             price_momentum = first_float(
                 row, "price_momentum", "priceMomentum", "momentum", default=0.0
             )
+        elif isinstance(adanos_row, dict) and adanos_row.get("found", True):
+            source = "adanos"
+            mention_count = int(first_float(adanos_row, "mention_count", "mentions", default=0.0))
+            bullish_ratio = first_float(adanos_row, "bullish_ratio", "bullishRatio", default=0.0)
+            mention_z = first_float(
+                adanos_row,
+                "mention_z_score",
+                "mentions_z_score",
+                "z_score",
+                "zScore",
+                default=0.0,
+            )
 
         heat_proxy = (
             first_float(as_dict(row), "score", "heat", "mentions", default=0.0) if row else 0.0
         )
+        if heat_proxy <= 0 and isinstance(adanos_row, dict):
+            heat_proxy = first_float(adanos_row, "buzz_score", "buzzScore", default=0.0)
 
         z = mention_z
         raw = sent.get("data") if sent.get("ok") else {}
@@ -79,7 +126,22 @@ class RetailHypeTrackerAgent:
                 if isinstance(per, dict):
                     z = z or first_float(per, "z_score", "zScore", "sentiment_z_score")
 
-        if not sent.get("ok") and not st.get("ok") and heat_proxy <= 0 and mention_count == 0:
+        if z == 0.0 and isinstance(adanos_row, dict) and adanos_row.get("found", True):
+            z = max(
+                -2.0,
+                min(2.0, first_float(adanos_row, "sentiment_score", "sentiment", default=0.0) * 2),
+            )
+
+        has_adanos_signal = source == "adanos" and (
+            mention_count > 0 or heat_proxy > 0 or z != 0.0 or bullish_ratio > 0
+        )
+        if (
+            not sent.get("ok")
+            and not st.get("ok")
+            and not has_adanos_signal
+            and heat_proxy <= 0
+            and mention_count == 0
+        ):
             return {
                 "status": "skipped",
                 "fomo_level": 50,
@@ -115,5 +177,6 @@ class RetailHypeTrackerAgent:
                 "price_momentum": price_momentum,
                 "mention_z_score": round(mention_z, 2),
                 "kol_heat_proxy": heat_proxy,
+                "sentiment_source": source,
             },
         }

--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,7 @@ from flow_log import FlowEventRepo, get_flow_repo, set_flow_repo
 from leadpage_local_scan import append_local_scan_result
 from llm.portfolio_llm import llm_portfolio_execute, llm_portfolio_proposal
 from market.universe import augment_universe_with_oi, select_universe_from_tickers
+from nexus_data.adanos import adanos_feeds_enabled, fetch_adanos_crypto_sentiment_bundle
 from nexus_data.client import NexusDataClient
 from nexus_data.feeds import (
     fetch_nexus_global_bundle,
@@ -366,6 +367,24 @@ def market_scan(state: HedgeFundState) -> dict[str, Any]:
                     nexus_bundle = {**gb, "errors": merged_errs}
             else:
                 nexus_bundle = gb if gb else None
+
+        if adanos_feeds_enabled():
+            if nexus_bundle is None:
+                nexus_bundle = {
+                    "fetched_at_epoch": time.time(),
+                    "integration_contract_version": "2026-04-04",
+                    "endpoints": {},
+                    "errors": [],
+                }
+            try:
+                adanos_block = fetch_adanos_crypto_sentiment_bundle(universe)
+                nexus_bundle.setdefault("endpoints", {})["adanos_crypto_sentiment"] = adanos_block
+                if not adanos_block.get("ok"):
+                    err = adanos_block.get("error") or "unknown"
+                    nexus_bundle.setdefault("errors", []).append(f"adanos_crypto_sentiment: {err}")
+            except Exception as e:
+                logger.warning("Adanos sentiment feed failed: %s", e)
+                nexus_bundle.setdefault("errors", []).append(f"adanos_crypto_sentiment: {e}")
 
         if nexus_bundle is not None:
             sm_out["nexus"] = nexus_bundle

--- a/src/nexus_data/adanos.py
+++ b/src/nexus_data/adanos.py
@@ -1,0 +1,183 @@
+"""Optional Adanos Market Sentiment API feed for crypto retail signals."""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from nexus_data.symbols import base_asset
+
+
+@dataclass(frozen=True)
+class AdanosSentimentConfig:
+    api_base: str = "https://api.adanos.org/reddit/crypto/v1"
+    api_key: str | None = None
+    timeout_s: float = 5.0
+    total_timeout_s: float = 20.0
+    lookback_days: int = 7
+    max_symbols: int = 8
+    max_workers: int = 4
+
+    @staticmethod
+    def from_env() -> "AdanosSentimentConfig":
+        api_base = os.getenv("ADANOS_API_BASE") or "https://api.adanos.org/reddit/crypto/v1"
+        return AdanosSentimentConfig(
+            api_base=api_base.strip().rstrip("/"),
+            api_key=(os.getenv("ADANOS_API_KEY") or "").strip() or None,
+            timeout_s=float(os.getenv("ADANOS_TIMEOUT_S") or "5"),
+            total_timeout_s=float(os.getenv("ADANOS_TOTAL_TIMEOUT_S") or "20"),
+            lookback_days=max(1, int(os.getenv("ADANOS_LOOKBACK_DAYS") or "7")),
+            max_symbols=max(1, int(os.getenv("ADANOS_SYMBOL_MAX") or "8")),
+            max_workers=max(1, int(os.getenv("ADANOS_MAX_WORKERS") or "4")),
+        )
+
+
+def adanos_credentials_configured() -> bool:
+    return bool((os.getenv("ADANOS_API_KEY") or "").strip())
+
+
+def adanos_feeds_enabled() -> bool:
+    if (os.getenv("ADANOS_DISABLE") or "").lower() in ("1", "true", "yes"):
+        return False
+    return adanos_credentials_configured()
+
+
+def _unique_base_assets(universe: list[str], limit: int) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in universe:
+        if not isinstance(raw, str):
+            continue
+        sym = base_asset(raw).strip().upper()
+        if not sym or sym in seen:
+            continue
+        seen.add(sym)
+        out.append(sym)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _as_float(payload: dict[str, Any], *names: str, default: float = 0.0) -> float:
+    for name in names:
+        value = payload.get(name)
+        if isinstance(value, (int, float)):
+            return float(value)
+    return default
+
+
+def _as_int(payload: dict[str, Any], *names: str, default: int = 0) -> int:
+    for name in names:
+        value = payload.get(name)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+    return default
+
+
+def _extract_data(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data")
+    return data if isinstance(data, dict) else payload
+
+
+def _normalize_row(symbol: str, payload: dict[str, Any]) -> dict[str, Any]:
+    data = _extract_data(payload)
+    sentiment = _as_float(data, "sentiment_score", "sentiment", "score")
+    bullish_pct = _as_float(data, "bullish_pct", "bullish_percentage")
+    bearish_pct = _as_float(data, "bearish_pct", "bearish_percentage")
+    return {
+        "symbol": symbol,
+        "found": bool(data.get("found", True)),
+        "mention_count": _as_int(data, "mentions", "mention_count", "mentionCount"),
+        "unique_posts": _as_int(data, "unique_posts", "uniquePosts"),
+        "subreddit_count": _as_int(data, "subreddit_count", "subredditCount"),
+        "total_upvotes": _as_int(data, "total_upvotes", "totalUpvotes"),
+        "sentiment_score": sentiment,
+        "buzz_score": _as_float(data, "buzz_score", "buzzScore"),
+        "bullish_ratio": bullish_pct / 100.0 if bullish_pct > 1.0 else bullish_pct,
+        "bearish_ratio": bearish_pct / 100.0 if bearish_pct > 1.0 else bearish_pct,
+        "trend": data.get("trend") if isinstance(data.get("trend"), str) else None,
+    }
+
+
+def _fetch_symbol_row(
+    symbol: str,
+    *,
+    cfg: AdanosSentimentConfig,
+    start: date,
+    end: date,
+) -> dict[str, Any]:
+    url = f"{cfg.api_base}/token/{quote(symbol, safe='')}"
+    with httpx.Client(timeout=cfg.timeout_s) as client:
+        resp = client.get(
+            url,
+            headers={"X-API-Key": cfg.api_key or ""},
+            params={"from": start.isoformat(), "to": end.isoformat()},
+        )
+        if resp.status_code == 404:
+            return {"symbol": symbol, "found": False, "mention_count": 0}
+        resp.raise_for_status()
+        payload = resp.json()
+        if not isinstance(payload, dict):
+            raise ValueError("Adanos response is not a JSON object")
+        return _normalize_row(symbol, payload)
+
+
+def fetch_adanos_crypto_sentiment_bundle(
+    universe: list[str],
+    *,
+    cfg: AdanosSentimentConfig | None = None,
+    today: date | None = None,
+) -> dict[str, Any]:
+    """Fetch per-token Adanos crypto sentiment for the current trading universe."""
+    cfg = cfg or AdanosSentimentConfig.from_env()
+    if not cfg.api_key:
+        return {"ok": False, "error": "ADANOS_API_KEY is not configured", "data": None}
+
+    end = today or datetime.now(UTC).date()
+    start = end - timedelta(days=cfg.lookback_days - 1)
+    symbols = _unique_base_assets(universe, cfg.max_symbols)
+    rows: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    if symbols:
+        rows_by_symbol: dict[str, dict[str, Any]] = {}
+        workers = min(cfg.max_workers, len(symbols))
+        executor = ThreadPoolExecutor(max_workers=workers)
+        futures = {
+            executor.submit(_fetch_symbol_row, symbol, cfg=cfg, start=start, end=end): symbol
+            for symbol in symbols
+        }
+        done, pending = wait(futures, timeout=cfg.total_timeout_s)
+        for fut in done:
+            symbol = futures[fut]
+            try:
+                rows_by_symbol[symbol] = fut.result()
+            except Exception as exc:
+                errors.append(f"{symbol}: {exc}")
+        for fut in pending:
+            symbol = futures[fut]
+            fut.cancel()
+            errors.append(f"{symbol}: timed out after {cfg.total_timeout_s:.1f}s total budget")
+        executor.shutdown(wait=False, cancel_futures=True)
+        rows = [rows_by_symbol[symbol] for symbol in symbols if symbol in rows_by_symbol]
+
+    ok = bool(rows) or not errors
+    return {
+        "ok": ok,
+        "data": {
+            "success": ok,
+            "source": "adanos",
+            "window": {"from": start.isoformat(), "to": end.isoformat()},
+            "rows": rows,
+            "partial_errors": errors,
+        },
+        "error": "; ".join(errors) if errors else None,
+    }

--- a/tests/test_adanos_sentiment.py
+++ b/tests/test_adanos_sentiment.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import time
+from datetime import date
+from typing import Any
+
+import httpx
+
+from agents.retail_hype_tracker import RetailHypeTrackerAgent
+from nexus_data.adanos import (
+    AdanosSentimentConfig,
+    adanos_feeds_enabled,
+    fetch_adanos_crypto_sentiment_bundle,
+)
+
+
+def test_adanos_feed_disabled_without_api_key(monkeypatch):
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+    monkeypatch.setenv("ADANOS_DISABLE", "0")
+
+    assert adanos_feeds_enabled() is False
+    assert fetch_adanos_crypto_sentiment_bundle(["BTC/USDT"]) == {
+        "ok": False,
+        "error": "ADANOS_API_KEY is not configured",
+        "data": None,
+    }
+
+
+def test_adanos_feed_fetches_unique_base_assets(monkeypatch):
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        symbol = request.url.path.rsplit("/", 1)[-1]
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "found": True,
+                    "mentions": 42 if symbol == "BTC" else 7,
+                    "sentiment_score": 0.35,
+                    "buzz_score": 24.5,
+                    "bullish_pct": 63.0,
+                    "bearish_pct": 12.0,
+                    "trend": "rising",
+                }
+            },
+        )
+
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        return real_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr("nexus_data.adanos.httpx.Client", client_factory)
+
+    out = fetch_adanos_crypto_sentiment_bundle(
+        ["BTC/USDT", "BTC/USDC", "ETH/USDT"],
+        cfg=AdanosSentimentConfig(
+            api_base="https://api.example.test/reddit/crypto/v1",
+            api_key="sk_test",
+            timeout_s=3.0,
+            lookback_days=3,
+            max_symbols=2,
+        ),
+        today=date(2026, 6, 27),
+    )
+
+    assert out["ok"] is True
+    assert out["data"]["window"] == {"from": "2026-06-25", "to": "2026-06-27"}
+    assert [row["symbol"] for row in out["data"]["rows"]] == ["BTC", "ETH"]
+    assert out["data"]["rows"][0]["mention_count"] == 42
+    assert out["data"]["rows"][0]["bullish_ratio"] == 0.63
+    assert len(calls) == 2
+    assert calls[0].headers["X-API-Key"] == "sk_test"
+    assert calls[0].url.params["from"] == "2026-06-25"
+
+
+def test_adanos_feed_treats_404_as_missing_symbol(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "not found"})
+
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        "nexus_data.adanos.httpx.Client",
+        lambda *args, **kwargs: real_client(*args, transport=transport, **kwargs),
+    )
+
+    out = fetch_adanos_crypto_sentiment_bundle(
+        ["DOGE/USDT"],
+        cfg=AdanosSentimentConfig(api_key="sk_test"),
+        today=date(2026, 6, 27),
+    )
+
+    assert out["ok"] is True
+    assert out["data"]["rows"] == [{"symbol": "DOGE", "found": False, "mention_count": 0}]
+
+
+def test_adanos_feed_enforces_total_timeout(monkeypatch):
+    def slow_fetch(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        time.sleep(0.1)
+        return {"symbol": "BTC", "found": True, "mention_count": 1}
+
+    monkeypatch.setattr("nexus_data.adanos._fetch_symbol_row", slow_fetch)
+
+    out = fetch_adanos_crypto_sentiment_bundle(
+        ["BTC/USDT"],
+        cfg=AdanosSentimentConfig(
+            api_key="sk_test",
+            timeout_s=0.1,
+            total_timeout_s=0.01,
+            max_workers=1,
+        ),
+        today=date(2026, 6, 27),
+    )
+
+    assert out["ok"] is False
+    assert out["data"]["rows"] == []
+    assert "BTC: timed out after 0.0s total budget" in out["error"]
+
+
+def test_retail_hype_tracker_uses_adanos_sentiment_when_nexus_is_absent():
+    analysis = RetailHypeTrackerAgent().analyze(
+        ticker="BTC/USDT",
+        market_data={},
+        nexus_context={
+            "endpoints": {
+                "adanos_crypto_sentiment": {
+                    "ok": True,
+                    "data": {
+                        "success": True,
+                        "rows": [
+                            {
+                                "symbol": "BTC",
+                                "found": True,
+                                "mention_count": 120,
+                                "sentiment_score": 0.4,
+                                "buzz_score": 32.0,
+                                "bullish_ratio": 0.66,
+                            }
+                        ],
+                    },
+                }
+            }
+        },
+    )
+
+    assert analysis["status"] == "success"
+    assert analysis["sentiment_z_score"] == 0.8
+    assert analysis["fomo_level"] > 80
+    assert analysis["inputs"]["mention_count"] == 120
+    assert analysis["inputs"]["sentiment_source"] == "adanos"
+
+
+def test_retail_hype_tracker_skips_empty_adanos_context():
+    analysis = RetailHypeTrackerAgent().analyze(
+        ticker="BTC/USDT",
+        market_data={},
+        nexus_context={
+            "endpoints": {
+                "adanos_crypto_sentiment": {
+                    "ok": True,
+                    "data": {"success": True, "rows": []},
+                }
+            }
+        },
+    )
+
+    assert analysis["status"] == "skipped"


### PR DESCRIPTION
## Summary

Adds an optional Adanos Market Sentiment API feed for crypto retail sentiment. When `ADANOS_API_KEY` is configured, the market scan fetches per-token Adanos Reddit crypto sentiment for the active CCXT universe and attaches it to the existing Tier-0 context. `RetailHypeTrackerAgent` can use that data as a fallback when Nexus/KOL sentiment is unavailable.

## Motivation

The project already models retail hype and social sentiment, but the current path depends on Nexus sentiment/KOL feeds or the experimental Twitter scraper. This keeps Adanos fully optional and fail-open while giving the retail hype tracker another structured crypto sentiment input for symbols such as `BTC/USDT` -> `BTC`.

## How to Test

- `uv run --extra dev pre-commit run --all-files`
- `uv run --extra dev ruff check src/nexus_data/adanos.py src/agents/retail_hype_tracker.py src/main.py tests/test_adanos_sentiment.py`
- `uv run --extra dev ruff format --check src/nexus_data/adanos.py src/agents/retail_hype_tracker.py src/main.py tests/test_adanos_sentiment.py`
- `uv run --extra dev pytest tests/test_adanos_sentiment.py -q`
- `uv run --extra dev pytest tests/test_adanos_sentiment.py tests/test_agentic_trading_e2e.py -q`
- `uv run --extra dev pytest tests/ -q`

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (add `--runslow` if you touched slow tests)
- [x] Documentation updated if behavior or public API changed
- [x] No API keys or secrets committed

---

**Note**: Please keep the description factual.
