### PR TITLE
feat(llm): add Atlas Cloud provider configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ OPENAI_API_KEY=
 OPENAI_BASE_URL=
 OPENAI_MODEL=gpt-4o-mini
 
+# Atlas Cloud (OpenAI-compatible alternative; used when OPENAI_API_KEY is unset)
+# ATLASCLOUD_API_KEY=
+# ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+# ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
+
 # Strategy (Tier-1 blueprint: balanced | aggressive | defensive). When unset, ``config/app.default.json``
 # ``strategy.tier1_preset`` is applied via ``setdefault`` after ``.env`` is loaded.
 # AIMM_STRATEGY_PRESET=

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@
 
 AIMM is designed to run **with an LLM token** — no LLM-less fallback paths.
 This eliminates the `AI_MARKET_MAKER_USE_LLM` toggle. If you have an
-`OPENAI_API_KEY` (or compatible endpoint), the system runs at full capability.
+`OPENAI_API_KEY` or an OpenAI-compatible provider key, the system runs at full capability.
 
 Three configuration layers:
 
@@ -24,6 +24,19 @@ config/policy.default.json  → trading policy (risk, sizing, rules)
 | `BINANCE_API_KEY`   | Binance API key for market data               |
 | `BINANCE_API_SECRET`| Binance API secret                            |
 | `NEXUS_API_KEY`     | Olaxbt Nexus data API key                     |
+
+Atlas Cloud can be selected without replacing the existing OpenAI variables:
+
+```bash
+ATLASCLOUD_API_KEY=your-key
+ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
+```
+
+The `ATLAS_CLOUD_API_KEY`, `ATLAS_CLOUD_BASE_URL`, and `ATLAS_CLOUD_MODEL`
+spellings are accepted as aliases. `ATLASCLOUD_API_BASE` and
+`ATLAS_CLOUD_API_BASE` are also accepted for the endpoint. Existing `OPENAI_*`
+settings keep priority.
 
 > **No LLM key → the process exits with a clear error.** No fallback, no silent
 > degradation. This is intentional — the system is an LLM-native architecture.
@@ -153,5 +166,3 @@ AI_MARKET_MAKER_ALLOW_LIVE ← double-gate for live
 ```
 AIMM_RISK_GUARD_KILL_SWITCH ← emergency stop
 ```
-
-

--- a/src/config/llm_env.py
+++ b/src/config/llm_env.py
@@ -1,23 +1,87 @@
-"""LLM env helpers for arbitrator key detection and legacy flags."""
+"""LLM environment helpers for OpenAI-compatible providers."""
 
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+ATLAS_CLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
+ATLAS_CLOUD_MODEL = "deepseek-ai/deepseek-v4-pro"
+_ATLAS_KEY_NAMES = ("ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY")
+_ATLAS_BASE_URL_NAMES = (
+    "ATLASCLOUD_BASE_URL",
+    "ATLAS_CLOUD_BASE_URL",
+    "ATLASCLOUD_API_BASE",
+    "ATLAS_CLOUD_API_BASE",
+)
+_ATLAS_MODEL_NAMES = ("ATLASCLOUD_MODEL", "ATLAS_CLOUD_MODEL")
 
 
-def _read_key(env: dict[str, str] | None) -> str:
+@dataclass(frozen=True)
+class LLMConfig:
+    api_key: str
+    base_url: str | None
+    model: str
+
+
+def _first(env: Mapping[str, str], names: Sequence[str]) -> str:
+    for name in names:
+        value = (env.get(name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def resolve_llm_config(
+    env: Mapping[str, str] | None = None,
+    *,
+    key_names: Sequence[str] = ("OPENAI_API_KEY", "LLM_API_KEY"),
+    base_url_names: Sequence[str] = ("OPENAI_BASE_URL",),
+    model_names: Sequence[str] = ("OPENAI_MODEL",),
+    default_base_url: str | None = None,
+    default_model: str = "gpt-4o-mini",
+) -> LLMConfig:
+    """Resolve existing provider settings, then Atlas Cloud aliases.
+
+    Existing provider variables keep priority. Atlas Cloud defaults are only
+    selected when none of the caller's existing key variables are configured.
+    """
+    env_map = os.environ if env is None else env
+    api_key = _first(env_map, key_names)
+    if api_key:
+        return LLMConfig(
+            api_key=api_key,
+            base_url=_first(env_map, base_url_names) or default_base_url,
+            model=_first(env_map, model_names) or default_model,
+        )
+
+    atlas_key = _first(env_map, _ATLAS_KEY_NAMES)
+    if atlas_key:
+        return LLMConfig(
+            api_key=atlas_key,
+            base_url=_first(env_map, _ATLAS_BASE_URL_NAMES) or ATLAS_CLOUD_BASE_URL,
+            model=_first(env_map, _ATLAS_MODEL_NAMES) or ATLAS_CLOUD_MODEL,
+        )
+
+    return LLMConfig(
+        api_key="",
+        base_url=_first(env_map, base_url_names) or default_base_url,
+        model=_first(env_map, model_names) or default_model,
+    )
+
+
+def _read_key(env: Mapping[str, str] | None) -> str:
     """Return the first non-empty API key from *env*."""
-    if env is None:
-        env = os.environ
-    return (env.get("OPENAI_API_KEY") or env.get("LLM_API_KEY") or "").strip()
+    return resolve_llm_config(env).api_key
 
 
-def llm_key_available(env: dict[str, str] | None = None) -> bool:
+def llm_key_available(env: Mapping[str, str] | None = None) -> bool:
     """Return True when an LLM API key is configured in *env*."""
     return bool(_read_key(env))
 
 
-def use_llm_arbitrator(env: dict[str, str] | None = None) -> bool:
+def use_llm_arbitrator(env: Mapping[str, str] | None = None) -> bool:
     """Return True when an LLM provider key is configured.
 
     Legacy ``AI_MARKET_MAKER_USE_LLM=0`` forces False.
@@ -32,15 +96,23 @@ def use_llm_arbitrator(env: dict[str, str] | None = None) -> bool:
     return bool(_read_key(env))
 
 
-def require_llm_key(env: dict[str, str] | None = None) -> None:
+def require_llm_key(env: Mapping[str, str] | None = None) -> None:
     """Exit with a clear message if no LLM key is configured."""
     if not llm_key_available(env):
         print(
-            "FATAL: OPENAI_API_KEY is required. "
-            "Set OPENAI_API_KEY in your environment or .env file.",
+            "FATAL: an LLM API key is required. "
+            "Set OPENAI_API_KEY or ATLASCLOUD_API_KEY in your environment or .env file.",
             file=__import__("sys").stderr,
         )
         __import__("sys").exit(1)
 
 
-__all__ = ["llm_key_available", "require_llm_key", "use_llm_arbitrator"]
+__all__ = [
+    "ATLAS_CLOUD_BASE_URL",
+    "ATLAS_CLOUD_MODEL",
+    "LLMConfig",
+    "llm_key_available",
+    "require_llm_key",
+    "resolve_llm_config",
+    "use_llm_arbitrator",
+]

--- a/src/llm/agent_llm_client.py
+++ b/src/llm/agent_llm_client.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from openai import OpenAI
 
+from config.llm_env import resolve_llm_config
+
 # Lazy-loaded decision cache
 _DECISION_CACHE: Any = None
 
@@ -137,16 +139,25 @@ def _init_llm() -> None:
     if _LLM_CLIENT is not None:
         return
 
-    api_key = _env("DEEPSEEK_API_KEY") or _env("OPENAI_API_KEY")
-    if not api_key:
+    llm_config = resolve_llm_config(
+        key_names=("DEEPSEEK_API_KEY", "OPENAI_API_KEY", "LLM_API_KEY"),
+        base_url_names=("AIMM_LLM_BASE_URL",),
+        model_names=("AIMM_LLM_MODEL",),
+        default_base_url="https://api.deepseek.com/v1",
+        default_model="deepseek-chat",
+    )
+    if not llm_config.api_key:
         raise ValueError(
             "agent_llm mode requires an LLM API key. "
-            "Set DEEPSEEK_API_KEY or OPENAI_API_KEY environment variable."
+            "Set DEEPSEEK_API_KEY, OPENAI_API_KEY, or ATLASCLOUD_API_KEY."
         )
-    base_url = _env("AIMM_LLM_BASE_URL", default="https://api.deepseek.com/v1")
-    _LLM_CLIENT = OpenAI(api_key=api_key, base_url=base_url)
-    _LLM_MODEL = _env("AIMM_LLM_MODEL", default="deepseek-chat")
-    logger.info("agent_llm client initialised (model=%s, base=%s)", _LLM_MODEL, base_url)
+    _LLM_CLIENT = OpenAI(api_key=llm_config.api_key, base_url=llm_config.base_url)
+    _LLM_MODEL = llm_config.model
+    logger.info(
+        "agent_llm client initialised (model=%s, base=%s)",
+        _LLM_MODEL,
+        llm_config.base_url,
+    )
 
 
 def _get_client() -> OpenAI:

--- a/src/llm/openai_client.py
+++ b/src/llm/openai_client.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from openai import OpenAI
 
+from config.llm_env import resolve_llm_config
 from llm.tool_registry import call_tool, openai_tools_payload
 
 logger = logging.getLogger(__name__)
@@ -38,11 +39,14 @@ def run_tool_calling_chat(
 
     conversation_history: prior user/assistant turns (excluding the latest user message in ``user``).
     """
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise ValueError("OPENAI_API_KEY is required when AI_MARKET_MAKER_USE_LLM=1")
+    llm_config = resolve_llm_config()
+    if not llm_config.api_key:
+        raise ValueError(
+            "OPENAI_API_KEY or ATLASCLOUD_API_KEY is required when AI_MARKET_MAKER_USE_LLM=1"
+        )
 
-    base_url = (os.getenv("OPENAI_BASE_URL") or "").strip() or None
+    api_key = llm_config.api_key
+    base_url = llm_config.base_url
     timeout_s_raw = (os.getenv("AIMM_LLM_TIMEOUT_S") or "").strip()
     try:
         timeout_s = float(timeout_s_raw) if timeout_s_raw else 60.0
@@ -58,8 +62,8 @@ def run_tool_calling_chat(
             client = OpenAI(api_key=api_key, base_url=base_url, timeout=timeout_s)
         except TypeError:
             client = OpenAI(api_key=api_key, base_url=base_url)
-    env_model = os.getenv("OPENAI_MODEL")
-    model_name = model or env_model or "gpt-4o-mini"
+    env_model = (os.getenv("OPENAI_MODEL") or "").strip() or None
+    model_name = model or llm_config.model
     if base_url and "deepseek" in base_url and env_model and model and model != env_model:
         # This is the classic "provider supports X but we forced Y" mismatch.
         logger.warning(
@@ -203,11 +207,14 @@ def stream_chat_completion(
 
     This intentionally does **not** support tool calls. It's used for UI chat streaming.
     """
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise ValueError("OPENAI_API_KEY is required when AI_MARKET_MAKER_USE_LLM=1")
+    llm_config = resolve_llm_config()
+    if not llm_config.api_key:
+        raise ValueError(
+            "OPENAI_API_KEY or ATLASCLOUD_API_KEY is required when AI_MARKET_MAKER_USE_LLM=1"
+        )
 
-    base_url = (os.getenv("OPENAI_BASE_URL") or "").strip() or None
+    api_key = llm_config.api_key
+    base_url = llm_config.base_url
     timeout_s_raw = (os.getenv("AIMM_LLM_TIMEOUT_S") or "").strip()
     try:
         timeout_s = float(timeout_s_raw) if timeout_s_raw else 60.0
@@ -223,7 +230,7 @@ def stream_chat_completion(
         except TypeError:
             client = OpenAI(api_key=api_key, base_url=base_url)
 
-    model_name = model or os.getenv("OPENAI_MODEL") or "gpt-4o-mini"
+    model_name = model or llm_config.model
     messages: List[Dict[str, Any]] = [
         {"role": "system", "content": system},
         {"role": "user", "content": user},

--- a/tests/test_llm_env.py
+++ b/tests/test_llm_env.py
@@ -5,7 +5,12 @@ key is configured.  The ``AI_MARKET_MAKER_USE_LLM`` env var is a legacy toggle
 that can force off but cannot conjure a key out of thin air.
 """
 
-from config.llm_env import use_llm_arbitrator
+from config.llm_env import (
+    ATLAS_CLOUD_BASE_URL,
+    ATLAS_CLOUD_MODEL,
+    resolve_llm_config,
+    use_llm_arbitrator,
+)
 
 _KEY = {"OPENAI_API_KEY": "sk-test-123"}
 _EMPTY = {}
@@ -38,3 +43,49 @@ def test_use_llm_legacy_flag_honoured_as_additional_hint():
     for val in ("true", "YES", "y", "On"):
         env = {"AI_MARKET_MAKER_USE_LLM": val, **_KEY}
         assert use_llm_arbitrator(env=env) is True, f"{val=} should work with key"
+
+
+def test_atlas_cloud_key_enables_llm_with_provider_defaults():
+    for key_name in ("ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY"):
+        config = resolve_llm_config({key_name: "atlas-test-key"})
+
+        assert use_llm_arbitrator(env={key_name: "atlas-test-key"}) is True
+        assert config.api_key == "atlas-test-key"
+        assert config.base_url == ATLAS_CLOUD_BASE_URL
+        assert config.model == ATLAS_CLOUD_MODEL
+
+
+def test_atlas_cloud_aliases_support_endpoint_and_model_overrides():
+    config = resolve_llm_config(
+        {
+            "ATLASCLOUD_API_KEY": "atlas-test-key",
+            "ATLAS_CLOUD_BASE_URL": "https://atlas.example/v1",
+            "ATLASCLOUD_MODEL": "qwen/qwen3.5-flash",
+        }
+    )
+
+    assert config.base_url == "https://atlas.example/v1"
+    assert config.model == "qwen/qwen3.5-flash"
+
+    api_base_config = resolve_llm_config(
+        {
+            "ATLAS_CLOUD_API_KEY": "atlas-test-key",
+            "ATLASCLOUD_API_BASE": "https://api-base.example/v1",
+        }
+    )
+    assert api_base_config.base_url == "https://api-base.example/v1"
+
+
+def test_existing_openai_configuration_keeps_priority_over_atlas_cloud():
+    config = resolve_llm_config(
+        {
+            "OPENAI_API_KEY": "openai-test-key",
+            "OPENAI_BASE_URL": "https://openai.example/v1",
+            "OPENAI_MODEL": "existing-model",
+            "ATLASCLOUD_API_KEY": "atlas-test-key",
+        }
+    )
+
+    assert config.api_key == "openai-test-key"
+    assert config.base_url == "https://openai.example/v1"
+    assert config.model == "existing-model"


### PR DESCRIPTION
## Summary

- add Atlas Cloud API key, endpoint, and model aliases to the shared OpenAI-compatible LLM configuration
- reuse the resolved configuration in tool-calling, streaming, and per-agent LLM clients
- preserve existing OpenAI and DeepSeek variable precedence and document the optional Atlas Cloud settings

## Motivation

AIMM already supports OpenAI-compatible endpoints, but its configuration is split across multiple clients and requires users to map another provider onto existing OpenAI variables. This adds a consistent Atlas Cloud fallback while keeping all existing provider settings unchanged.

## How to Test

- `uv run pre-commit run --all-files`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (`316 passed`)
- verified the authenticated Atlas Cloud `/v1/models` catalog (`121` models), the default `deepseek-ai/deepseek-v4-pro` model, streaming chat output, and per-agent client initialization

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (add `--runslow` if you touched slow tests)
- [x] Documentation updated if behavior or public API changed
- [x] No API keys or secrets committed
