### PR TITLE
feat: move LLM strategy flags to config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,139 +1,68 @@
-# Flow API
+# Strategy (desks, weights, LLM overlays): config/deploy.active.json
+
+# Flow / DB
 NEXT_PUBLIC_FLOW_API_BASE_URL=http://127.0.0.1:8001
-
-# Docker Compose — hostname `db` matches the Postgres service.
 DATABASE_URL=postgresql+psycopg://aimm:aimm@db:5432/aimm
-
-# JWT signing secret (change before deploy)
 AIMM_AUTH_SECRET=dev-secret-change-me
-
-# Optional: absolute path to `.runs` for backtests + leaderboard files (default: `<repo>/.runs`).
 # AIMM_RUNS_DIR=
+# AIMM_DEPLOY_CONFIG_PATH=config/deploy.active.json
 
-# Binance (paper/testnet)
+# Exchange
 BINANCE_API_KEY=
 BINANCE_API_SECRET=
 
-# LLM (required for agentic backtests)
+# LLM
 OPENAI_API_KEY=
 OPENAI_BASE_URL=
 OPENAI_MODEL=gpt-4o-mini
-# DeepSeek: same OPENAI_* vars or DEEPSEEK_API_KEY
-
-# Atlas Cloud (OpenAI-compatible alternative; used when OPENAI_API_KEY is unset)
+# DEEPSEEK_API_KEY=
 # ATLASCLOUD_API_KEY=
 # ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
 # ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
+# AIMM_LLM_TIMEOUT_S=60
 
-# Strategy (Tier-1 blueprint: balanced | aggressive | defensive). When unset, ``config/app.default.json``
-# ``strategy.tier1_preset`` is applied via ``setdefault`` after ``.env`` is loaded.
-# AIMM_STRATEGY_PRESET=
-
-# Desk TA bundle: default | trend_guard | trend_follow | all_weather | adaptive
-# AIMM_DESK_STRATEGY_PRESET=
-
-# Backtest only: extend graph HOLD before sizing — off | momentum | legacy (legacy = old bar-parity probe).
-# AIMM_BACKTEST_HOLD_FALLBACK=
-
-# Graph run interval (seconds)
+# Runtime
+# AIMM_STRATEGY_PRESET=balanced
+# AIMM_DESK_STRATEGY_PRESET=default
 STRATEGY_INTERVAL_SEC=900
 
-# Nexus (Olaxbt data API)
-# Demo key (rate-limited) included so fresh clones work out of the box.
-# Replace with your own key for production / heavier usage.
+# Nexus
 NEXUS_API_KEY=4Qbp6biPAKPS1gOksAySOlqK
 NEXUS_DISABLE=0
-
 NEXUS_JWT=
 NEXUS_API_BASE=
 NEXUS_TIMEOUT_S=30
-
-# Optional Nexus data URL for depth tools
 OLAXBT_NEXUS_DATA_BASE_URL=
 
-# Backtest safety limit
+# API
 BACKTEST_API_MAX_STEPS=5000
-
-# Optional / advanced
 # AIMM_API_KEY=
 # AIMM_CORS_ORIGINS=*
-# AIMM_LLM_MODE=          # 0=force off, 1=force on
-TWITTER_BEARER_TOKEN=
+# TWITTER_BEARER_TOKEN=
 
-# ---------------------------------------------------------------------------
-# Execution engine (opt-in OMS layer)
-# ---------------------------------------------------------------------------
-# AI_MARKET_MAKER_EXECUTION_ENGINE=legacy   # default — NexusAdapter paper path unchanged
-# AI_MARKET_MAKER_EXECUTION_ENGINE=oms      # opt-in — routes through OMS lifecycle tracking
-
-# ---------------------------------------------------------------------------
-# Exchange selection
-# ---------------------------------------------------------------------------
-# EXCHANGE=paper           # default — no real keys needed
-# EXCHANGE=hyperliquid     # requires AI_MARKET_MAKER_ALLOW_LIVE=1
-
-# Guard: must be 1 to allow any non-paper exchange. Leave 0 for paper-only operation.
+# Execution
+# AI_MARKET_MAKER_EXECUTION_ENGINE=oms
+# EXCHANGE=paper
 AI_MARKET_MAKER_ALLOW_LIVE=0
+HYPERLIQUID_TESTNET=1
+HYPERLIQUID_DRY_RUN=1
+# HYPERLIQUID_API_BASE=
+# HYPERLIQUID_API_KEY=
+# HYPERLIQUID_SECRET=
+# AI_MARKET_MAKER_OMS_LEDGER=in_memory
+# AI_MARKET_MAKER_OMS_SQLITE_PATH=.runs/oms/orders.sqlite
 
-# ---------------------------------------------------------------------------
-# Hyperliquid adapter (requires EXCHANGE=hyperliquid + AI_MARKET_MAKER_ALLOW_LIVE=1)
-# WARNING: Real live order placement is NOT implemented in this version.
-#          HYPERLIQUID_DRY_RUN=1 is the only supported Hyperliquid path.
-#          Setting HYPERLIQUID_DRY_RUN=0 without a complete SDK implementation
-#          will raise RuntimeError at startup. See docs/run-modes.md.
-# ---------------------------------------------------------------------------
-HYPERLIQUID_TESTNET=1       # 1=testnet (default/safe), 0=mainnet
-HYPERLIQUID_DRY_RUN=1       # 1=parse+validate only, never sends real orders
-# HYPERLIQUID_API_BASE=     # optional: override API base URL
-# HYPERLIQUID_API_KEY=      # wallet address (leave blank for dry-run/testnet only)
-# HYPERLIQUID_SECRET=       # NEVER commit this — private key / secret
+# Futu
+# FUTU_OPEND_HOST=127.0.0.1
+# FUTU_OPEND_QUOTE_PORT=11111
+# FUTU_OPEND_TRADE_PORT=11112
+# FUTU_UNLOCK_PWD=
+# FUTU_PWD_MD5=0
+# FUTU_DRY_RUN=1
 
-# ---------------------------------------------------------------------------
-# OMS persistent ledger (opt-in, only active when execution engine is OMS)
-# ---------------------------------------------------------------------------
-# AI_MARKET_MAKER_OMS_LEDGER=in_memory   # default — no filesystem side-effects
-# AI_MARKET_MAKER_OMS_LEDGER=sqlite      # opt-in — SQLite persistence (stdlib only)
-#
-# When sqlite is selected:
-#   - Restart-safe idempotency: duplicate orders blocked across process restarts
-#   - Order state and events survive process exits
-#   - oms_orders and oms_order_events tables are created lazily on first use
-#   - No secrets are stored; only order metadata already held in OmsOrder
-#
-# AI_MARKET_MAKER_OMS_SQLITE_PATH=.runs/oms/orders.sqlite   # default path
-
-# ---------------------------------------------------------------------------
-# Futu OpenD adapter (HK/US stock data + simulated orders via Futu OpenD gateway)
-# ---------------------------------------------------------------------------
-# Docker note: the API container's 127.0.0.1 is NOT your laptop. If OpenD runs on the host
-# (normal Futu desktop OpenD), set FUTU_OPEND_HOST=host.docker.internal (docker-compose.prod.yml
-# adds extra_hosts so Linux resolves it). If you use compose profile ``with-futu``, use
-# FUTU_OPEND_HOST=futu-opend instead.
-# Real charts in the web Futu tab: Flow API must expose GET /futu/price (this repo's
-# ``api.flow_stream_server`` does). Next.js ``FLOW_API_BASE_URL`` must point at that
-# process (e.g. http://127.0.0.1:8001). Then:
-#   1. Install and run Futu OpenD; enable API (default quote port 11111).
-#   2. ``futu-api`` is required on the Flow/API host (included in this project's deps).
-#   3. Set host/ports below so the API process can reach OpenD.
-# FUTU_OPEND_HOST=127.0.0.1       # OpenD host (same machine as Flow, or reachable IP)
-# FUTU_OPEND_QUOTE_PORT=11111     # OpenD quote port
-# FUTU_OPEND_TRADE_PORT=11112     # OpenD trade port
-# FUTU_UNLOCK_PWD=                # Trade unlock password (for order placement)
-# FUTU_PWD_MD5=0                  # 1=password is MD5-hashed
-# FUTU_DRY_RUN=1                  # 1=parse only, never send real orders (safe default)
-
-# ---------------------------------------------------------------------------
-# Next.js web (`web/`) — Flow / Nexus console payload
-# ---------------------------------------------------------------------------
-# Default: load live topology from Flow (``/api/traces`` → ``/runs/latest/payload``). LLM is optional for the graph.
-# Set NEXT_PUBLIC_USE_MOCK=1 (and optionally USE_MOCK=1 for /api/traces) only for standalone demo without Flow.
-# Local ``npm run dev`` (from ``web/``): copy ``web/.env.example`` to ``web/.env.local`` — server routes use ``FLOW_API_BASE_URL`` (and fall back to ``NEXT_PUBLIC_FLOW_API_BASE_URL`` if unset).
-# Next.js server (``web/``) proxies ``/api/futu/price`` → ``${FLOW_API_BASE_URL}/futu/price``.
-# Set the same base URL the browser uses for Flow (often http://127.0.0.1:8001 in dev).
+# Web (web/.env.local)
 # FLOW_API_BASE_URL=http://127.0.0.1:8001
-# NEXT_PUBLIC_FLOW_API_BASE_URL=http://127.0.0.1:8001
 # NEXT_PUBLIC_USE_MOCK=1
 # USE_MOCK=1
-# Server: if Flow is down, return bundled demo JSON instead of 502 (default on).
 # FLOW_ALLOW_MOCK_FALLBACK=0
 # NEXT_PUBLIC_FLOW_ALLOW_MOCK_FALLBACK=0

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Designed to feel like a small professional trading firm — not just another bot
 - **OpenClaw-ready packaging** (`SKILL.md` + `manifest.json` + dedicated runners)
 - Paper trading on Binance Testnet + rich local backtester; Hyperliquid adapter (dry-run) via OMS layer
 - Modern web dashboard for telemetry and traces
-- Clean configuration (JSON policy + env for secrets only)
+- Clean configuration: **deploy JSON** for strategy, policy/app JSON for defaults, `.env` for secrets only
 
 ### Sponsorship — Atlas Cloud
 
@@ -75,9 +75,9 @@ Deeper agentic capabilities, better OpenClaw integration, and support for additi
 
 Rough flow (LangGraph):
 
-1. **Market scan + Tier-0 desks** — macro, TA, pattern, stats, narrative, flow, …
-2. **Risk + desk debate** — risk context, then bull/bear evidence
-3. **Signal arbitrator** — optional per-desk LLM (`agent_llm`), then **weight assigner** fuses scores into BUY/SELL/HOLD
+1. **Market scan + Tier-0 desks** — enabled desks from deploy JSON (TA, macro, pattern, …)
+2. **Risk + desk debate** — risk context; optional `desk_debate_llm` (off in shipped presets)
+3. **Signal arbitrator** — static `agents.*.weight` math first; optional desk CoT (`llm_enabled`) then optional `arbitrator_llm` overlay → BUY/SELL/HOLD
 4. **Portfolio** — proposal → Risk Guard veto → execute
 
 <img width="784" height="1138" alt="workflow_diagram" src="https://github.com/user-attachments/assets/fcf5d491-7562-4acc-8499-3d93d24d395b" />
@@ -109,7 +109,8 @@ uv run pre-commit install
 
 # 5. Set up environment
 cp .env.example .env
-# Edit .env — set OPENAI_API_KEY or ATLASCLOUD_API_KEY (agentic runs need a key)
+# Edit .env — set OPENAI_API_KEY or ATLASCLOUD_API_KEY (required for LLM calls)
+# Strategy (desks, weights, LLM overlays) lives in config/deploy.active.json
 
 # 6. Run the platform stack: DB + migrate + API + worker + web
 # Requires Docker Desktop. Futu OpenD optional (`--profile with-futu`).
@@ -225,10 +226,12 @@ pip install ta-lib
 **Note for OpenClaw Users:** If running in OpenClaw environment without sudo privileges, use Option 1 (Conda) as shown in the CI workflow.
 
 ### Configuration Philosophy
-- **Policy & universe** → `config/policy.default.json` and `config/app.default.json` (single source of truth)
-- **Secrets** → only in `.env`
+- **Strategy** → `config/deploy.active.json` (desks, weights, LLM overlays, gates). See [`docs/agentic-config.md`](docs/agentic-config.md)
+- **Policy & universe** → `config/policy.default.json` and `config/app.default.json`
+- **Secrets / ops** → `.env` only (no arbitrator-mode or LLM-agent env flags)
 
 Detailed docs:
+- [`docs/agentic-config.md`](docs/agentic-config.md)
 - [`docs/configuration.md`](docs/configuration.md)
 - [`docs/policy-schema.md`](docs/policy-schema.md)
 - [`docs/run-modes.md`](docs/run-modes.md)
@@ -247,13 +250,13 @@ uv run pytest -q tests/test_agentic_trading_e2e.py tests/test_tier0_consensus.py
 
 ## Agents (Desks)
 
-- **Tier-0** — macro (1.1), news (1.2), pattern (2.1), stats (2.2), TA (2.3), retail hype / pro bias / whale / liquidity (3.x–4.x)
+- **Tier-0** — `monetary_sentinel`, `news_narrative_miner`, `pattern_recognition_bot`, `statistical_alpha_engine`, `technical_ta_engine`, `retail_hype_tracker`, `pro_bias_analyst`, `whale_behavior_analyst`, `liquidity_order_flow`
 - **Market scan, risk, desk debate** — universe + risk context before arbitration
-- **Signal arbitrator** — desk LLMs (when `agent_llm`) then weight assigner → `trade_intent`
+- **Signal arbitrator** — weighted math on static JSON weights; optional desk CoT + `arbitrator_llm` overlay → `trade_intent`
 - **Portfolio** — proposal / execute
 - **Risk Guard** — hard veto before execution
 
-Default research weights (`macro_tilt`): 2.3×0.55, 1.1×0.25, 2.1×0.15. Personas in `docs/personas/`; interface in `src/agents/base_agent.py`.
+Default research combo (`macro_tilt` in `config/deploy.active.json`): TA×0.55, macro×0.25, pattern×0.15. Personas in `docs/personas/`; interface in `src/agents/base_agent.py`.
 
 ---
 
@@ -286,7 +289,7 @@ AIMM_BACKTEST_OHLCV_NEXUS=0 AIMM_BACKTEST_LLM_MAX_STEPS=200 uv run python -m bac
   --ticker BTC/USDT
 ```
 
-OHLCV-derived macro context feeds agent **1.1** in backtest (no live Nexus, no look-ahead).
+OHLCV-derived macro context feeds `monetary_sentinel` in backtest (no live Nexus, no look-ahead).
 See [`docs/backtest-data.md`](docs/backtest-data.md) for data layers and future Nexus agent wiring.
 
 Watch **stderr** for the per-bar transcript; stdout ends with JSON metrics;
@@ -321,25 +324,26 @@ Research helpers (period sweep, preset compare) live under `out/scripts/` (gitig
 
 | Knob | Recommendation | Why |
 |------|----------------|-----|
-| **Desk combo** | `macro_tilt` (`config/deploy.active.json`): 2.3×0.55, 1.1×0.25, 2.1×0.15 | Golden gates; leverage 2.0 |
+| **Desk combo** | `macro_tilt` in `config/deploy.active.json`: `technical_ta_engine`×0.55 (`llm_enabled`), `monetary_sentinel`×0.25, `pattern_recognition_bot`×0.15 | Static weights; TA CoT + `arbitrator_llm`; leverage 2.0 |
 | **Horizon** | `--steps 180` daily (50 warmup + 180 eval) | Best return/Sharpe balance in period sweep |
 | **Period lock** | `--until 2026-07-12` | Pin eval end date when CSV grows |
 | **Data** | `bootstrap_showcase --eval-steps 180 --until 2026-07-12` → `--csv-only` | Enough history for offline reruns |
 | **OHLCV context** | `AIMM_BACKTEST_OHLCV_NEXUS=0` | OHLCV-only desk; defers live Nexus |
-| **Nexus desks** | Defer 1.2/3.x/4.x to later PR | Need historical feeds — see `docs/backtest-data.md` |
+| **Nexus desks** | Enable in deploy JSON when you have historical feeds | See `docs/backtest-data.md` |
 | **Symbols** | BTC + ETH + SOL | Multi-asset book; transcript defaults to `--ticker` only |
 | **Transcript** | `AIMM_BACKTEST_TERMINAL_ALL_SYMBOLS=1` optional | Show all three symbols per bar (verbose) |
 | **Stress test** | `--steps 365` separately | Full-year bear-market eval; report PF even if &lt; 1 |
 
 ```bash
-# Optional: explicit desk list (same as macro_tilt default)
-AIMM_LLM_AGENTS=2.3,2.1,1.1 NEXUS_DISABLE=1 AIMM_BACKTEST_LLM_MAX_STEPS=200 \
+# Desk list + LLM flags come from config/deploy.active.json
+NEXUS_DISABLE=1 AIMM_BACKTEST_LLM_MAX_STEPS=200 \
   uv run python -m backtest.run_demo \
+  --deploy config/deploy.active.json \
   --symbols 'BTC/USDT,ETH/USDT,SOL/USDT' --steps 180 --until 2026-07-12 --online --timeframe 1d --ticker BTC/USDT
 ```
 
 If you see `ModuleNotFoundError: No module named 'backtest'`, you are not in the repo root or dependencies are not installed (`uv sync`).
-If your `.env` sets `AIMM_STRATEGY_PRESET`, it overrides `config/app.default.json` strategy defaults; unset it to use shipped `app.default.json` presets.
+`AIMM_STRATEGY_PRESET` / `AIMM_DESK_STRATEGY_PRESET` are optional TA/research overlays, not LLM strategy flags. Desk LLM and arbitrator overlays come from deploy JSON.
 
 ### How the default backtest works (agentic)
 
@@ -347,15 +351,17 @@ Each bar invokes the full LangGraph workflow with **LLM-active** desks:
 
 | Piece | Behavior |
 |-------|----------|
-| **Arbitrator mode** | Default `agent_llm` — per-agent LLM inference (`infer_agent`) then **weighted convergence** fusion |
+| **Fusion** | Weighted math on static `agents.*.weight` (not retuned each bar) |
+| **Desk LLM** | `execution.use_llm_synthesis` + `agents.*.llm_enabled` → `infer_agent` |
+| **Arbitrator LLM** | `execution.arbitrator_llm` overlay after math (falls back to math on failure) |
 | **Portfolio** | Always `llm_portfolio_proposal` / `llm_portfolio_execute` (no rule-based fallback) |
-| **OHLCV context** | Market scan + Tier-0 math feed LLM prompts; 1.1 gets OHLCV-derived macro (`AIMM_BACKTEST_OHLCV_NEXUS=1`) |
+| **OHLCV context** | Market scan + Tier-0 math feed prompts; `monetary_sentinel` can use OHLCV-derived macro (`AIMM_BACKTEST_OHLCV_NEXUS=1`). Showcase commands use `=0`. |
 | **No fallback layer** | Graph `trade_intent` only — no HOLD→BUY/SELL override |
 | **Fill model** | Signal on completed bars; fill at bar open; TP/SL at bar close |
 | **Terminal output** | Per-bar desk CoT on stderr (on by default in backtest; disable with `AIMM_BACKTEST_TERMINAL_LOG=0`) |
 | **Audit receipts** | `tier0_summary` in iterations (on by default in backtest; disable with `AIMM_BACKTEST_VERBOSE_RECEIPTS=0`) |
 
-Optional: `config/deploy.active.json` with `agents[id].llm_enabled` or `AIMM_LLM_AGENTS=2.1,2.3` to limit which desks call the LLM.
+Strategy knobs: `config/deploy.active.json` — see [`docs/agentic-config.md`](docs/agentic-config.md).
 
 ### Comparison with [TradingAgents](https://github.com/TauricResearch/TradingAgents)
 
@@ -470,7 +476,7 @@ ai-market-maker/
 │   └── api/                # FastAPI endpoints
 ├── web/                    # Next.js dashboard
 ├── openclaw/               # OpenClaw skill definitions
-├── config/                 # Default policy and app config
+├── config/                 # deploy.active.json (strategy) + policy/app defaults
 ├── assets/                 # Branding
 ├── docs/                   # Detailed documentation
 ├── tests/                  # Test suite

--- a/config/deploy.active.json
+++ b/config/deploy.active.json
@@ -2,10 +2,22 @@
   "profile": {
     "profile_id": "macro_tilt"
   },
-  "effective_weights": {
-    "2.3": 0.55,
-    "2.1": 0.15,
-    "1.1": 0.25
+  "agents": {
+    "technical_ta_engine": {
+      "weight": 0.55,
+      "llm_enabled": true,
+      "enabled": true
+    },
+    "pattern_recognition_bot": {
+      "weight": 0.15,
+      "llm_enabled": false,
+      "enabled": true
+    },
+    "monetary_sentinel": {
+      "weight": 0.25,
+      "llm_enabled": false,
+      "enabled": true
+    }
   },
   "decision_threshold": {
     "buy": {
@@ -26,14 +38,16 @@
     },
     "ta_led": {
       "enabled": true,
-      "agent_id": "2.3",
+      "agent_id": "technical_ta_engine",
       "buy_min_composite": 57,
       "sell_max_composite": 43,
       "min_confidence": 14
     }
   },
   "execution": {
-    "arbitrator_mode": "agent_llm",
+    "use_llm_synthesis": true,
+    "desk_debate_llm": false,
+    "arbitrator_llm": true,
     "allows_short": true,
     "leverage": 2.0
   }

--- a/config/deploy.conservative_gate.json
+++ b/config/deploy.conservative_gate.json
@@ -2,11 +2,6 @@
   "profile": {
     "profile_id": "conservative_gate"
   },
-  "effective_weights": {
-    "2.3": 0.60,
-    "2.1": 0.20,
-    "1.1": 0.15
-  },
   "decision_threshold": {
     "buy": {
       "min_composite": 53,
@@ -26,15 +21,34 @@
     },
     "ta_led": {
       "enabled": true,
-      "agent_id": "2.3",
+      "agent_id": "technical_ta_engine",
       "buy_min_composite": 59,
       "sell_max_composite": 41,
       "min_confidence": 14
     }
   },
   "execution": {
-    "arbitrator_mode": "agent_llm",
     "allows_short": true,
-    "leverage": 1.5
+    "leverage": 1.5,
+    "use_llm_synthesis": true,
+    "desk_debate_llm": false,
+    "arbitrator_llm": false
+  },
+  "agents": {
+    "technical_ta_engine": {
+      "weight": 0.6,
+      "llm_enabled": false,
+      "enabled": true
+    },
+    "pattern_recognition_bot": {
+      "weight": 0.2,
+      "llm_enabled": false,
+      "enabled": true
+    },
+    "monetary_sentinel": {
+      "weight": 0.15,
+      "llm_enabled": false,
+      "enabled": true
+    }
   }
 }

--- a/config/deploy.golden.json
+++ b/config/deploy.golden.json
@@ -1,10 +1,19 @@
 {
-  "profile": { "profile_id": "macro_tilt" },
-  "effective_weights": { "2.3": 0.55, "2.1": 0.15, "1.1": 0.25 },
+  "profile": {
+    "profile_id": "macro_tilt"
+  },
   "decision_threshold": {
-    "buy": { "min_composite": 53, "min_confidence": 16 },
-    "sell": { "max_composite": 41, "min_confidence": 26 },
-    "hold": { "else": true },
+    "buy": {
+      "min_composite": 53,
+      "min_confidence": 16
+    },
+    "sell": {
+      "max_composite": 41,
+      "min_confidence": 26
+    },
+    "hold": {
+      "else": true
+    },
     "alignment_gating": {
       "enabled": true,
       "min_factors_for_directional": 2,
@@ -12,15 +21,34 @@
     },
     "ta_led": {
       "enabled": true,
-      "agent_id": "2.3",
+      "agent_id": "technical_ta_engine",
       "buy_min_composite": 57,
       "sell_max_composite": 43,
       "min_confidence": 14
     }
   },
   "execution": {
-    "arbitrator_mode": "agent_llm",
     "allows_short": true,
-    "leverage": 2.0
+    "leverage": 2.0,
+    "use_llm_synthesis": false,
+    "desk_debate_llm": false,
+    "arbitrator_llm": true
+  },
+  "agents": {
+    "technical_ta_engine": {
+      "weight": 0.55,
+      "llm_enabled": false,
+      "enabled": true
+    },
+    "pattern_recognition_bot": {
+      "weight": 0.15,
+      "llm_enabled": false,
+      "enabled": true
+    },
+    "monetary_sentinel": {
+      "weight": 0.25,
+      "llm_enabled": false,
+      "enabled": true
+    }
   }
 }

--- a/config/deploy.hybrid.json
+++ b/config/deploy.hybrid.json
@@ -1,10 +1,19 @@
 {
-  "profile": { "profile_id": "macro_tilt_hybrid" },
-  "effective_weights": { "2.3": 0.55, "2.1": 0.15, "1.1": 0.25 },
+  "profile": {
+    "profile_id": "macro_tilt_hybrid"
+  },
   "decision_threshold": {
-    "buy": { "min_composite": 54, "min_confidence": 17 },
-    "sell": { "max_composite": 41, "min_confidence": 27 },
-    "hold": { "else": true },
+    "buy": {
+      "min_composite": 54,
+      "min_confidence": 17
+    },
+    "sell": {
+      "max_composite": 41,
+      "min_confidence": 27
+    },
+    "hold": {
+      "else": true
+    },
     "alignment_gating": {
       "enabled": true,
       "min_factors_for_directional": 2,
@@ -12,15 +21,34 @@
     },
     "ta_led": {
       "enabled": true,
-      "agent_id": "2.3",
+      "agent_id": "technical_ta_engine",
       "buy_min_composite": 58,
       "sell_max_composite": 42,
       "min_confidence": 15
     }
   },
   "execution": {
-    "arbitrator_mode": "agent_llm",
     "allows_short": true,
-    "leverage": 2.0
+    "leverage": 2.0,
+    "use_llm_synthesis": false,
+    "desk_debate_llm": false,
+    "arbitrator_llm": true
+  },
+  "agents": {
+    "technical_ta_engine": {
+      "weight": 0.55,
+      "llm_enabled": false,
+      "enabled": true
+    },
+    "pattern_recognition_bot": {
+      "weight": 0.15,
+      "llm_enabled": false,
+      "enabled": true
+    },
+    "monetary_sentinel": {
+      "weight": 0.25,
+      "llm_enabled": false,
+      "enabled": true
+    }
   }
 }

--- a/config/deploy.ohlcv_only.json
+++ b/config/deploy.ohlcv_only.json
@@ -2,12 +2,22 @@
   "profile": {
     "profile_id": "ohlcv_only"
   },
-  "effective_weights": {
-    "2.3": 0.75,
-    "2.1": 0.25
+  "agents": {
+    "technical_ta_engine": {
+      "weight": 0.75,
+      "llm_enabled": false,
+      "enabled": true
+    },
+    "pattern_recognition_bot": {
+      "weight": 0.25,
+      "llm_enabled": false,
+      "enabled": true
+    }
   },
   "execution": {
-    "arbitrator_mode": "agent_llm",
+    "use_llm_synthesis": false,
+    "desk_debate_llm": false,
+    "arbitrator_llm": false,
     "allows_short": true,
     "leverage": 1.5
   }

--- a/docs/agentic-config.md
+++ b/docs/agentic-config.md
@@ -1,0 +1,76 @@
+# Agentic configuration
+
+Primary source of truth: `config/deploy.active.json`.
+
+Secrets stay in `.env` (API keys, exchange credentials, DB).
+**Deploy JSON is the single source of truth for strategy** — there are no env overrides for arbitrator mode, LLM agent lists, or desk debate.
+
+## Schema
+
+```json
+{
+  "profile": { "profile_id": "macro_tilt" },
+  "agents": {
+    "technical_ta_engine": { "weight": 0.55, "llm_enabled": true, "enabled": true },
+    "pattern_recognition_bot": { "weight": 0.15, "llm_enabled": false, "enabled": true },
+    "monetary_sentinel": { "weight": 0.25, "llm_enabled": false, "enabled": true }
+  },
+  "execution": {
+    "use_llm_synthesis": true,
+    "desk_debate_llm": false,
+    "arbitrator_llm": true,
+    "allows_short": true,
+    "leverage": 2.0
+  },
+  "decision_threshold": {
+    "buy": { "min_composite": 53, "min_confidence": 16 },
+    "sell": { "max_composite": 41, "min_confidence": 26 },
+    "alignment_gating": { "enabled": true, "min_factors_for_directional": 2 },
+    "ta_led": { "enabled": true, "agent_id": "technical_ta_engine" }
+  }
+}
+```
+
+Agent keys (only these):
+
+- `monetary_sentinel`, `news_narrative_miner`
+- `pattern_recognition_bot`, `statistical_alpha_engine`, `technical_ta_engine`
+- `retail_hype_tracker`, `pro_bias_analyst`
+- `whale_behavior_analyst`, `liquidity_order_flow`
+
+## LLM control
+
+Desk CoT and the final arbitrator overlay are independent. Weighted math always runs first (static `agents.*.weight`). LLM overlays fall back to that math on failure. Alignment gating still blocks a directional LLM override.
+
+| Field | Effect |
+|-------|--------|
+| `agents.*.llm_enabled` | That desk may call the model (`infer_agent`) |
+| `execution.use_llm_synthesis` | Master switch for **per-desk** LLM enrichment |
+| `execution.arbitrator_llm` | LLM overlay on the final BUY/SELL/HOLD **after** weighted math |
+| `execution.desk_debate_llm` | LLM turns in desk debate (kept off in shipped presets) |
+
+`use_llm_synthesis` does not turn on the arbitrator overlay. `arbitrator_llm` does not turn on desk CoT. Both need an API key (`OPENAI_API_KEY` or `ATLASCLOUD_API_KEY`).
+
+| Preset | Desks | Arbitrator LLM |
+|--------|-------|----------------|
+| `deploy.active.json` | TA desk `llm_enabled: true` + `use_llm_synthesis: true` | on |
+| `deploy.golden.json` / `deploy.hybrid.json` | numeric desks (`llm_enabled: false`, `use_llm_synthesis: false`) | on |
+| `deploy.ohlcv_only.json` / `deploy.conservative_gate.json` | numeric desks | off |
+
+Weights are one-time config in `agents.*.weight` (Config Designer / deploy JSON). They are not retuned each bar.
+
+Fewer agents / selective `llm_enabled` is how you control desk cost. Turn `arbitrator_llm` off for measurement backtests.
+
+Omitted or `"enabled": false` desks are **not added to the LangGraph** — they do not run, not just zero-weight.
+
+## Config Designer (outside the graph)
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /config-designer/styles` | List presets |
+| `POST /config-designer/style` | Seed a preset |
+| `POST /config-designer/review` | Validate deploy JSON |
+| `POST /config-designer/chat` | Design chat |
+
+Presets: `macro_tilt`, `ohlcv_measurement`, `conservative`.  
+Shortcut without LLM: message `style: macro_tilt`.

--- a/docs/backtest-data.md
+++ b/docs/backtest-data.md
@@ -16,18 +16,18 @@ uv run python -m backtest.bootstrap_showcase
 
 ## Default desk combo (`macro_tilt`)
 
-`config/deploy.active.json` — agents **2.3** (TA), **2.1** (pattern), **1.1** (macro).
+`config/deploy.active.json` — `technical_ta_engine`, `pattern_recognition_bot`, `monetary_sentinel`.
 
 All three work in backtest without live Nexus:
 
-- **2.3 / 2.1** — OHLCV + TA-Lib Tier-0
-- **1.1** — OHLCV window return/vol → synthetic `market_overview` (no look-ahead)
+- **technical_ta_engine / pattern_recognition_bot** — OHLCV + TA-Lib Tier-0
+- **monetary_sentinel** — OHLCV window return/vol → synthetic `market_overview` (no look-ahead)
 
 Set `AIMM_BACKTEST_OHLCV_NEXUS=0` to disable synthetic Nexus context.
 
 ## Nexus-heavy agents (later PR)
 
-Agents **1.2** (news), **2.2** (stat arb), **3.x** (sentiment), **4.x** (flow) need feeds that are not reconstructible from OHLCV alone.
+Agents `news_narrative_miner`, `statistical_alpha_engine`, `retail_hype_tracker`, `pro_bias_analyst`, `whale_behavior_analyst`, `liquidity_order_flow` need feeds that are not reconstructible from OHLCV alone. Omit them from deploy JSON so they are not added to the graph.
 
 **Recommended path (not blocking showcase):**
 
@@ -39,9 +39,9 @@ Do not wire live Nexus per bar in backtest — it would inject look-ahead (today
 
 ## OHLCV-only two-desk mode
 
-For fastest smoke tests: `config/deploy.ohlcv_only.json` (2.3 + 2.1 only).
+For fastest smoke tests: `config/deploy.ohlcv_only.json` (technical_ta_engine + pattern_recognition_bot only).
 
 ```bash
-AIMM_LLM_AGENTS=2.3,2.1 uv run python -m backtest.run_demo \
+uv run python -m backtest.run_demo \
   --deploy config/deploy.ohlcv_only.json --ticker-only --steps 20 --csv-only
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,45 +40,32 @@ settings keep priority.
 
 Budget-friendly API access: https://www.atlascloud.ai/console/coding-plan
 
-> **No LLM key → the process exits with a clear error.** No fallback, no silent
-> degradation. This is intentional — the system is an LLM-native architecture.
+> **No LLM key → desk CoT and arbitrator overlay cannot run.** Weighted math still
+> produces a decision. An LLM call without a key raises a clear error.
 
 ---
 
 ## Optional Environment Variables
 
-### Arbitrator Mode
+### Strategy / agentic settings
 
-| Variable              | Values                                     | Default                |
-|-----------------------|--------------------------------------------|------------------------|
-| `AIMM_ARBITRATOR_MODE`| `weighted_convergence` / `llm` / `legacy`  | `weighted_convergence` |
+**Not in `.env`.** Configure via `config/deploy.active.json` (see `docs/agentic-config.md`):
 
-- **weighted_convergence** (default): deterministic factor-weighted engine, no LLM cost
-- **llm**: LLM-based synthesis (uses OPENAI_API_KEY)
-- **legacy**: original Tier-0 consensus voting
+- `agents.*.weight` / `llm_enabled` / `enabled`
+- `execution.use_llm_synthesis`
+- `execution.arbitrator_llm`
+- `execution.desk_debate_llm`
+- `decision_threshold`
 
-### Agent Toggles
+Optional path only: `AIMM_DEPLOY_CONFIG_PATH` selects which deploy JSON file to load.
+
+### Safety / ops
 
 | Variable                         | Effect                                  |
 |----------------------------------|-----------------------------------------|
-| `AIMM_ORCHESTRATOR_DISABLE`      | Skip policy orchestrator node           |
-| `AIMM_TA_TIER0_DISABLE`          | Disable technical TA agent              |
 | `AIMM_RISK_GUARD_KILL_SWITCH`    | Emergency stop — blocks all trades      |
-
-
-Each agent derives its enabled/disabled state from:
-1. Hardcoded default (e.g., Whale 4.1 is disabled by default)
-2. Environment variable override
-3. Orchestrator policy override (when orchestrator is active)
-
-### Debug & Observability
-
-| Variable                  | Purpose                                      |
-|---------------------------|----------------------------------------------|
-| `AIMM_DEBUG_RISK`         | Verbose risk calculation logs                |
-| `AIMM_FLOW_INCLUDE_FULL_DEBATE` | Include full debate transcript in output |
-| `AIMM_LLM_DESK_DEBATE`    | Enable LLM desk debate (costly)              |
-| `STRATEGY_INTERVAL_SEC`   | Graph run interval (default: 180)            |
+| `STRATEGY_INTERVAL_SEC`          | Graph run interval (default: 180)       |
+| `AIMM_DEBUG_RISK`                | Verbose risk calculation logs           |
 
 ### Execution
 
@@ -113,8 +100,8 @@ desk_market_scan ── [always on]
 ├─ liquidity_order_flow ── [config weight=0 → skip]
         │
 desk_risk ── [always on]
-desk_debate ── [always on, LLM part guarded by AIMM_LLM_DESK_DEBATE]
-signal_arbitrator ── [AIMM_ARBITRATOR_MODE selects engine]
+desk_debate ── [always on; LLM part from execution.desk_debate_llm]
+signal_arbitrator ── [execution.use_llm_synthesis selects engine]
 portfolio_proposal ── [always on]
 desk_risk_guard ── [AIMM_RISK_GUARD_KILL_SWITCH]
 portfolio_execute ── [MODE controls real vs paper]
@@ -123,11 +110,11 @@ audit ── [always on]
 
 ### Enabling/disabling agents via weight config
 
-Setting an agent's weight to `0.0` effectively disables it. The remaining enabled
-weights are re-normalized automatically:
+Setting an agent's weight to `0.0`, or omitting it from deploy JSON `agents`, disables it.
+Omitted desks are skipped in the graph. Remaining enabled weights are re-normalized:
 
 ```python
-weights = {"2.1": 0.25, "2.3": 0.30, "4.2": 0.15}  # others set to 0
+weights = {"pattern_recognition_bot": 0.25, "technical_ta_engine": 0.30, "liquidity_order_flow": 0.15}
 # Normalized internally: 0.25 + 0.30 + 0.15 = 0.70 ≠ 1.0
 # Each weight scaled by 1/0.70: 0.357 + 0.429 + 0.214 = 1.0
 ```
@@ -155,7 +142,7 @@ AIMM_TA_TIER0_DISABLE      ← Technical TA
 
 ### Layer 2 — Arbitrator
 ```
-AIMM_ARBITRATOR_MODE       ← Engine selection
+deploy.active.json         ← Engine selection (use_llm_synthesis)
 ```
 
 ### Layer 3 — Execution

--- a/docs/personas/11_desk_debate.md
+++ b/docs/personas/11_desk_debate.md
@@ -1,7 +1,7 @@
 # Persona: Desk Debate (辩论台 / Tier-2 综合)
 
 ## Position
-Pre-arbitration debate stage that generates two-sided evidence lines from Tier-0 contracts. Always produces deterministic bull/bear summaries. Optionally adds LLM desk turns (Desk_Risk with depth tool access, Desk_Tape narrative-only) when `AIMM_LLM_DESK_DEBATE=1`.
+Pre-arbitration debate stage that generates two-sided evidence lines from Tier-0 contracts. Always produces deterministic bull/bear summaries. Optionally adds LLM desk turns (Desk_Risk with depth tool access, Desk_Tape narrative-only) when `execution.desk_debate_llm=true in deploy JSON`.
 
 ## Agent Classification
 - **Agent ID**: N/A (Tier-2 Synthesis)
@@ -21,7 +21,7 @@ Pre-arbitration debate stage that generates two-sided evidence lines from Tier-0
    - **Deterministic** (always): `bull_evidence_lines()` + `bear_evidence_lines()` from `tier2_context.py`
      - Scans each agent's contract fields for constructive (bull) and defensive (bear) signals
      - Calls `legacy_deterministic_stance_preview()` for score reference
-   - **LLM** (optional, `AIMM_LLM_DESK_DEBATE=1`):
+   - **LLM** (optional, `execution.desk_debate_llm=true in deploy JSON`):
      - Desk_Risk: LLM with optional `nexus.fetch_market_depth` tool
      - Desk_Tape: LLM with no tools (narrative-only)
      - Both desks use structured format: Decision / Evidence / Risks / Would change mind if
@@ -62,7 +62,7 @@ Pre-arbitration debate stage that generates two-sided evidence lines from Tier-0
 
 ## Rules / Constraints
 - Deterministic debate is always active — no API cost
-- LLM debate requires `AIMM_LLM_DESK_DEBATE=1` env var AND `AIMM_ARBITRATOR_MODE=llm`
+- LLM debate requires `execution.desk_debate_llm=true` in deploy JSON
 - Full transcript stored in state; preview (320 chars) used for reasoning logs
 - Full transcript can be included in flow events via `AIMM_FLOW_INCLUDE_FULL_DEBATE=1`
 - Desk_Risk (LLM) may call tools up to 2 rounds; Desk_Tape has no tools

--- a/docs/personas/12_signal_arbitrator.md
+++ b/docs/personas/12_signal_arbitrator.md
@@ -8,7 +8,7 @@ Core arbitration node that synthesizes all 9 Tier-0 agents' signals into a singl
 - **Type**: Arbitration / Signal Synthesis
 - **Code Class**: `weighted_arbitrator_node` (`src/workflow/weighted_arbitrator.py`) + `compute_weighted_arbitration()` (`src/workflow/weight_assigner.py`)
 - **Enabled by default**: Yes (weighted_convergence mode)
-- **Alternative**: `AIMM_ARBITRATOR_MODE=llm` for LLM-based arbitrator
+- **Alternative**: `execution.arbitrator_llm=true` for an LLM overlay on the weighted decision. Desk weights stay in deploy JSON.
 
 ## Goals
 - Compute per-agent weighted composites from standardized Tier-0 contracts

--- a/docs/personas/README.md
+++ b/docs/personas/README.md
@@ -75,5 +75,6 @@ alignment_gating: min_factors_for_directional = 3
 
 ### Optional LLM Features
 
-- **AIMM_ARBITRATOR_MODE=llm**: Use LLM-based arbitrator instead of weighted convergence
-- **AIMM_LLM_DESK_DEBATE=1**: Enable LLM desk debate (Desk_Risk + Desk_Tape LLM turns)
+- **execution.use_llm_synthesis=true**: Per-desk LLM enrichment (`agents.*.llm_enabled`)
+- **execution.arbitrator_llm=true**: LLM may confirm or override the weighted BUY/SELL/HOLD
+- **execution.desk_debate_llm=true**: Enable LLM desk debate (Desk_Risk + Desk_Tape LLM turns)

--- a/docs/weighted-arbitrator.md
+++ b/docs/weighted-arbitrator.md
@@ -15,8 +15,9 @@ Tier-0 Agents → desk_risk → desk_debate
     → portfolio_proposal → desk_risk_guard → portfolio_execute → audit
 ```
 
-The arbitrator replaces the `signal_arbitrator` node. It is a **deterministic
-formula engine** — no LLM costs, no API latency, fully reproducible.
+The arbitrator is a **formula engine with an optional LLM overlay** configured in
+deploy JSON (`execution.arbitrator_llm`). Desk weights are static JSON. Math
+always runs; the model may confirm or override the final action.
 
 ## Decision Flow
 
@@ -162,12 +163,13 @@ decision. Per-agent entries contain the full factor breakdown:
 
 ## Opt-In / Opt-Out
 
-The arbitrator supports three modes via `AIMM_ARBITRATOR_MODE`:
+The arbitrator supports optional LLM overlays via deploy JSON:
 
-| Mode                   | Engine                   | Use Case                     |
-|------------------------|--------------------------|------------------------------|
-| `weighted_convergence` | `weighted_arbitrator.py` | Default — deterministic      |
-| `llm`                  | `signal_arbitrator_llm`  | LLM-based synthesis          |
+| Flag | Engine | Use case |
+|------|--------|----------|
+| (none) | `weighted_arbitrator.py` math | Reproducible baseline |
+| `execution.arbitrator_llm` | LLM confirms/overrides action | Agentic PM decision |
+| `execution.use_llm_synthesis` | Per-desk `infer_agent` | Desk CoT, not fusion |
 
 
 Additionally, disable the arbitrator entirely by setting `AIMM_ARBITRATOR_DISABLE=1`

--- a/src/agents/config_designer.py
+++ b/src/agents/config_designer.py
@@ -1,0 +1,386 @@
+"""Config Designer — outside the trading graph.
+
+Chat to seed, review, and refine deploy JSON. Does not place trades.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = """You are the Config Designer for an agentic crypto trading system (AIMM).
+
+Your job is to help the user design a clean deploy JSON configuration. You are
+NOT inside the live trading graph. You only produce configuration.
+
+## Deploy JSON schema (preferred)
+
+```json
+{
+  "profile": { "profile_id": "macro_tilt" },
+  "agents": {
+    "technical_ta_engine": { "weight": 0.55, "llm_enabled": true, "enabled": true },
+    "pattern_recognition_bot": { "weight": 0.15, "llm_enabled": false, "enabled": true },
+    "monetary_sentinel": { "weight": 0.25, "llm_enabled": false, "enabled": true }
+  },
+  "execution": {
+    "use_llm_synthesis": true,
+    "desk_debate_llm": false,
+    "arbitrator_llm": true,
+    "allows_short": true,
+    "leverage": 2.0
+  },
+  "decision_threshold": {
+    "buy": { "min_composite": 53, "min_confidence": 16 },
+    "sell": { "max_composite": 41, "min_confidence": 26 },
+    "hold": { "else": true },
+    "alignment_gating": {
+      "enabled": true,
+      "min_factors_for_directional": 2,
+      "risk_override_if_blocked": true
+    },
+    "ta_led": {
+      "enabled": true,
+      "agent_id": "technical_ta_engine",
+      "buy_min_composite": 57,
+      "sell_max_composite": 43,
+      "min_confidence": 14
+    }
+  }
+}
+```
+
+## Available agents (use these keys only)
+
+- monetary_sentinel — Macro / liquidity regime
+- news_narrative_miner — News & narrative shock
+- pattern_recognition_bot — Chart patterns / setup quality
+- statistical_alpha_engine — Cross-sectional / factor alpha
+- technical_ta_engine — TA-Lib indicators (RSI, MACD, …)
+- retail_hype_tracker — Retail FOMO / divergence
+- pro_bias_analyst — Smart money / funding / OI
+- whale_behavior_analyst — Whale concentration / dump risk
+- liquidity_order_flow — Depth, slippage, imbalance
+
+## Style guidance
+
+- scalp: tight thresholds, high TA weight, short horizon, low leverage
+- daytrade: balanced TA + pattern, moderate thresholds
+- swing: more macro + news weight, looser thresholds
+- buffett / conservative: few agents, high confidence bars, low leverage
+- macro_tilt: TA-led with macro support (default research profile)
+
+## Rules
+
+1. Always reply with a short explanation, then a single JSON block when proposing a config.
+2. Agent weights for enabled agents should sum roughly to 1.0 (0.9–1.1 ok).
+3. Prefer readable agent names — never invent numeric ids like "2.3" in new configs.
+4. Never include API keys or secrets in the JSON.
+5. If the user asks to review an existing JSON, point out risks (over-concentration, too many LLM agents, thresholds that never fire, etc.).
+6. Keep leverage modest unless the user explicitly wants aggressive settings.
+7. Agentic hedge-fund configs should set execution.arbitrator_llm true;
+   measurement/conservative configs should set it false. Desk CoT is
+   agents.*.llm_enabled. Desk weights are one-time config, not retuned each bar.
+"""
+
+
+STYLE_SEEDS: dict[str, dict[str, Any]] = {
+    "macro_tilt": {
+        "profile": {"profile_id": "macro_tilt"},
+        "agents": {
+            "technical_ta_engine": {"weight": 0.55, "llm_enabled": True, "enabled": True},
+            "pattern_recognition_bot": {"weight": 0.15, "llm_enabled": False, "enabled": True},
+            "monetary_sentinel": {"weight": 0.25, "llm_enabled": False, "enabled": True},
+        },
+        "execution": {
+            "use_llm_synthesis": True,
+            "desk_debate_llm": False,
+            "arbitrator_llm": True,
+            "allows_short": True,
+            "leverage": 2.0,
+        },
+        "decision_threshold": {
+            "buy": {"min_composite": 53, "min_confidence": 16},
+            "sell": {"max_composite": 41, "min_confidence": 26},
+            "hold": {"else": True},
+            "alignment_gating": {
+                "enabled": True,
+                "min_factors_for_directional": 2,
+                "risk_override_if_blocked": True,
+            },
+            "ta_led": {
+                "enabled": True,
+                "agent_id": "technical_ta_engine",
+                "buy_min_composite": 57,
+                "sell_max_composite": 43,
+                "min_confidence": 14,
+            },
+        },
+    },
+    "ohlcv_measurement": {
+        "profile": {"profile_id": "ohlcv_only"},
+        "agents": {
+            "technical_ta_engine": {"weight": 0.75, "llm_enabled": False, "enabled": True},
+            "pattern_recognition_bot": {"weight": 0.25, "llm_enabled": False, "enabled": True},
+        },
+        "execution": {
+            "use_llm_synthesis": False,
+            "desk_debate_llm": False,
+            "arbitrator_llm": False,
+            "allows_short": True,
+            "leverage": 1.5,
+        },
+    },
+    "conservative": {
+        "profile": {"profile_id": "conservative"},
+        "agents": {
+            "technical_ta_engine": {"weight": 0.5, "llm_enabled": False, "enabled": True},
+            "monetary_sentinel": {"weight": 0.3, "llm_enabled": False, "enabled": True},
+            "liquidity_order_flow": {"weight": 0.2, "llm_enabled": False, "enabled": True},
+        },
+        "execution": {
+            "use_llm_synthesis": False,
+            "desk_debate_llm": False,
+            "arbitrator_llm": False,
+            "allows_short": False,
+            "leverage": 1.0,
+        },
+        "decision_threshold": {
+            "buy": {"min_composite": 60, "min_confidence": 40},
+            "sell": {"max_composite": 40, "min_confidence": 40},
+            "hold": {"else": True},
+            "alignment_gating": {
+                "enabled": True,
+                "min_factors_for_directional": 3,
+                "risk_override_if_blocked": True,
+            },
+        },
+    },
+}
+
+
+@dataclass
+class ConfigDesignerTurn:
+    role: str  # user | assistant | system
+    content: str
+
+
+@dataclass
+class ConfigDesignerResult:
+    reply: str
+    draft_config: dict[str, Any] | None = None
+    warnings: list[str] = field(default_factory=list)
+    style: str | None = None
+
+
+def _extract_json_block(text: str) -> dict[str, Any] | None:
+    """Pull the last fenced or raw JSON object from model output."""
+    fence = re.findall(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.S)
+    candidates = fence or re.findall(r"(\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\})", text, flags=re.S)
+    for raw in reversed(candidates):
+        try:
+            obj = json.loads(raw)
+            if isinstance(obj, dict) and ("agents" in obj or "execution" in obj):
+                return obj
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def validate_deploy_draft(cfg: dict[str, Any]) -> list[str]:
+    """Lightweight validation — returns human warnings, not hard errors."""
+    warnings: list[str] = []
+    from agents.registry import get_registry
+
+    known = set(get_registry().names())
+
+    agents = cfg.get("agents")
+    if isinstance(agents, dict):
+        total_w = 0.0
+        llm_count = 0
+        for key, meta in agents.items():
+            if key not in known:
+                warnings.append(f"Unknown agent key: {key}")
+            if not isinstance(meta, dict):
+                continue
+            if meta.get("enabled", True) is False:
+                continue
+            try:
+                total_w += float(meta.get("weight") or 0)
+            except (TypeError, ValueError):
+                warnings.append(f"Invalid weight for {key}")
+            if meta.get("llm_enabled"):
+                llm_count += 1
+        if total_w and (total_w < 0.85 or total_w > 1.15):
+            warnings.append(f"Enabled agent weights sum to {total_w:.2f} (prefer ~1.0)")
+        if llm_count > 3:
+            warnings.append(f"{llm_count} agents have llm_enabled — cost may be high")
+    else:
+        warnings.append("No agents block")
+
+    execution = cfg.get("execution") if isinstance(cfg.get("execution"), dict) else {}
+    lev = execution.get("leverage")
+    try:
+        if lev is not None and float(lev) > 5:
+            warnings.append(f"Leverage {lev} is aggressive")
+    except (TypeError, ValueError):
+        pass
+
+    thr = cfg.get("decision_threshold") if isinstance(cfg.get("decision_threshold"), dict) else {}
+    buy = thr.get("buy") if isinstance(thr.get("buy"), dict) else {}
+    sell = thr.get("sell") if isinstance(thr.get("sell"), dict) else {}
+    try:
+        if buy.get("min_composite") is not None and sell.get("max_composite") is not None:
+            if float(buy["min_composite"]) <= float(sell["max_composite"]):
+                warnings.append("buy.min_composite should be greater than sell.max_composite")
+    except (TypeError, ValueError):
+        pass
+
+    return warnings
+
+
+class ConfigDesignerAgent:
+    """Outside-graph specialist: chat → deploy JSON draft."""
+
+    name = "config_designer"
+    role = "strategy_config_specialist"
+
+    def seed_style(self, style: str) -> ConfigDesignerResult:
+        key = (style or "").strip().lower().replace("-", "_")
+        aliases = {
+            "measurement": "ohlcv_measurement",
+            "ohlcv": "ohlcv_measurement",
+            "ohlcv_only": "ohlcv_measurement",
+            "buffett": "conservative",
+            "safe": "conservative",
+        }
+        key = aliases.get(key, key)
+        cfg = STYLE_SEEDS.get(key)
+        if cfg is None:
+            available = ", ".join(sorted(STYLE_SEEDS))
+            return ConfigDesignerResult(
+                reply=f"Unknown style '{style}'. Available: {available}",
+                warnings=[f"unknown_style:{style}"],
+            )
+        draft = copy.deepcopy(cfg)
+        warnings = validate_deploy_draft(draft)
+        return ConfigDesignerResult(
+            reply=f"Seeded deploy config for style `{key}`. Review and adjust weights/thresholds as needed.",
+            draft_config=draft,
+            warnings=warnings,
+            style=key,
+        )
+
+    def review(self, cfg: dict[str, Any]) -> ConfigDesignerResult:
+        warnings = validate_deploy_draft(cfg)
+        if warnings:
+            body = "Review complete. Issues to consider:\n" + "\n".join(f"- {w}" for w in warnings)
+        else:
+            body = "Review complete. No structural issues found in the draft."
+        return ConfigDesignerResult(reply=body, draft_config=cfg, warnings=warnings)
+
+    def chat(
+        self,
+        message: str,
+        *,
+        history: list[ConfigDesignerTurn] | None = None,
+        current_config: dict[str, Any] | None = None,
+    ) -> ConfigDesignerResult:
+        """LLM-backed design turn. Falls back to seed/review heuristics without a key."""
+        msg = (message or "").strip()
+        if not msg:
+            return ConfigDesignerResult(
+                reply="Send a design request or paste a deploy JSON to review."
+            )
+        lower = msg.lower()
+        if lower.startswith("style:") or lower.startswith("preset:"):
+            style = msg.split(":", 1)[1].strip()
+            return self.seed_style(style)
+        if lower in STYLE_SEEDS or lower in ("measurement", "ohlcv", "buffett", "safe"):
+            return self.seed_style(lower)
+
+        pasted = _extract_json_block(msg)
+        if pasted is not None and any(k in lower for k in ("review", "check", "validate")):
+            return self.review(pasted)
+
+        # LLM path
+        try:
+            from llm.agent_llm_client import check_api_key
+            from llm.openai_client import run_tool_calling_chat
+        except Exception as e:
+            return ConfigDesignerResult(
+                reply=(
+                    f"LLM client unavailable ({e}). "
+                    "Use `style: macro_tilt` / `style: conservative` / `style: ohlcv_measurement` "
+                    "or paste JSON with the word 'review'."
+                ),
+                warnings=["llm_unavailable"],
+            )
+
+        key_err = check_api_key()
+        if key_err:
+            if pasted is not None:
+                return self.review(pasted)
+            return ConfigDesignerResult(
+                reply=(
+                    f"No LLM API key configured ({key_err}). "
+                    "Try: `style: macro_tilt`, `style: conservative`, or paste JSON + 'review'."
+                ),
+                draft_config=STYLE_SEEDS.get("macro_tilt"),
+                warnings=["no_api_key"],
+                style="macro_tilt",
+            )
+
+        messages: list[dict[str, str]] = [{"role": "system", "content": SYSTEM_PROMPT}]
+        if current_config:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": "Current deploy config:\n```json\n"
+                    + json.dumps(current_config, indent=2)
+                    + "\n```",
+                }
+            )
+        for turn in history or []:
+            if turn.role in ("user", "assistant") and turn.content:
+                messages.append({"role": turn.role, "content": turn.content})
+        messages.append({"role": "user", "content": msg})
+
+        try:
+            result = run_tool_calling_chat(
+                messages=messages,
+                tools=[],
+                temperature=0.2,
+                max_tokens=1200,
+            )
+            reply = ""
+            if isinstance(result, dict):
+                reply = str(result.get("content") or result.get("text") or "")
+            else:
+                reply = str(result)
+        except Exception as e:
+            logger.exception("config designer LLM failed")
+            return ConfigDesignerResult(
+                reply=f"LLM error: {e}", warnings=[f"llm_error:{type(e).__name__}"]
+            )
+
+        draft = _extract_json_block(reply) or pasted
+        warnings = validate_deploy_draft(draft) if draft else []
+        return ConfigDesignerResult(
+            reply=reply or "(empty model response)", draft_config=draft, warnings=warnings
+        )
+
+
+__all__ = [
+    "ConfigDesignerAgent",
+    "ConfigDesignerResult",
+    "ConfigDesignerTurn",
+    "STYLE_SEEDS",
+    "validate_deploy_draft",
+]

--- a/src/agents/operator/2.3_technical_ta_engine/persona.md
+++ b/src/agents/operator/2.3_technical_ta_engine/persona.md
@@ -20,7 +20,7 @@ Classical Technical Indicator Analyst — computes and interprets standard TA in
 ```json
 {
   "schema_version": "tier0/v1",
-  "agent": "2.3",
+  "agent": "technical_ta_engine",
   "ta_period": "4h",
   "bars_used": 100,
   "indicator_catalog_version": "ta_bundle/v1",

--- a/src/agents/profile_agent.py
+++ b/src/agents/profile_agent.py
@@ -16,8 +16,8 @@ Output:
     {
         "profile_id": "user_<hash>",
         "base": "AGENT_WEIGHTS_DEFAULT",
-        "deltas": {"2.1": "+0.10", "1.2": "-0.05", ...},
-        "effective_weights": {"1.1": 0.05, "2.1": 0.35, ...},
+        "deltas": {"pattern_recognition_bot": "+0.10", "news_narrative_miner": "-0.05", ...},
+        "effective_weights": {"monetary_sentinel": 0.05, "pattern_recognition_bot": 0.35, ...},
         "reasoning": "Pattern-based trader with news confirmation bias...",
         "narrative": "Technician"
     }
@@ -31,32 +31,12 @@ import os
 import time
 from typing import Any
 
+from agents.registry import get_registry
 from config.llm_env import llm_key_available
 
-# Default base weights (mirrors _V4_AGENT_WEIGHTS in weighted_arbitrator.py)
-AGENT_WEIGHTS_DEFAULT: dict[str, float] = {
-    "1.1": 0.15,
-    "1.2": 0.05,
-    "2.1": 0.20,
-    "2.2": 0.10,
-    "2.3": 0.55,
-    "3.1": 0.05,
-    "3.2": 0.05,
-    "4.1": 0.05,  # disabled by default, but kept for config
-    "4.2": 0.15,
-}
-
-AGENT_LABELS: dict[str, str] = {
-    "1.1": "monetary_sentinel (Macro Regime)",
-    "1.2": "news_narrative_miner (News & Narrative)",
-    "2.1": "pattern_recognition_bot (Chart Patterns)",
-    "2.2": "statistical_alpha_engine (Statistical Alpha)",
-    "2.3": "technical_ta_engine (Technical TA)",
-    "3.1": "retail_hype_tracker (Retail Sentiment)",
-    "3.2": "pro_bias_analyst (Smart Money)",
-    "4.1": "whale_behavior_analyst (On-Chain Whale)",
-    "4.2": "liquidity_order_flow (Order Flow)",
-}
+_reg = get_registry()
+AGENT_WEIGHTS_DEFAULT: dict[str, float] = _reg.default_weights()
+AGENT_LABELS: dict[str, str] = {s.name: f"{s.name} ({s.label})" for s in _reg.all_specs()}
 
 # 5-Question weight delta rules
 # Format: (risk, horizon, signals, leverage, assets) -> {agent_id: delta}
@@ -71,7 +51,12 @@ _WEIGHT_RULES: list[tuple[str, str, str, str, str, dict[str, float]]] = [
         "*",
         "*",
         "*",
-        {"1.1": 0.10, "2.3": 0.05, "3.1": -0.03, "4.2": -0.05},
+        {
+            "monetary_sentinel": 0.10,
+            "technical_ta_engine": 0.05,
+            "retail_hype_tracker": -0.03,
+            "liquidity_order_flow": -0.05,
+        },
     ),
     (
         "conservative",
@@ -79,7 +64,12 @@ _WEIGHT_RULES: list[tuple[str, str, str, str, str, dict[str, float]]] = [
         "*",
         "*",
         "*",
-        {"1.1": 0.05, "2.3": 0.05, "3.1": -0.02, "4.2": -0.03},
+        {
+            "monetary_sentinel": 0.05,
+            "technical_ta_engine": 0.05,
+            "retail_hype_tracker": -0.02,
+            "liquidity_order_flow": -0.03,
+        },
     ),
     # === AGGRESSIVE profiles ===
     # Aggressive + short horizon: tilt → momentum, retail, whale
@@ -89,7 +79,12 @@ _WEIGHT_RULES: list[tuple[str, str, str, str, str, dict[str, float]]] = [
         "*",
         "*",
         "*",
-        {"2.1": 0.10, "4.2": 0.10, "1.1": -0.03, "1.2": -0.03},
+        {
+            "pattern_recognition_bot": 0.10,
+            "liquidity_order_flow": 0.10,
+            "monetary_sentinel": -0.03,
+            "news_narrative_miner": -0.03,
+        },
     ),
     (
         "aggressive",
@@ -97,22 +92,153 @@ _WEIGHT_RULES: list[tuple[str, str, str, str, str, dict[str, float]]] = [
         "*",
         "*",
         "*",
-        {"2.1": 0.05, "4.2": 0.05, "3.1": 0.03, "1.1": -0.02},
+        {
+            "pattern_recognition_bot": 0.05,
+            "liquidity_order_flow": 0.05,
+            "retail_hype_tracker": 0.03,
+            "monetary_sentinel": -0.02,
+        },
     ),
-    ("aggressive", "*", "*", "5x+", "*", {"2.1": 0.08, "4.2": 0.05, "3.1": 0.05, "1.2": -0.03}),
+    (
+        "aggressive",
+        "*",
+        "*",
+        "5x+",
+        "*",
+        {
+            "pattern_recognition_bot": 0.08,
+            "liquidity_order_flow": 0.05,
+            "retail_hype_tracker": 0.05,
+            "news_narrative_miner": -0.03,
+        },
+    ),
     # === SIGNAL preference profiles ===
-    ("*", "*", "technical", "*", "*", {"2.3": 0.10, "2.1": 0.05, "3.1": -0.05, "1.2": -0.05}),
-    ("*", "*", "onchain", "*", "*", {"4.1": 0.15, "4.2": 0.05, "2.3": -0.10, "2.1": -0.05}),
-    ("*", "*", "news", "*", "*", {"1.2": 0.15, "3.1": 0.05, "2.3": -0.10, "2.1": -0.05}),
-    ("*", "*", "sentiment", "*", "*", {"3.1": 0.15, "3.2": 0.05, "2.3": -0.10, "2.1": -0.05}),
-    ("*", "*", "mixed", "*", "*", {"1.2": 0.03, "3.1": 0.03, "3.2": 0.03, "2.3": -0.05}),
+    (
+        "*",
+        "*",
+        "technical",
+        "*",
+        "*",
+        {
+            "technical_ta_engine": 0.10,
+            "pattern_recognition_bot": 0.05,
+            "retail_hype_tracker": -0.05,
+            "news_narrative_miner": -0.05,
+        },
+    ),
+    (
+        "*",
+        "*",
+        "onchain",
+        "*",
+        "*",
+        {
+            "whale_behavior_analyst": 0.15,
+            "liquidity_order_flow": 0.05,
+            "technical_ta_engine": -0.10,
+            "pattern_recognition_bot": -0.05,
+        },
+    ),
+    (
+        "*",
+        "*",
+        "news",
+        "*",
+        "*",
+        {
+            "news_narrative_miner": 0.15,
+            "retail_hype_tracker": 0.05,
+            "technical_ta_engine": -0.10,
+            "pattern_recognition_bot": -0.05,
+        },
+    ),
+    (
+        "*",
+        "*",
+        "sentiment",
+        "*",
+        "*",
+        {
+            "retail_hype_tracker": 0.15,
+            "pro_bias_analyst": 0.05,
+            "technical_ta_engine": -0.10,
+            "pattern_recognition_bot": -0.05,
+        },
+    ),
+    (
+        "*",
+        "*",
+        "mixed",
+        "*",
+        "*",
+        {
+            "news_narrative_miner": 0.03,
+            "retail_hype_tracker": 0.03,
+            "pro_bias_analyst": 0.03,
+            "technical_ta_engine": -0.05,
+        },
+    ),
     # === LEVERAGE profiles ===
-    ("*", "*", "*", "1x", "*", {"2.3": 0.05, "1.1": 0.05, "3.1": -0.02, "4.2": -0.02}),
-    ("*", "*", "*", "3-5x", "*", {"2.1": 0.05, "3.1": 0.03, "4.2": 0.03, "1.1": -0.03}),
+    (
+        "*",
+        "*",
+        "*",
+        "1x",
+        "*",
+        {
+            "technical_ta_engine": 0.05,
+            "monetary_sentinel": 0.05,
+            "retail_hype_tracker": -0.02,
+            "liquidity_order_flow": -0.02,
+        },
+    ),
+    (
+        "*",
+        "*",
+        "*",
+        "3-5x",
+        "*",
+        {
+            "pattern_recognition_bot": 0.05,
+            "retail_hype_tracker": 0.03,
+            "liquidity_order_flow": 0.03,
+            "monetary_sentinel": -0.03,
+        },
+    ),
     # === ASSET profiles ===
-    ("*", "*", "*", "*", "majors_only", {"2.3": 0.05, "3.1": -0.03, "4.1": -0.03}),
-    ("*", "*", "*", "*", "full_universe", {"3.1": 0.08, "3.2": 0.05, "4.1": 0.05, "2.3": -0.10}),
-    ("*", "*", "*", "*", "majors_alts", {"2.1": 0.03, "3.2": 0.03, "1.2": 0.02}),
+    (
+        "*",
+        "*",
+        "*",
+        "*",
+        "majors_only",
+        {
+            "technical_ta_engine": 0.05,
+            "retail_hype_tracker": -0.03,
+            "whale_behavior_analyst": -0.03,
+        },
+    ),
+    (
+        "*",
+        "*",
+        "*",
+        "*",
+        "full_universe",
+        {
+            "retail_hype_tracker": 0.08,
+            "pro_bias_analyst": 0.05,
+            "whale_behavior_analyst": 0.05,
+            "technical_ta_engine": -0.10,
+        },
+    ),
+    (
+        "*",
+        "*",
+        "*",
+        "*",
+        "majors_alts",
+        {"pattern_recognition_bot": 0.03, "pro_bias_analyst": 0.03, "news_narrative_miner": 0.02},
+    ),
 ]
 
 # === Narrative labels for user-facing profile ===
@@ -228,7 +354,7 @@ class ProfileAgent:
             "4. The final weights will be re-normalized to sum 1.0\n"
             "5. Provide a concise reasoning string (1-2 sentences)\n"
             "6. Output valid JSON ONLY, no markdown:\n"
-            '{"deltas": {"2.1": 0.10, "2.3": -0.05}, "reasoning": "...", "narrative": "..."}'
+            '{"deltas": {"pattern_recognition_bot": 0.10, "technical_ta_engine": -0.05}, "reasoning": "...", "narrative": "..."}'
         )
 
     # ------------------------------------------------------------------

--- a/src/agents/profile_registry.py
+++ b/src/agents/profile_registry.py
@@ -10,7 +10,7 @@ Each profile file contains:
   {
     "profile_id": "user_a1b2c3...",
     "created_at": 1710000000,
-    "effective_weights": {"1.1": 0.05, ...},
+    "effective_weights": {"monetary_sentinel": 0.05, ...},
     "narrative": "Balanced Technician",
     "input": { ... }
   }

--- a/src/agents/registry.py
+++ b/src/agents/registry.py
@@ -1,0 +1,62 @@
+"""Canonical Tier-0 agent registry. Keys are readable snake_case names only."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    name: str
+    label: str
+    default_weight: float = 0.0
+    default_llm_enabled: bool = False
+
+
+_SPECS: tuple[AgentSpec, ...] = (
+    AgentSpec("monetary_sentinel", "Macro Economist", 0.25),
+    AgentSpec("news_narrative_miner", "News & Narrative", 0.05),
+    AgentSpec("pattern_recognition_bot", "Pattern Recognition", 0.15),
+    AgentSpec("statistical_alpha_engine", "Statistical Alpha", 0.10),
+    AgentSpec("technical_ta_engine", "Technical Analysis", 0.55),
+    AgentSpec("retail_hype_tracker", "Retail Hype Tracker", 0.05),
+    AgentSpec("pro_bias_analyst", "Smart Money Tracker", 0.05),
+    AgentSpec("whale_behavior_analyst", "Whale Behavior", 0.0),
+    AgentSpec("liquidity_order_flow", "Liquidity & Order Flow", 0.15),
+)
+
+
+class AgentRegistry:
+    def __init__(self, specs: Iterable[AgentSpec] = _SPECS) -> None:
+        self._by_name = {s.name: s for s in specs}
+
+    def get(self, name: str) -> AgentSpec | None:
+        return self._by_name.get((name or "").strip())
+
+    def require(self, name: str) -> AgentSpec:
+        spec = self.get(name)
+        if spec is None:
+            raise KeyError(f"unknown agent: {name!r}")
+        return spec
+
+    def all_specs(self) -> list[AgentSpec]:
+        return list(self._by_name.values())
+
+    def names(self) -> list[str]:
+        return list(self._by_name.keys())
+
+    def default_weights(self) -> dict[str, float]:
+        return {s.name: s.default_weight for s in self._by_name.values()}
+
+    def labels(self) -> dict[str, str]:
+        return {s.name: s.label for s in self._by_name.values()}
+
+
+@lru_cache(maxsize=1)
+def get_registry() -> AgentRegistry:
+    return AgentRegistry()
+
+
+__all__ = ["AgentSpec", "AgentRegistry", "get_registry"]

--- a/src/api/config_designer_routes.py
+++ b/src/api/config_designer_routes.py
@@ -1,0 +1,85 @@
+"""API for the outside-graph Config Designer agent.
+
+Chat to design / review deploy JSON (agents, weights, decision_threshold, LLM flags)
+without running the trading graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from agents.config_designer import STYLE_SEEDS, ConfigDesignerAgent, ConfigDesignerTurn
+
+router = APIRouter(tags=["config-designer"])
+_agent = ConfigDesignerAgent()
+
+
+class ChatMessage(BaseModel):
+    role: str = Field(description="user | assistant")
+    content: str
+
+
+class ConfigDesignerChatRequest(BaseModel):
+    message: str
+    history: list[ChatMessage] = Field(default_factory=list)
+    current_config: dict[str, Any] | None = None
+
+
+class ConfigDesignerChatResponse(BaseModel):
+    reply: str
+    draft_config: dict[str, Any] | None = None
+    warnings: list[str] = Field(default_factory=list)
+    style: str | None = None
+
+
+class StyleRequest(BaseModel):
+    style: str = Field(description="macro_tilt | ohlcv_measurement | conservative | ...")
+
+
+@router.get("/config-designer/styles")
+def list_styles() -> dict[str, Any]:
+    return {
+        "styles": sorted(STYLE_SEEDS.keys()),
+        "hint": 'POST /config-designer/style with {"style": "macro_tilt"} or chat with \'style: macro_tilt\'',
+    }
+
+
+@router.post("/config-designer/style", response_model=ConfigDesignerChatResponse)
+def seed_style(req: StyleRequest) -> ConfigDesignerChatResponse:
+    result = _agent.seed_style(req.style)
+    return ConfigDesignerChatResponse(
+        reply=result.reply,
+        draft_config=result.draft_config,
+        warnings=result.warnings,
+        style=result.style,
+    )
+
+
+@router.post("/config-designer/review", response_model=ConfigDesignerChatResponse)
+def review_config(body: dict[str, Any]) -> ConfigDesignerChatResponse:
+    """Review a full deploy JSON body."""
+    result = _agent.review(body)
+    return ConfigDesignerChatResponse(
+        reply=result.reply,
+        draft_config=result.draft_config,
+        warnings=result.warnings,
+    )
+
+
+@router.post("/config-designer/chat", response_model=ConfigDesignerChatResponse)
+def chat_design(req: ConfigDesignerChatRequest) -> ConfigDesignerChatResponse:
+    history = [ConfigDesignerTurn(role=m.role, content=m.content) for m in req.history]
+    result = _agent.chat(
+        req.message,
+        history=history,
+        current_config=req.current_config,
+    )
+    return ConfigDesignerChatResponse(
+        reply=result.reply,
+        draft_config=result.draft_config,
+        warnings=result.warnings,
+        style=result.style,
+    )

--- a/src/api/deploy_routes.py
+++ b/src/api/deploy_routes.py
@@ -19,35 +19,20 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, field_validator
 
+from agents.registry import get_registry
+
 router = APIRouter(tags=["deploy"])
 
-
-# ── Constants ────────────────────────────────────────────────────────────
-
 _DEFAULT_DEPLOY_PATH = "config/deploy.active.json"
-_AGENT_WEIGHTS_DEFAULT: dict[str, float] = {
-    "1.1": 0.15,  # monetary_sentinel
-    "1.2": 0.05,  # news_narrative_miner
-    "2.1": 0.20,  # pattern_recognition_bot
-    "2.2": 0.10,  # statistical_alpha_engine
-    "2.3": 0.55,  # technical_ta_engine
-    "3.1": 0.05,  # retail_hype_tracker
-    "3.2": 0.05,  # pro_bias_analyst
-    "4.1": 0.05,  # whale_behavior_analyst
-    "4.2": 0.15,  # liquidity_order_flow
-}
 
-_AGENT_LABELS: dict[str, str] = {
-    "1.1": "Monetary Sentinel",
-    "1.2": "News & Narrative Miner",
-    "2.1": "Pattern Recognition Bot",
-    "2.2": "Statistical Alpha Engine",
-    "2.3": "Technical TA Engine",
-    "3.1": "Retail Hype Tracker",
-    "3.2": "Pro Bias Analyst",
-    "4.1": "Whale Behavior Analyst",
-    "4.2": "Liquidity & Order Flow",
-}
+
+def _agent_labels() -> dict[str, str]:
+    return get_registry().labels()
+
+
+def _agent_weights_default() -> dict[str, float]:
+    return get_registry().default_weights()
+
 
 _GRAPH_EDGES_DEFAULT: list[dict[str, str]] = [
     {"from": "policy_orchestrator", "to": "market_scan"},
@@ -113,6 +98,7 @@ class ExecConfig(BaseModel):
         description="weighted_convergence | agent_llm",
     )
     desk_debate_enabled: bool = False
+    arbitrator_llm: bool = False
     nexus_api_key: str | None = None
     default_ticker: str = "BTC/USDT"
     universe_symbols: list[str] = Field(
@@ -176,7 +162,7 @@ def _resolve_effective_weights(
     profile: ProfileWeights,
 ) -> dict[str, float]:
     """Build effective weight map: defaults + per-agent overrides + profile deltas."""
-    weights = dict(_AGENT_WEIGHTS_DEFAULT)
+    weights = dict(_agent_weights_default())
 
     # Per-agent weight overrides
     for agent in agents:
@@ -207,14 +193,14 @@ def _validate_config(req: DeployConfigRequest) -> dict[str, Any]:
     warnings: list[str] = []
 
     # Validate agent IDs
-    valid_ids = set(_AGENT_LABELS.keys())
+    valid_ids = set(_agent_labels())
     known_ids = {a.id for a in req.agents}
     unknown = known_ids - valid_ids
     if unknown:
         warnings.append(f"Unknown agent ids: {', '.join(sorted(unknown))}")
 
     # Check mandatory agents
-    mandatory = {"2.1", "2.3"}  # core TA agents
+    mandatory = {"pattern_recognition_bot", "technical_ta_engine"}  # core TA agents
     missing_mandatory = mandatory - known_ids
     if missing_mandatory:
         warnings.append(
@@ -260,7 +246,7 @@ async def deploy_config(req: DeployConfigRequest) -> dict[str, Any]:
         aid = agent.id
         agent_map[aid] = {
             "id": aid,
-            "label": agent.label or _AGENT_LABELS.get(aid, aid),
+            "label": agent.label or _agent_labels().get(aid, aid),
             "enabled": agent.enabled,
             "llm_enabled": agent.llm_enabled,
             "persona_path": agent.persona_path or f"operator/{aid}/persona.md",
@@ -386,9 +372,9 @@ async def deploy_config_schema() -> dict[str, Any]:
     Useful for the Config UI to generate the form dynamically.
     """
     return {
-        "agent_ids": list(_AGENT_LABELS.keys()),
-        "agent_labels": _AGENT_LABELS,
-        "default_weights": _AGENT_WEIGHTS_DEFAULT,
+        "agent_ids": list(_agent_labels().keys()),
+        "agent_labels": _agent_labels(),
+        "default_weights": _agent_weights_default(),
         "default_edges": _GRAPH_EDGES_DEFAULT,
         "arbitrator_modes": ["weighted_convergence", "agent_llm"],
         "valid_modes": ["weighted_convergence", "agent_llm"],

--- a/src/api/flow_stream_server.py
+++ b/src/api/flow_stream_server.py
@@ -23,6 +23,7 @@ from .auth_routes import router as auth_router
 from .backtest_routes import recover_stale_backtest_jobs
 from .backtest_routes import router as backtest_router
 from .capabilities_routes import router as capabilities_router
+from .config_designer_routes import router as config_designer_router
 from .copy_routes import router as copy_router
 from .deploy_routes import router as deploy_router
 from .engine_routes import router as engine_router
@@ -143,6 +144,7 @@ app.include_router(capabilities_router)
 app.include_router(ops_router)
 app.include_router(profile_router)
 app.include_router(deploy_router)
+app.include_router(config_designer_router)
 app.include_router(engine_router)
 
 

--- a/src/api/studio_routes.py
+++ b/src/api/studio_routes.py
@@ -774,7 +774,7 @@ async def post_studio_chat(request: Request, req: StudioChatRequest) -> dict[str
             status_code=503,
             detail={
                 "error": "llm_required",
-                "hint": "Set OPENAI_API_KEY (and ensure AI_MARKET_MAKER_USE_LLM is not forcing LLM off).",
+                "hint": "Set OPENAI_API_KEY or ATLASCLOUD_API_KEY, and enable use_llm_synthesis in deploy JSON.",
             },
         )
 

--- a/src/backtest/agentic_defaults.py
+++ b/src/backtest/agentic_defaults.py
@@ -8,9 +8,9 @@ from typing import Any
 # macro_tilt preset (run_agentic_sweep): TA-led desk + macro/pattern support.
 DEFAULT_AGENTIC_PROFILE_ID = "macro_tilt"
 DEFAULT_AGENTIC_PROFILE_WEIGHTS: dict[str, float] = {
-    "2.3": 0.55,
-    "2.1": 0.15,
-    "1.1": 0.25,
+    "technical_ta_engine": 0.55,
+    "pattern_recognition_bot": 0.15,
+    "monetary_sentinel": 0.25,
 }
 
 # Mirrors weighted_arbitrator._V4_DECISION_THRESHOLD / sweep _THR_BASE.
@@ -25,7 +25,7 @@ DEFAULT_AGENTIC_DECISION_THRESHOLD: dict[str, Any] = {
     },
     "ta_led": {
         "enabled": True,
-        "agent_id": "2.3",
+        "agent_id": "technical_ta_engine",
         "buy_min_composite": 57,
         "sell_max_composite": 43,
         "min_confidence": 14,

--- a/src/backtest/config.py
+++ b/src/backtest/config.py
@@ -1,4 +1,4 @@
-"""Backtest config: merge deploy JSON, env vars, and CLI overrides."""
+"""Backtest config: merge deploy JSON and CLI overrides."""
 
 from __future__ import annotations
 
@@ -74,12 +74,12 @@ def resolve_backtest_config(
     )
 
     result: dict[str, Any] = {
-        "arbitrator_mode": ARBITRATOR_AGENT_LLM,
+        "arbitrator_mode": ARBITRATOR_WEIGHTED_CONVERGENCE,
         "profile_weights": default_agentic_profile_weights(),
         "profile_id": DEFAULT_AGENTIC_PROFILE_ID,
         "decision_threshold": default_agentic_decision_threshold(),
         "allows_short": True,
-        "use_llm": True,
+        "use_llm": False,
         "take_profit_pct": 0.0,
         "stop_loss_pct": 0.0,
         "leverage": 2.0,
@@ -89,19 +89,11 @@ def resolve_backtest_config(
         "source_description": "defaults",
     }
 
-    env_arb_mode = (env.get("AIMM_ARBITRATOR_MODE") or "").strip().lower()
-    if env_arb_mode in VALID_ARBITRATOR_MODES:
-        result["arbitrator_mode"] = env_arb_mode
-
+    # Optional: which deploy file to load (path only — not strategy knobs).
+    # An explicit deploy_path argument wins over the env alias.
     env_deploy_path = (env.get("AIMM_DEPLOY_CONFIG_PATH") or "").strip()
-    if env_deploy_path:
+    if not deploy_path and env_deploy_path:
         deploy_path = env_deploy_path
-
-    use_llm_env = (env.get("AI_MARKET_MAKER_USE_LLM") or "").strip()
-    if use_llm_env in ("0", "false", "no", "off"):
-        logger.warning(
-            "AI_MARKET_MAKER_USE_LLM=0 is ignored; agentic backtests require LLM (agent_llm)."
-        )
 
     deploy_cfg: dict[str, Any] | None = None
     deploy_execution: Mapping[str, Any] | None = None
@@ -120,41 +112,59 @@ def resolve_backtest_config(
         result["deploy_path"] = str(deploy_file.resolve())
         result["deploy_loaded"] = True
 
-        deploy_arb_mode = (deploy_cfg.get("execution") or {}).get("arbitrator_mode")
-        if deploy_arb_mode in VALID_ARBITRATOR_MODES:
-            result["arbitrator_mode"] = deploy_arb_mode
+        exec_cfg = (
+            deploy_cfg.get("execution") if isinstance(deploy_cfg.get("execution"), dict) else {}
+        )
+        deploy_execution = exec_cfg
 
-        ew = deploy_cfg.get("effective_weights")
-        if isinstance(ew, dict):
-            result["profile_weights"] = dict(ew)
+        use_llm = exec_cfg.get("use_llm_synthesis")
+        if use_llm is None:
+            legacy = str(exec_cfg.get("arbitrator_mode") or "").strip().lower()
+            use_llm = legacy in ("agent_llm", "llm", "full_agentic")
+        if use_llm:
+            result["arbitrator_mode"] = ARBITRATOR_AGENT_LLM
+            result["use_llm"] = True
+        else:
+            result["arbitrator_mode"] = ARBITRATOR_WEIGHTED_CONVERGENCE
+            result["use_llm"] = False
+
+        agents = deploy_cfg.get("agents")
+        if isinstance(agents, dict) and agents:
+            weights: dict[str, float] = {}
+            for name, meta in agents.items():
+                if not isinstance(meta, dict) or meta.get("enabled", True) is False:
+                    continue
+                try:
+                    weights[str(name)] = float(meta.get("weight") or 0.0)
+                except (TypeError, ValueError):
+                    continue
+            if weights:
+                positive = {k: v for k, v in weights.items() if v > 0}
+                if positive:
+                    result["profile_weights"] = positive
 
         dt = deploy_cfg.get("decision_threshold")
         if isinstance(dt, dict) and dt:
             result["decision_threshold"] = dict(dt)
 
-        exec_allows = (deploy_cfg.get("execution") or {}).get("allows_short")
-        if exec_allows is not None:
-            result["allows_short"] = bool(exec_allows)
+        if exec_cfg.get("allows_short") is not None:
+            result["allows_short"] = bool(exec_cfg.get("allows_short"))
 
-        profile_id = (
-            deploy_cfg.get("profile", {}).get("profile_id")
-            if isinstance(deploy_cfg.get("profile"), dict)
-            else None
-        )
-        if profile_id:
-            result["profile_id"] = str(profile_id)
+        profile = deploy_cfg.get("profile")
+        if isinstance(profile, dict) and profile.get("profile_id"):
+            result["profile_id"] = str(profile["profile_id"])
 
-        exec_cfg = deploy_cfg.get("execution") or {}
-        deploy_execution = exec_cfg if isinstance(exec_cfg, dict) else {}
-        lev = deploy_execution.get("leverage") or result["leverage"]
-        mhb = deploy_execution.get("max_hold_bars") or result["max_hold_bars"]
+        lev = exec_cfg.get("leverage") or result["leverage"]
+        mhb = exec_cfg.get("max_hold_bars") or result["max_hold_bars"]
         result["leverage"] = float(lev) if lev else 2.0
         result["max_hold_bars"] = int(mhb) if mhb else 0
 
+    # CLI can still pick a deploy mode for a single experiment run
     if cli_arbitrator_mode is not None and cli_arbitrator_mode.strip():
         mode = cli_arbitrator_mode.strip().lower()
         if mode in VALID_ARBITRATOR_MODES:
             result["arbitrator_mode"] = mode
+            result["use_llm"] = mode == ARBITRATOR_AGENT_LLM
         else:
             logger.warning("unknown arbitrator mode %r, ignoring", mode)
 
@@ -170,14 +180,6 @@ def resolve_backtest_config(
 
     if cli_max_hold_bars is not None and cli_max_hold_bars > 0:
         result["max_hold_bars"] = int(cli_max_hold_bars)
-
-    result["use_llm"] = result["arbitrator_mode"] == ARBITRATOR_AGENT_LLM
-    if result["arbitrator_mode"] == ARBITRATOR_WEIGHTED_CONVERGENCE:
-        logger.warning(
-            "weighted_convergence is deprecated for product runs; defaulting to agent_llm."
-        )
-        result["arbitrator_mode"] = ARBITRATOR_AGENT_LLM
-        result["use_llm"] = True
 
     from backtest.symbol_routing import resolve_agent_led_symbols
 
@@ -199,15 +201,16 @@ def resolve_backtest_config(
 
 
 def set_env_from_config(cfg: dict[str, Any]) -> None:
-    """Apply resolved config to process environment."""
-    mode = str(cfg.get("arbitrator_mode") or ARBITRATOR_AGENT_LLM)
-    if mode == ARBITRATOR_WEIGHTED_CONVERGENCE:
-        mode = ARBITRATOR_AGENT_LLM
-    os.environ["AIMM_ARBITRATOR_MODE"] = mode
+    """Apply non-strategy process settings for a backtest run."""
+    os.environ.pop("AIMM_ARBITRATOR_MODE", None)
     os.environ.pop("AI_MARKET_MAKER_USE_LLM", None)
     os.environ.pop("AIMM_LLM_MODE", None)
-    # Enable file-backed agent decision cache (historical bars are deterministic).
+    os.environ.pop("AIMM_LLM_AGENTS", None)
+    os.environ.pop("AIMM_LLM_DESK_DEBATE", None)
     os.environ["MODE"] = "backtest"
+
+    if cfg.get("deploy_path"):
+        os.environ["AIMM_DEPLOY_CONFIG_PATH"] = str(cfg["deploy_path"])
 
     if os.environ.get("AIMM_BACKTEST_VERBOSE_RECEIPTS") is None:
         os.environ["AIMM_BACKTEST_VERBOSE_RECEIPTS"] = "1"

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -186,6 +186,11 @@ class BacktestEngine:
             else None,
             ta_warmup_bars=ta_warmup,
             eval_bars=eval_steps,
+            use_llm=bool(
+                c.get("use_llm")
+                or c.get("arbitrator_mode") == "agent_llm"
+                or c.get("deploy_arbitrator_mode") == "agent_llm"
+            ),
         )
 
         _pw = c.get("deploy_profile_weights")
@@ -194,7 +199,7 @@ class BacktestEngine:
                 str(k) for k, v in sorted(_pw.items(), key=lambda x: -float(x[1] or 0))
             ]
         else:
-            _active_agents = ["2.3", "2.1", "1.1"]
+            _active_agents = ["technical_ta_engine", "pattern_recognition_bot", "monetary_sentinel"]
 
         run_mem = RunWorkingMemory(cfg=run_memory_config(settings))
 
@@ -403,6 +408,10 @@ class BacktestEngine:
                 dt = deploy_cfg.get("decision_threshold")
                 if isinstance(dt, dict) and dt:
                     state["decision_threshold"] = dt
+                exec_cfg = deploy_cfg.get("execution")
+                if isinstance(exec_cfg, dict):
+                    if "arbitrator_llm" in exec_cfg:
+                        state["arbitrator_llm"] = bool(exec_cfg.get("arbitrator_llm"))
             state["universe"] = list(bars_by_symbol.keys())
             state["market_data"] = {
                 s: {

--- a/src/backtest/run_agentic_sweep.py
+++ b/src/backtest/run_agentic_sweep.py
@@ -65,7 +65,7 @@ _THR_BASE: dict[str, Any] = {
     },
     "ta_led": {
         "enabled": True,
-        "agent_id": "2.3",
+        "agent_id": "technical_ta_engine",
         "buy_min_composite": 57,
         "sell_max_composite": 43,
         "min_confidence": 14,
@@ -161,19 +161,31 @@ PRESETS: tuple[AgenticPreset, ...] = (
     AgenticPreset(
         id="ta_heavy_75",
         label="TA-heavy desk (2.3@0.75, ta_led 55/44)",
-        profile_weights={"2.3": 0.75, "2.1": 0.10, "1.1": 0.10},
+        profile_weights={
+            "technical_ta_engine": 0.75,
+            "pattern_recognition_bot": 0.10,
+            "monetary_sentinel": 0.10,
+        },
         decision_threshold=_thr(ta_led={"buy_min_composite": 55, "sell_max_composite": 44}),
     ),
     AgenticPreset(
         id="balanced_desk",
         label="Balanced TA + pattern (2.3@0.55, 2.1@0.25, global 54/18)",
-        profile_weights={"2.3": 0.55, "2.1": 0.25, "1.1": 0.15},
+        profile_weights={
+            "technical_ta_engine": 0.55,
+            "pattern_recognition_bot": 0.25,
+            "monetary_sentinel": 0.15,
+        },
         decision_threshold=_thr(buy={"min_composite": 54, "min_confidence": 18}),
     ),
     AgenticPreset(
         id="conservative_gate",
         label="Conservative gates (2.3@0.60, ta_led 59/41)",
-        profile_weights={"2.3": 0.60, "2.1": 0.20, "1.1": 0.15},
+        profile_weights={
+            "technical_ta_engine": 0.60,
+            "pattern_recognition_bot": 0.20,
+            "monetary_sentinel": 0.15,
+        },
         decision_threshold=_thr(ta_led={"buy_min_composite": 59, "sell_max_composite": 41}),
     ),
     AgenticPreset(
@@ -185,19 +197,31 @@ PRESETS: tuple[AgenticPreset, ...] = (
     AgenticPreset(
         id="pattern_assist",
         label="Pattern-assist blend (2.1@0.30, 2.3@0.50)",
-        profile_weights={"2.3": 0.50, "2.1": 0.30, "1.1": 0.15},
+        profile_weights={
+            "technical_ta_engine": 0.50,
+            "pattern_recognition_bot": 0.30,
+            "monetary_sentinel": 0.15,
+        },
         decision_threshold=None,
     ),
     AgenticPreset(
         id="macro_tilt",
         label="Macro tilt (1.1@0.25, 2.3@0.55)",
-        profile_weights={"2.3": 0.55, "2.1": 0.15, "1.1": 0.25},
+        profile_weights={
+            "technical_ta_engine": 0.55,
+            "pattern_recognition_bot": 0.15,
+            "monetary_sentinel": 0.25,
+        },
         decision_threshold=None,
     ),
     AgenticPreset(
         id="aggressive_ta",
         label="Aggressive TA (2.3@0.70, ta_led 54/44, buy 51)",
-        profile_weights={"2.3": 0.70, "2.1": 0.12, "1.1": 0.10},
+        profile_weights={
+            "technical_ta_engine": 0.70,
+            "pattern_recognition_bot": 0.12,
+            "monetary_sentinel": 0.10,
+        },
         decision_threshold=_thr(
             buy={"min_composite": 51, "min_confidence": 15},
             ta_led={"buy_min_composite": 54, "sell_max_composite": 44, "min_confidence": 12},
@@ -206,7 +230,11 @@ PRESETS: tuple[AgenticPreset, ...] = (
     AgenticPreset(
         id="strict_align",
         label="Strict alignment (min 3 factors, ta_led 58/42)",
-        profile_weights={"2.3": 0.65, "2.1": 0.15, "1.1": 0.10},
+        profile_weights={
+            "technical_ta_engine": 0.65,
+            "pattern_recognition_bot": 0.15,
+            "monetary_sentinel": 0.10,
+        },
         decision_threshold=_thr(
             alignment_gating={"enabled": True, "min_factors_for_directional": 3},
             ta_led={"buy_min_composite": 58, "sell_max_composite": 42},

--- a/src/backtest/run_demo.py
+++ b/src/backtest/run_demo.py
@@ -212,9 +212,8 @@ def build_run_demo_parser() -> argparse.ArgumentParser:
         default=None,
         choices=("agent_llm", "weighted_convergence"),
         help=(
-            "Arbitrator mode: ``agent_llm`` (per-agent LLM → weighted arbitrator), "
-            "``weighted_convergence`` (deterministic, no LLM). "
-            "Overrides deploy config if set."
+            "Arbitrator mode for this run only (experiment override). "
+            "Deploy JSON is the strategy source of truth; omit this to use execution.use_llm_synthesis."
         ),
     )
     parser.add_argument(
@@ -293,23 +292,6 @@ def resolve_run_demo_symbols(
         pool = list(s.market.universe_symbols)
         sym_list = [str(args.ticker)] + [x for x in pool if x != str(args.ticker)]
         sym_list = sym_list[:u_sz]
-    # Optional: drop stablecoin legs for clearer "risk assets" comparisons.
-    # Stable exclusion removed in frozen config mode (explicit universe list should be curated).
-    if False and sym_list:
-
-        def _is_stable(sym: str) -> bool:
-            s = (sym or "").upper()
-            return any(
-                x in s for x in ("USDC/USDT", "USD1/USDT", "FDUSD/USDT", "TUSD/USDT", "USDP/USDT")
-            )
-
-        before = list(sym_list)
-        sym_list = [s for s in sym_list if not _is_stable(s)]
-        # Keep at least the primary ticker.
-        if not sym_list:
-            sym_list = [str(args.ticker)]
-        if before != sym_list:
-            print(f"[universe] excluded stables → {sym_list}", file=sys.stderr)
     if sym_list:
         if len(sym_list) < 2:
             parser.error("--symbols requires at least two pairs (comma-separated)")

--- a/src/backtest/terminal_log.py
+++ b/src/backtest/terminal_log.py
@@ -13,17 +13,9 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, TextIO
 
-_AGENT_LABELS: dict[str, str] = {
-    "1.1": "Macro Sentinel",
-    "1.2": "News & Narrative",
-    "2.1": "Pattern Recognition",
-    "2.3": "Technical TA",
-    "2.2": "Statistical Alpha",
-    "3.1": "Retail Hype",
-    "3.2": "Pro Bias",
-    "4.1": "Whale Behavior",
-    "4.2": "Liquidity / Flow",
-}
+from agents.registry import get_registry
+
+_AGENT_LABELS: dict[str, str] = get_registry().labels()
 
 _CONFIGURED = False
 _API_WARNED = False
@@ -210,7 +202,7 @@ def _extract_agent_rows(
         if isinstance(pw, dict) and pw:
             active = [str(a) for a, w in pw.items() if float(w or 0) > 0]
     if not active:
-        active = ["2.3", "2.1", "1.1"]
+        active = ["technical_ta_engine", "pattern_recognition_bot", "monetary_sentinel"]
 
     by_id: dict[str, dict[str, Any]] = {}
 
@@ -304,16 +296,8 @@ def _extract_agent_rows(
     return sorted(by_id.values(), key=lambda r: order.get(str(r["agent_id"]), 99))
 
 
-def _should_print_bar(*, symbol: str, primary_symbol: str, action: str, confidence: float) -> bool:
-    if _terminal_all_symbols() or symbol == primary_symbol:
-        pass
-    else:
-        return False
-    if action in ("BUY", "SELL"):
-        return True
-    if confidence >= 0.12:
-        return True
-    return False
+def _should_print_bar(*, symbol: str, primary_symbol: str) -> bool:
+    return _terminal_all_symbols() or symbol == primary_symbol
 
 
 def print_run_header(
@@ -325,6 +309,7 @@ def print_run_header(
     profile_weights: dict[str, float] | None = None,
     ta_warmup_bars: int = 0,
     eval_bars: int | None = None,
+    use_llm: bool = False,
     stream: TextIO | None = None,
 ) -> None:
     if not backtest_terminal_log_enabled():
@@ -339,7 +324,8 @@ def print_run_header(
         parts = [
             f"{k}×{float(v):.2f}" for k, v in sorted(profile_weights.items(), key=lambda x: -x[1])
         ]
-        desks = f"\n desks:   {', '.join(parts)} (LLM CoT)"
+        llm_note = " (LLM CoT)" if use_llm else ""
+        desks = f"\n desks:   {', '.join(parts)}{llm_note}"
     ev = eval_bars if eval_bars is not None else max(0, total_bars - ta_warmup_bars)
     warmup_line = (
         f"\n warmup:  {ta_warmup_bars} bars (TA context only — no LLM, no trades)"
@@ -359,7 +345,7 @@ def print_run_header(
         f"{bars_line}"
         f"{warmup_line}"
         f"{desks}\n"
-        f" transcript: {sym_mode} │ BUY/SELL + high-confidence bars\n"
+        f" transcript: {sym_mode} │ every bar\n"
         f"{'█' * 72}",
         file=out,
         flush=True,
@@ -386,9 +372,7 @@ def print_bar_decision(
     if not backtest_terminal_log_enabled():
         return
     primary = primary_symbol or symbol
-    if not _should_print_bar(
-        symbol=symbol, primary_symbol=primary, action=action, confidence=confidence
-    ):
+    if not _should_print_bar(symbol=symbol, primary_symbol=primary):
         return
 
     out = stream or sys.stderr

--- a/src/config/agent_run_mode.py
+++ b/src/config/agent_run_mode.py
@@ -1,39 +1,29 @@
-"""Per-agent LLM toggle (weighted_convergence vs agent_llm)."""
+"""Agent LLM toggles — deploy JSON is the source of truth."""
 
 from __future__ import annotations
 
-import os
 from typing import Mapping
 
-# Global mode env
-_ENV_MODE = "AIMM_RUN_MODE"
 _AGENT_LLM_MODE = "agent_llm"
 _WEIGHTED_CONVERGENCE = "weighted_convergence"
 
-# Per-agent toggle env — comma-separated agent IDs
-# Example: AIMM_LLM_AGENTS=2.1,2.3,3.1
-_ENV_AGENTS = "AIMM_LLM_AGENTS"
-
-# When set to "ALL", every agent uses LLM path
-_ALL_SENTINEL = "ALL"
-
 
 def current_run_mode(env: Mapping[str, str] | None = None) -> str:
-    """Return the current execution mode string.
+    """Return ``agent_llm`` or ``weighted_convergence`` from deploy config."""
+    try:
+        from config.deploy_loader import get_use_llm_synthesis
 
-    Returns "weighted_convergence" or "agent_llm".
-    Default is "weighted_convergence" (zero LLM calls).
-    """
-    if env is None:
-        env = os.environ
-    raw = (env.get(_ENV_MODE) or "").strip().lower()
-    if raw in (_AGENT_LLM_MODE, "agentic", "llm"):
-        return _AGENT_LLM_MODE
+        use_llm = get_use_llm_synthesis()
+        if use_llm is True:
+            return _AGENT_LLM_MODE
+        if use_llm is False:
+            return _WEIGHTED_CONVERGENCE
+    except Exception:
+        pass
     return _WEIGHTED_CONVERGENCE
 
 
 def is_agent_llm_mode(env: Mapping[str, str] | None = None) -> bool:
-    """Return True if global mode is ``agent_llm``."""
     return current_run_mode(env) == _AGENT_LLM_MODE
 
 
@@ -43,21 +33,13 @@ def agent_llm_enabled(
     *,
     default: bool = False,
 ) -> bool:
-    """Return True if *agent_id* should use the LLM path.
+    """Whether *agent_id* may use the LLM path (from deploy ``agents.*.llm_enabled``)."""
+    try:
+        from config.deploy_loader import get_llm_enabled_agent_names
 
-    Priority:
-    1. ``AIMM_LLM_AGENTS`` env var: comma-separated IDs or ``ALL``.
-    2. ``default`` parameter (used when nothing is configured).
-
-    In agent_llm mode, a failed LLM call yields an error contract (source: error),
-    not the deterministic Tier-0 output.
-    """
-    if env is None:
-        env = os.environ
-    raw = (env.get(_ENV_AGENTS) or "").strip()
-    if not raw:
-        return default
-    if raw == _ALL_SENTINEL:
-        return True
-    agents = [a.strip() for a in raw.split(",") if a.strip()]
-    return agent_id in agents
+        names = get_llm_enabled_agent_names()
+        if names is not None:
+            return agent_id in names
+    except Exception:
+        pass
+    return default

--- a/src/config/deploy_loader.py
+++ b/src/config/deploy_loader.py
@@ -1,19 +1,4 @@
-"""Deploy config loader — runtime integration for deployed configurations.
-
-Reads ``config/deploy.active.json`` (written by the ``POST /deploy-config``
-endpoint) and provides a clean interface for the rest of the system to
-access deployed policy, execution settings, agent topology, and profile
-weights.
-
-Usage::
-
-    from config.deploy_loader import load_deploy_config
-
-    cfg = load_deploy_config()
-    if cfg is not None:
-        weights = cfg.get("effective_weights", {})
-        mode = cfg.get("execution", {}).get("arbitrator_mode", "weighted_convergence")
-"""
+"""Load active deploy config from config/deploy.active.json."""
 
 from __future__ import annotations
 
@@ -34,91 +19,183 @@ def _deploy_path() -> Path:
 
 
 def load_deploy_config() -> dict[str, Any] | None:
-    """Load the active deployed configuration from disk.
-
-    Returns the parsed config dict, or ``None`` if no deploy config exists
-    or it cannot be parsed.
-    """
     path = _deploy_path()
     if not path.is_file():
         return None
     try:
-        raw = path.read_text(encoding="utf-8")
-        obj = json.loads(raw)
-        if not isinstance(obj, dict):
-            logger.warning("deploy config at %s is not a dict, ignoring", path)
-            return None
-        return obj
+        obj = json.loads(path.read_text(encoding="utf-8"))
+        return obj if isinstance(obj, dict) else None
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("failed to read deploy config at %s: %s", path, e)
         return None
 
 
-def get_effective_weights() -> dict[str, float] | None:
-    """Get effective agent weights from the active deploy config.
-
-    Returns ``None`` if no deploy config is active.
-    """
-    cfg = load_deploy_config()
-    if cfg is None:
-        return None
-    ew = cfg.get("effective_weights")
-    if not isinstance(ew, dict):
-        return None
-    return dict(ew)
-
-
-def get_arbitrator_mode() -> str | None:
-    """Get the arbitrator mode from the active deploy config.
-
-    Returns ``"weighted_convergence"``, ``"agent_llm"``, or ``None`` if
-    no deploy config is active.
-    """
-    cfg = load_deploy_config()
-    if cfg is None:
-        return None
-    return cfg.get("execution", {}).get("arbitrator_mode")
-
-
-def get_deploy_policy() -> dict[str, Any] | None:
-    """Get policy overrides from the active deploy config.
-
-    Returns a dict of policy keys to merge into the base FundPolicy,
-    or ``None`` if no deploy config is active.
-    """
-    cfg = load_deploy_config()
-    if cfg is None:
-        return None
-    return cfg.get("policy")
-
-
 def get_deploy_agents() -> dict[str, dict[str, Any]] | None:
-    """Get the agent topology from the active deploy config.
-
-    Returns a map of agent_id -> agent_config, or ``None``.
-    """
     cfg = load_deploy_config()
     if cfg is None:
         return None
     agents = cfg.get("agents")
-    if not isinstance(agents, dict):
+    if not isinstance(agents, dict) or not agents:
         return None
-    return dict(agents)
+    from agents.registry import get_registry
+
+    known = set(get_registry().names())
+    out: dict[str, dict[str, Any]] = {}
+    for key, meta in agents.items():
+        name = str(key).strip()
+        if name not in known:
+            logger.warning("deploy agents: unknown key %r ignored", name)
+            continue
+        out[name] = dict(meta) if isinstance(meta, dict) else {}
+    return out or None
+
+
+def get_effective_weights() -> dict[str, float] | None:
+    """Weights keyed by agent name."""
+    agents = get_deploy_agents()
+    if agents:
+        weights: dict[str, float] = {}
+        for name, meta in agents.items():
+            if meta.get("enabled", True) is False:
+                continue
+            w = meta.get("weight")
+            if w is None:
+                continue
+            try:
+                weights[name] = float(w)
+            except (TypeError, ValueError):
+                continue
+        return weights or None
+    return None
+
+
+def get_enabled_agent_names() -> list[str] | None:
+    """Enabled desks from deploy JSON. ``None`` means no agents block (use registry)."""
+    agents = get_deploy_agents()
+    if agents is None:
+        return None
+    return [name for name, meta in agents.items() if meta.get("enabled", True) is not False]
+
+
+def resolve_tier0_graph_nodes() -> list[str]:
+    """LangGraph perception nodes: enabled deploy desks, else the full registry."""
+    from agents.registry import get_registry
+
+    known = get_registry().names()
+    enabled = get_enabled_agent_names()
+    if enabled is None:
+        return known
+    ordered = [n for n in known if n in enabled]
+    if not ordered:
+        logger.warning("deploy JSON has no enabled agents; using full registry")
+        return known
+    return ordered
+
+
+def get_llm_enabled_agent_names() -> list[str] | None:
+    agents = get_deploy_agents()
+    if agents is None:
+        return None
+    return [
+        name
+        for name, meta in agents.items()
+        if meta.get("llm_enabled") and meta.get("enabled", True) is not False
+    ]
+
+
+def get_use_llm_synthesis() -> bool | None:
+    cfg = load_deploy_config()
+    if cfg is None:
+        return None
+    execution = cfg.get("execution") if isinstance(cfg.get("execution"), dict) else {}
+    if "use_llm_synthesis" in execution:
+        return bool(execution.get("use_llm_synthesis"))
+    mode = str(execution.get("arbitrator_mode") or "").strip().lower()
+    if mode in ("agent_llm", "llm", "full_agentic"):
+        return True
+    if mode in ("weighted_convergence", "weighted", "measurement", "none"):
+        return False
+    return None
+
+
+def get_desk_debate_llm() -> bool | None:
+    cfg = load_deploy_config()
+    if cfg is None:
+        return None
+    execution = cfg.get("execution") if isinstance(cfg.get("execution"), dict) else {}
+    if "desk_debate_llm" in execution:
+        return bool(execution.get("desk_debate_llm"))
+    if "desk_debate_enabled" in execution:
+        return bool(execution.get("desk_debate_enabled"))
+    return None
+
+
+def _execution_flag(name: str) -> bool | None:
+    cfg = load_deploy_config()
+    if cfg is None:
+        return None
+    execution = cfg.get("execution") if isinstance(cfg.get("execution"), dict) else {}
+    if name not in execution:
+        return None
+    return bool(execution.get(name))
+
+
+def get_arbitrator_llm() -> bool:
+    """LLM overlay on the weighted decision. Default off."""
+    return bool(_execution_flag("arbitrator_llm"))
+
+
+def get_arbitrator_mode() -> str | None:
+    """How desks feed the weighted formula — not a per-bar reweight.
+
+    Weights stay as configured in deploy JSON. ``agent_llm`` only means
+    ``llm_enabled`` desks may call the model before the same weighted math.
+    """
+    use_llm = get_use_llm_synthesis()
+    if use_llm is True:
+        return "agent_llm"
+    if use_llm is False:
+        return "weighted_convergence"
+    cfg = load_deploy_config()
+    if cfg is None:
+        return None
+    execution = cfg.get("execution") if isinstance(cfg.get("execution"), dict) else {}
+    mode = execution.get("arbitrator_mode")
+    return str(mode) if mode else None
+
+
+def get_deploy_policy() -> dict[str, Any] | None:
+    cfg = load_deploy_config()
+    return None if cfg is None else cfg.get("policy")
 
 
 def get_deploy_profile_id() -> str | None:
-    """Get the profile_id referenced in the active deploy config."""
     cfg = load_deploy_config()
     if cfg is None:
         return None
     return cfg.get("profile", {}).get("profile_id")
 
 
+def get_decision_threshold() -> dict[str, Any] | None:
+    cfg = load_deploy_config()
+    if cfg is None:
+        return None
+    thr = cfg.get("decision_threshold")
+    return dict(thr) if isinstance(thr, dict) else None
+
+
 __all__ = [
     "load_deploy_config",
     "get_effective_weights",
     "get_arbitrator_mode",
+    "get_use_llm_synthesis",
+    "get_desk_debate_llm",
+    "get_llm_enabled_agent_names",
     "get_deploy_policy",
     "get_deploy_agents",
+    "get_enabled_agent_names",
+    "resolve_tier0_graph_nodes",
     "get_deploy_profile_id",
+    "get_decision_threshold",
+    "get_arbitrator_llm",
 ]

--- a/src/config/llm_env.py
+++ b/src/config/llm_env.py
@@ -82,17 +82,7 @@ def llm_key_available(env: Mapping[str, str] | None = None) -> bool:
 
 
 def use_llm_arbitrator(env: Mapping[str, str] | None = None) -> bool:
-    """Return True when an LLM provider key is configured.
-
-    Legacy ``AI_MARKET_MAKER_USE_LLM=0`` forces False.
-    """
-    if env is None:
-        env = os.environ
-
-    old_flag = (env.get("AI_MARKET_MAKER_USE_LLM") or "").strip().lower()
-    if old_flag in ("0", "false", "no", "off"):
-        return False
-
+    """Return True when an LLM provider key is configured."""
     return bool(_read_key(env))
 
 

--- a/src/llm/agent_llm_client.py
+++ b/src/llm/agent_llm_client.py
@@ -16,6 +16,7 @@ from typing import Any
 from openai import OpenAI
 
 from config.llm_env import resolve_llm_config
+from llm.json_parse import parse_json_object
 
 # Lazy-loaded decision cache
 _DECISION_CACHE: Any = None
@@ -42,46 +43,54 @@ def _get_decision_cache() -> Any:
     return _DECISION_CACHE
 
 
-def _cache_key_for_agent(
-    agent_id: str,
-    ticker: str | None,
-    prompt_text: str,
-) -> str | None:
-    """Generate a deterministic cache key for this agent call.
+def _date_tag_from_state(state: dict[str, Any]) -> str:
+    sm = state.get("shared_memory") if isinstance(state.get("shared_memory"), dict) else {}
+    bt = sm.get("backtest") if isinstance(sm.get("backtest"), dict) else {}
+    ts = bt.get("window_last_ts_ms")
+    if ts is None:
+        ts = state.get("ts_ms")
+    try:
+        return str(int(float(ts)))
+    except (TypeError, ValueError):
+        return "na"
 
-    Returns None if caching is disabled.
-    """
-    cache = _get_decision_cache()
-    enabled_fn = cache.get("enabled")
-    if enabled_fn and not enabled_fn():
-        return None
-    raw = f"{agent_id}|{ticker or ''}|{prompt_text}"
-    return hashlib.sha256(raw.encode()).hexdigest()
+
+def _prompt_hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
 
 
 logger = logging.getLogger(__name__)
 
 
 _AGENT_INFO: dict[str, dict[str, str]] = {
-    "1.1": {"name": "Monetary Sentinel", "dir": "1.1_monetary_sentinel"},
-    "1.2": {"name": "News & Narrative Miner", "dir": "1.2_news_narrative_miner"},
-    "2.1": {"name": "Pattern Recognition Bot", "dir": "2.1_pattern_recognition_bot"},
-    "2.2": {"name": "Statistical Alpha Engine", "dir": "2.2_statistical_alpha_engine"},
-    "2.3": {"name": "Technical TA Engine", "dir": "2.3_technical_ta_engine"},
-    "3.1": {"name": "Retail Hype Tracker", "dir": "3.1_retail_hype_tracker"},
-    "3.2": {"name": "Pro Bias Analyst", "dir": "3.2_pro_bias_analyst"},
-    "4.1": {"name": "Whale Behavior Analyst", "dir": "4.1_whale_behavior_analyst"},
-    "4.2": {"name": "Liquidity & Order Flow", "dir": "4.2_liquidity_order_flow"},
+    "monetary_sentinel": {"name": "Monetary Sentinel", "dir": "1.1_monetary_sentinel"},
+    "news_narrative_miner": {"name": "News & Narrative Miner", "dir": "1.2_news_narrative_miner"},
+    "pattern_recognition_bot": {
+        "name": "Pattern Recognition Bot",
+        "dir": "2.1_pattern_recognition_bot",
+    },
+    "statistical_alpha_engine": {
+        "name": "Statistical Alpha Engine",
+        "dir": "2.2_statistical_alpha_engine",
+    },
+    "technical_ta_engine": {"name": "Technical TA Engine", "dir": "2.3_technical_ta_engine"},
+    "retail_hype_tracker": {"name": "Retail Hype Tracker", "dir": "3.1_retail_hype_tracker"},
+    "pro_bias_analyst": {"name": "Pro Bias Analyst", "dir": "3.2_pro_bias_analyst"},
+    "whale_behavior_analyst": {
+        "name": "Whale Behavior Analyst",
+        "dir": "4.1_whale_behavior_analyst",
+    },
+    "liquidity_order_flow": {"name": "Liquidity & Order Flow", "dir": "4.2_liquidity_order_flow"},
 }
 
 # Per-agent PascalCase schema (weight_assigner extractors read these fields).
 # Nested keys are documented inline; underscores denote nesting.
 _AGENT_OUTPUT_SCHEMA: dict[str, list[str]] = {
-    "1.1": ["macro_regime_state", "Liquidity_Score"],
-    "1.2": ["News_Impact_Score", "Event_Type"],
-    "2.1": ["Setup_Score", "pattern"],
-    "2.2": ["cross_sectional_z_score", "kalman_support", "alpha_signal"],
-    "2.3": [
+    "monetary_sentinel": ["macro_regime_state", "Liquidity_Score"],
+    "news_narrative_miner": ["News_Impact_Score", "Event_Type"],
+    "pattern_recognition_bot": ["Setup_Score", "pattern"],
+    "statistical_alpha_engine": ["cross_sectional_z_score", "kalman_support", "alpha_signal"],
+    "technical_ta_engine": [
         "ta_indicators.rsi",
         "ta_indicators.macd_hist",
         "ta_indicators.obv",
@@ -92,19 +101,23 @@ _AGENT_OUTPUT_SCHEMA: dict[str, list[str]] = {
         "ta_indicators.volume",
         "ta_indicators.pattern_rec",
     ],
-    "3.1": ["FOMO_Level", "Divergence_Warning"],
-    "3.2": ["Pro_Bias", "ETF_Trend"],
-    "4.1": ["Dump_Probability", "Sell_Pressure_Gauge"],
-    "4.2": ["Slippage_Risk_Score", "Order_Imbalance"],
+    "retail_hype_tracker": ["FOMO_Level", "Divergence_Warning"],
+    "pro_bias_analyst": ["Pro_Bias", "ETF_Trend"],
+    "whale_behavior_analyst": ["Dump_Probability", "Sell_Pressure_Gauge"],
+    "liquidity_order_flow": ["Slippage_Risk_Score", "Order_Imbalance"],
 }
 
 # Neutral defaults for every field — returned when LLM fails or omits a field.
 _NEUTRAL_CONTRACT: dict[str, dict[str, Any]] = {
-    "1.1": {"macro_regime_state": "neutral", "Liquidity_Score": 50},
-    "1.2": {"News_Impact_Score": 50, "Event_Type": "neutral"},
-    "2.1": {"Setup_Score": 50, "pattern": "none"},
-    "2.2": {"cross_sectional_z_score": 0.0, "kalman_support": 50, "alpha_signal": 0.0},
-    "2.3": {
+    "monetary_sentinel": {"macro_regime_state": "neutral", "Liquidity_Score": 50},
+    "news_narrative_miner": {"News_Impact_Score": 50, "Event_Type": "neutral"},
+    "pattern_recognition_bot": {"Setup_Score": 50, "pattern": "none"},
+    "statistical_alpha_engine": {
+        "cross_sectional_z_score": 0.0,
+        "kalman_support": 50,
+        "alpha_signal": 0.0,
+    },
+    "technical_ta_engine": {
         "ta_indicators": {
             "rsi": 50,
             "macd_hist": 0.0,
@@ -116,10 +129,10 @@ _NEUTRAL_CONTRACT: dict[str, dict[str, Any]] = {
             "pattern_rec": "none",
         }
     },
-    "3.1": {"FOMO_Level": 50, "Divergence_Warning": 50},
-    "3.2": {"Pro_Bias": 50, "ETF_Trend": 50},
-    "4.1": {"Dump_Probability": 50, "Sell_Pressure_Gauge": 50},
-    "4.2": {"Slippage_Risk_Score": 50, "Order_Imbalance": 0.0},
+    "retail_hype_tracker": {"FOMO_Level": 50, "Divergence_Warning": 50},
+    "pro_bias_analyst": {"Pro_Bias": 50, "ETF_Trend": 50},
+    "whale_behavior_analyst": {"Dump_Probability": 50, "Sell_Pressure_Gauge": 50},
+    "liquidity_order_flow": {"Slippage_Risk_Score": 50, "Order_Imbalance": 0.0},
 }
 
 _AGENTS_BASE = Path(__file__).resolve().parent.parent / "agents" / "operator"
@@ -141,8 +154,8 @@ def _init_llm() -> None:
 
     llm_config = resolve_llm_config(
         key_names=("DEEPSEEK_API_KEY", "OPENAI_API_KEY", "LLM_API_KEY"),
-        base_url_names=("AIMM_LLM_BASE_URL",),
-        model_names=("AIMM_LLM_MODEL",),
+        base_url_names=("AIMM_LLM_BASE_URL", "OPENAI_BASE_URL"),
+        model_names=("AIMM_LLM_MODEL", "OPENAI_MODEL"),
         default_base_url="https://api.deepseek.com/v1",
         default_model="deepseek-chat",
     )
@@ -404,13 +417,12 @@ def _build_agent_prompt(
         "### Critical Rules:\n"
         "- The deterministic analysis is **context only**. Do NOT copy it verbatim.\n"
         "- You must reason from the raw market data and produce your OWN assessment.\n"
-        "- Output ONLY valid JSON with these exact fields:\n"
-        "```json\n"
+        "- Reply with a single JSON object only. No markdown fences, no preamble, "
+        "no <think> blocks.\n"
+        "- Required fields (use these types; fill every key):\n"
         f"{schema_json}\n"
-        "```\n"
         "- Every field is required. If you have no strong opinion, use the neutral default shown above.\n"
-        '- Add a "reasoning" field (string) explaining your key signal adjustments.\n'
-        "Output ONLY the JSON on a single line or pretty-printed. No preamble, no markdown fences.\n"
+        '- Add a "reasoning" field (string, <= 400 chars) explaining your key signal adjustments.\n'
     )
 
     user = f"## Current Market Data\n{market_context}\n\nProduce your structured signal now."
@@ -420,24 +432,8 @@ def _build_agent_prompt(
 
 def _parse_llm_json(text: str | None) -> dict[str, Any]:
     """Robust JSON extraction from LLM output."""
-    if not text or not text.strip():
-        return {}
-    raw = text.strip()
-    if raw.startswith("```"):
-        idx = raw.find("\n")
-        if idx != -1:
-            raw = raw[idx:].strip()
-        if raw.endswith("```"):
-            raw = raw[:-3].strip()
-    start = raw.find("{")
-    end = raw.rfind("}")
-    if start != -1 and end != -1 and end > start:
-        raw = raw[start : end + 1]
-    try:
-        obj = json.loads(raw)
-        return obj if isinstance(obj, dict) else {}
-    except json.JSONDecodeError:
-        return {}
+    parsed = parse_json_object(text or "")
+    return parsed if parsed is not None else {}
 
 
 def _fill_missing_fields(output: dict[str, Any], agent_id: str) -> dict[str, Any]:
@@ -500,6 +496,126 @@ def _error_contract(agent_id: str, error_reason: str) -> dict[str, Any]:
     return contract
 
 
+def _chat_create(
+    client: OpenAI,
+    *,
+    model_name: str,
+    messages: list[dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+) -> Any:
+    kwargs: dict[str, Any] = {
+        "model": model_name,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "timeout": 45,
+        "extra_body": {"thinking": {"type": "disabled"}},
+    }
+    try:
+        return client.chat.completions.create(**kwargs)
+    except Exception as exc:
+        msg = str(exc).lower()
+        unknown = "unknown" in msg or "unexpected" in msg or "not supported" in msg
+        if unknown and ("thinking" in msg or "extra_body" in msg):
+            kwargs.pop("extra_body", None)
+            return client.chat.completions.create(**kwargs)
+        raise
+
+
+def _message_content(resp: Any) -> str:
+    try:
+        return resp.choices[0].message.content or ""
+    except (AttributeError, IndexError, TypeError):
+        return ""
+
+
+def complete_json(
+    *,
+    cache_id: str,
+    system: str,
+    user: str,
+    state: dict[str, Any],
+    ticker: str | None = None,
+    model: str | None = None,
+    temperature: float = 0.1,
+    max_tokens: int = 1024,
+) -> dict[str, Any]:
+    """Cached JSON completion with thinking disabled. Empty dict on failure."""
+    try:
+        client = _get_client()
+    except ValueError as e:
+        logger.warning("agent_llm: no API key for %s: %s", cache_id, e)
+        return {}
+
+    cache = _get_decision_cache()
+    ticker_s = str(ticker or state.get("ticker") or "")
+    prompt_hash = _prompt_hash(system + "\n" + user)
+    date_tag = _date_tag_from_state(state)
+    read_fn = cache.get("read")
+    if read_fn:
+        hit = read_fn(cache_id, ticker_s, date_tag, prompt_hash)
+        if isinstance(hit, dict) and hit:
+            logger.info("agent_llm: cache HIT for %s date=%s", cache_id, date_tag)
+            out = dict(hit)
+            out["cached"] = True
+            return out
+
+    model_name = model or get_default_model()
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    try:
+        resp = _chat_create(
+            client,
+            model_name=model_name,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+    except Exception as e:
+        logger.warning("agent_llm: LLM call failed for %s: %s", cache_id, e)
+        return {}
+
+    text = _message_content(resp)
+    obj = _parse_llm_json(text)
+    if not obj:
+        logger.warning(
+            "agent_llm: unparseable output for %s, retrying once snippet=%r",
+            cache_id,
+            text[:240],
+        )
+        retry_msgs = [
+            {"role": "system", "content": system + "\nReturn ONLY a JSON object. No markdown."},
+            {"role": "user", "content": user},
+        ]
+        try:
+            resp = _chat_create(
+                client,
+                model_name=model_name,
+                messages=retry_msgs,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            text = _message_content(resp)
+            obj = _parse_llm_json(text)
+        except Exception as e:
+            logger.warning("agent_llm: retry failed for %s: %s", cache_id, e)
+            obj = {}
+    if not obj:
+        logger.warning("agent_llm: unparseable output for %s after retry", cache_id)
+        return {}
+
+    write_fn = cache.get("write")
+    if write_fn:
+        try:
+            write_fn(cache_id, ticker_s, date_tag, prompt_hash, obj)
+        except Exception as e:
+            logger.debug("agent_llm: cache write failed: %s", e)
+    return obj
+
+
 def infer_agent(
     agent_id: str,
     state: dict[str, Any],
@@ -508,29 +624,15 @@ def infer_agent(
     ticker: str | None = None,
     model: str | None = None,
     temperature: float = 0.1,
-    max_tokens: int = 1024,
+    max_tokens: int = 2048,
 ) -> dict[str, Any]:
     """Run a single agent's LLM inference.
 
     **No fallback to deterministic.** If the LLM call fails, an error
     contract with neutral values is returned (source: error).
-
-    Args:
-        agent_id: Agent identifier (e.g., ``"2.3"``).
-        state: Full HedgeFundState dict.
-        deterministic_contract: Tier-0 deterministic findings —
-            used ONLY as context in the prompt. NOT a fallback output.
-        ticker: Override primary ticker (default from state).
-        model: Model override (default from ``AIMM_LLM_MODEL`` env).
-        temperature: LLM temperature.
-        max_tokens: Max output tokens.
-
-    Returns:
-        Dict with the agent's PascalCase fields + metadata.
-        ``source`` is ``"agent_llm"`` on success, ``"error"`` on failure.
     """
     try:
-        client = _get_client()
+        _get_client()
     except ValueError as e:
         raise ValueError(
             f"agent_llm mode requires an LLM API key for agent {agent_id}. "
@@ -545,63 +647,102 @@ def infer_agent(
         deterministic_contract=deterministic_contract,
         agent_id=agent_id,
     )
-
     system, user = _build_agent_prompt(agent_id, persona, skill, market_context)
-
-    # Decision cache: check before LLM call
-    cache = _get_decision_cache()
-    full_prompt = system + "\n" + user
-    ck = _cache_key_for_agent(agent_id, ticker or state.get("ticker", ""), full_prompt)
-    if ck:
-        cached = cache.get("read")
-        if cached:
-            hit = cached(agent_id, ck)
-            if hit is not None:
-                logger.info("agent_llm: cache HIT for %s (key=%s...)", agent_id, ck[:12])
-                hit["agent"] = agent_id
-                hit["agent_id"] = agent_id
-                hit["source"] = "agent_llm"
-                hit["llm_enabled"] = True
-                hit["cached"] = True
-                return _fill_missing_fields(hit, agent_id)
-
-    try:
-        resp = client.chat.completions.create(
-            model=model or get_default_model(),
-            messages=[
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
-            ],
-            temperature=temperature,
-            max_tokens=max_tokens,
-            timeout=45,
-        )
-    except Exception as e:
-        logger.warning("agent_llm: LLM call failed for %s: %s", agent_id, e)
-        return _error_contract(agent_id, f"API error: {e}")
-
-    text = resp.choices[0].message.content or ""
-    obj = _parse_llm_json(text)
+    obj = complete_json(
+        cache_id=agent_id,
+        system=system,
+        user=user,
+        state=state,
+        ticker=ticker,
+        model=model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
     if not obj:
-        logger.warning("agent_llm: unparseable output for %s", agent_id)
         return _error_contract(agent_id, "unparseable LLM response")
 
+    cached = bool(obj.pop("cached", False))
     result = _fill_missing_fields(obj, agent_id)
     result["agent"] = agent_id
     result["agent_id"] = agent_id
     result["label"] = _AGENT_INFO.get(agent_id, {}).get("name", agent_id)
     result["source"] = "agent_llm"
     result["llm_enabled"] = True
-
-    # Write to cache for reproducibility
-    write_fn = cache.get("write")
-    if ck and write_fn:
-        try:
-            write_fn(agent_id, ck, result)
-        except Exception as e:
-            logger.debug("agent_llm: cache write failed: %s", e)
-
+    result["cached"] = cached
     return result
+
+
+def infer_arbitrator_decision(
+    math_brief: dict[str, Any],
+    state: dict[str, Any],
+    *,
+    ticker: str | None = None,
+) -> dict[str, Any]:
+    """LLM overlay on the weighted math decision. Empty/invalid → source error."""
+    system = (
+        "You are the signal arbitrator for an agentic crypto hedge fund.\n"
+        "Deterministic math already produced a composite, confidence, and gate result.\n"
+        "You may confirm or override the trade decision.\n"
+        'Return ONLY JSON: {"action": "BUY"|"SELL"|"HOLD", '
+        '"stance": "bullish"|"bearish"|"neutral", '
+        '"confidence": number 0-1, "reasons": [string, ...]}.'
+    )
+    user = json.dumps(
+        {
+            "ticker": ticker or state.get("ticker"),
+            "math": math_brief,
+            "desk_scores": _desk_score_brief(state),
+        },
+        default=str,
+    )
+    obj = complete_json(
+        cache_id="signal_arbitrator",
+        system=system,
+        user=user,
+        state=state,
+        ticker=ticker,
+        max_tokens=512,
+    )
+    action = str(obj.get("action") or "").upper()
+    stance = str(obj.get("stance") or "").lower()
+    if action not in ("BUY", "SELL", "HOLD"):
+        return {"source": "error"}
+    if stance not in ("bullish", "bearish", "neutral"):
+        stance = {"BUY": "bullish", "SELL": "bearish"}.get(action, "neutral")
+    try:
+        conf = max(0.0, min(0.95, float(obj.get("confidence"))))
+    except (TypeError, ValueError):
+        conf = 0.5
+    reasons = obj.get("reasons")
+    if not isinstance(reasons, list):
+        reasons = []
+    return {
+        "source": "agent_llm",
+        "action": action,
+        "stance": stance,
+        "confidence": round(conf, 4),
+        "reasons": [str(r) for r in reasons][:8],
+        "cached": bool(obj.get("cached")),
+    }
+
+
+def _desk_score_brief(state: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for c in state.get("tier0_contracts") or []:
+        if not isinstance(c, dict):
+            continue
+        aid = str(c.get("agent_id") or c.get("agent") or "")
+        if not aid:
+            continue
+        rows.append(
+            {
+                "agent": aid,
+                "composite": c.get("composite"),
+                "stance": c.get("stance"),
+                "confidence": c.get("confidence"),
+            }
+        )
+    return rows[:12]
 
 
 def check_api_key() -> str | None:
@@ -617,7 +758,9 @@ def check_api_key() -> str | None:
 
 
 __all__ = [
-    "infer_agent",
     "check_api_key",
+    "complete_json",
     "get_default_model",
+    "infer_agent",
+    "infer_arbitrator_decision",
 ]

--- a/src/llm/json_parse.py
+++ b/src/llm/json_parse.py
@@ -11,7 +11,18 @@ We keep parsing logic centralized so all nodes behave consistently.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
+
+_THINK_RE = re.compile(
+    r"<(think|thinking|reasoning)>.*?</\1>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _strip_reasoning_wrappers(text: str) -> str:
+    """Drop chain-of-thought wrappers that reasoning models prepend to JSON."""
+    return _THINK_RE.sub("", text or "").strip()
 
 
 def parse_json_object(text: str) -> dict[str, Any] | None:
@@ -20,7 +31,7 @@ def parse_json_object(text: str) -> dict[str, Any] | None:
     Returns a dict if a JSON object can be parsed, else None.
     """
 
-    raw = (text or "").strip()
+    raw = _strip_reasoning_wrappers(text)
     if not raw:
         return None
 

--- a/src/llm/openai_client.py
+++ b/src/llm/openai_client.py
@@ -41,9 +41,7 @@ def run_tool_calling_chat(
     """
     llm_config = resolve_llm_config()
     if not llm_config.api_key:
-        raise ValueError(
-            "OPENAI_API_KEY or ATLASCLOUD_API_KEY is required when AI_MARKET_MAKER_USE_LLM=1"
-        )
+        raise ValueError("OPENAI_API_KEY or ATLASCLOUD_API_KEY is required for LLM calls")
 
     api_key = llm_config.api_key
     base_url = llm_config.base_url
@@ -209,9 +207,7 @@ def stream_chat_completion(
     """
     llm_config = resolve_llm_config()
     if not llm_config.api_key:
-        raise ValueError(
-            "OPENAI_API_KEY or ATLASCLOUD_API_KEY is required when AI_MARKET_MAKER_USE_LLM=1"
-        )
+        raise ValueError("OPENAI_API_KEY or ATLASCLOUD_API_KEY is required for LLM calls")
 
     api_key = llm_config.api_key
     base_url = llm_config.base_url

--- a/src/main.py
+++ b/src/main.py
@@ -1398,45 +1398,46 @@ def validate_ticker(ticker: str) -> bool:
         return False
 
 
-def build_workflow() -> StateGraph:
-    """Compile LangGraph: serial perception → proposal → risk → conditional execution.
+_TIER0_NODE_FNS: dict[str, Any] = {}
 
-    Node IDs are prefixed with ``desk_`` where needed so they do not collide with
-    :class:`HedgeFundState` keys (LangGraph requirement).
-    """
+
+def _tier0_node_fns() -> dict[str, Any]:
+    if not _TIER0_NODE_FNS:
+        _TIER0_NODE_FNS.update(
+            {
+                "monetary_sentinel": monetary_sentinel,
+                "news_narrative_miner": news_narrative_miner,
+                "pattern_recognition_bot": pattern_recognition_bot,
+                "statistical_alpha_engine": statistical_alpha_engine,
+                "technical_ta_engine": technical_ta_engine,
+                "retail_hype_tracker": retail_hype_tracker,
+                "pro_bias_analyst": pro_bias_analyst,
+                "whale_behavior_analyst": whale_behavior_analyst,
+                "liquidity_order_flow": liquidity_order_flow,
+            }
+        )
+    return _TIER0_NODE_FNS
+
+
+def build_workflow(*, tier0_nodes: list[str] | None = None) -> StateGraph:
+    """Perception desks come from deploy JSON ``agents.*.enabled`` (registry order)."""
+    from config.deploy_loader import resolve_tier0_graph_nodes
+
+    perception = _tier0_node_fns()
+    nodes = list(tier0_nodes) if tier0_nodes is not None else resolve_tier0_graph_nodes()
+    unknown = [n for n in nodes if n not in perception]
+    if unknown:
+        raise ValueError(f"unknown tier0 nodes: {unknown}")
+    if not nodes:
+        nodes = list(perception)
+
     workflow: StateGraph = StateGraph(HedgeFundState)
     workflow.add_node(
         "policy_orchestrator", _instrument_node("policy_orchestrator", policy_orchestrator)
     )
     workflow.add_node("desk_market_scan", _instrument_node("market_scan", market_scan))
-    # Tier-0 AIMM8 perception layer.
-    workflow.add_node("monetary_sentinel", _instrument_node("monetary_sentinel", monetary_sentinel))
-    workflow.add_node(
-        "news_narrative_miner",
-        _instrument_node("news_narrative_miner", news_narrative_miner),
-    )
-    workflow.add_node(
-        "pattern_recognition_bot",
-        _instrument_node("pattern_recognition_bot", pattern_recognition_bot),
-    )
-    workflow.add_node(
-        "statistical_alpha_engine",
-        _instrument_node("statistical_alpha_engine", statistical_alpha_engine),
-    )
-    workflow.add_node(
-        "technical_ta_engine",
-        _instrument_node("technical_ta_engine", technical_ta_engine),
-    )
-    workflow.add_node(
-        "retail_hype_tracker", _instrument_node("retail_hype_tracker", retail_hype_tracker)
-    )
-    workflow.add_node("pro_bias_analyst", _instrument_node("pro_bias_analyst", pro_bias_analyst))
-    workflow.add_node(
-        "whale_behavior_analyst", _instrument_node("whale_behavior_analyst", whale_behavior_analyst)
-    )
-    workflow.add_node(
-        "liquidity_order_flow", _instrument_node("liquidity_order_flow", liquidity_order_flow)
-    )
+    for node_id in nodes:
+        workflow.add_node(node_id, _instrument_node(node_id, perception[node_id]))
     workflow.add_node("desk_risk", _instrument_node("risk", risk))
     workflow.add_node("desk_debate", _instrument_node("desk_debate", desk_debate))
     workflow.add_node(
@@ -1454,19 +1455,8 @@ def build_workflow() -> StateGraph:
     workflow.add_node("audit", _instrument_node("audit", audit))
 
     workflow.set_entry_point("policy_orchestrator")
-    tier0_nodes = [
-        "monetary_sentinel",
-        "news_narrative_miner",
-        "pattern_recognition_bot",
-        "statistical_alpha_engine",
-        "technical_ta_engine",
-        "retail_hype_tracker",
-        "pro_bias_analyst",
-        "whale_behavior_analyst",
-        "liquidity_order_flow",
-    ]
     workflow.add_edge("policy_orchestrator", "desk_market_scan")
-    for node_id in tier0_nodes:
+    for node_id in nodes:
         workflow.add_edge("desk_market_scan", node_id)
         workflow.add_edge(node_id, "desk_risk")
     workflow.add_edge("desk_risk", "desk_debate")
@@ -1537,7 +1527,7 @@ def main():
         default=False,
         help=(
             "Load active deploy config from config/deploy.active.json. "
-            "Uses the effective_weights from the deployed configuration "
+            "Uses agents.*.weight from the deployed configuration "
             "as profile weights. Overrides --profile-id."
         ),
     )
@@ -1588,11 +1578,15 @@ def main():
 
     # Inject arbitrator_mode from deploy config (if loaded)
     if args.deploy:
-        from config.deploy_loader import get_arbitrator_mode
+        from config.deploy_loader import (
+            get_arbitrator_llm,
+            get_arbitrator_mode,
+        )
 
         deploy_arb_mode = get_arbitrator_mode()
         if deploy_arb_mode:
             state["arbitrator_mode"] = deploy_arb_mode
+        state["arbitrator_llm"] = get_arbitrator_llm()
     logger.debug("Initial state: %s", state)
 
     run_id = f"run-{args.ticker.replace('/', '-')}-{int(time.time())}"

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -19,7 +19,7 @@ from schemas.flow_events import (
 from schemas.state import REDUCER_STATE_KEYS, HedgeFundState, initial_hedge_fund_state
 from schemas.tier0_contract import (
     CONTRACT_SCHEMA_VERSION,
-    TIER0_NODE_TO_AGENT_ID,
+    TIER0_AGENT_NAMES,
     build_tier0_contract_json,
     tier0_consensus_for_arbitrator,
     tier0_contracts_by_agent,
@@ -45,7 +45,7 @@ __all__ = [
     "RiskGuardPayload",
     "initial_hedge_fund_state",
     "CONTRACT_SCHEMA_VERSION",
-    "TIER0_NODE_TO_AGENT_ID",
+    "TIER0_AGENT_NAMES",
     "build_tier0_contract_json",
     "tier0_contracts_by_agent",
     "tier0_consensus_for_arbitrator",

--- a/src/schemas/arbitration.py
+++ b/src/schemas/arbitration.py
@@ -1,52 +1,44 @@
-"""Weighted convergence arbitration schemas.
-
-Factor → agent → composite → decision pipeline
-as specified in the v4 AI-MM config.
-"""
+"""Weighted convergence arbitration schemas and factor maps."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from agents.registry import get_registry
+
 
 @dataclass
 class FactorSignal:
-    """Single factor evaluation from a Tier-0 contract field."""
-
     factor_id: str
     agent_id: str
     raw_value: float
-    normalized: float  # mapped to [0, 1] bullish range
-    weight: float  # factor weight from config
+    normalized: float
+    weight: float
     enabled: bool = True
-    source_field: str = ""  # Tier-0 contract key, e.g. "Liquidity_Score"
+    source_field: str = ""
 
 
 @dataclass
 class AgentWeightedSignal:
-    """Aggregated signal from one agent after factor weighting."""
-
     agent_id: str
     agent_type: str
     label: str
-    composite: float  # Σ(factor_weight × factor_signal)
-    raw_composite: float  # before agent weight multiplication
-    agent_weight: float  # from v4 config
-    weighted_composite: float  # agent_weight × composite
+    composite: float
+    raw_composite: float
+    agent_weight: float
+    weighted_composite: float
     factor_signals: list[FactorSignal] = field(default_factory=list)
     enabled: bool = True
     confidence: float = 0.5
-    stance: str = "neutral"  # bullish / bearish / neutral
+    stance: str = "neutral"
 
 
 @dataclass
 class ArbitrationResult:
-    """Final output of the weighted convergence arbitrator."""
-
-    composite_score: float  # Σ(agent_weight × composite) over all enabled agents
-    confidence: float  # confidence_formula result
-    stance: str  # bullish / bearish / neutral
-    conviction_level: str  # low / medium / high
+    composite_score: float
+    confidence: float
+    stance: str
+    conviction_level: str
     reasons: list[str] = field(default_factory=list)
     agent_signals: list[AgentWeightedSignal] = field(default_factory=list)
     consensus_ratio: float = 0.0
@@ -57,27 +49,31 @@ class ArbitrationResult:
     alignment_reason: str = ""
 
 
-# v4 Config weight definitions (defaults matching the validated config)
+def _registry_maps() -> tuple[dict[str, float], dict[str, str]]:
+    reg = get_registry()
+    return reg.default_weights(), reg.labels()
+
+
 AGENT_FACTOR_MAP: dict[str, dict[str, float]] = {
-    "1.1": {},  # monetary_sentinel — no config factors, uses contract fields directly
-    "1.2": {
+    "monetary_sentinel": {},
+    "news_narrative_miner": {
         "sentiment_score": 0.28,
         "impact_score": 0.38,
         "event_type": 0.19,
         "narrative_freshness": 0.15,
     },
-    "2.1": {
+    "pattern_recognition_bot": {
         "setup_score": 0.40,
         "pattern_quality": 0.30,
         "timeframe_align": 0.20,
         "volume_conf": 0.10,
     },
-    "2.2": {
+    "statistical_alpha_engine": {
         "alpha_signal": 0.50,
         "z_score": 0.25,
         "regime_fit": 0.25,
     },
-    "2.3": {
+    "technical_ta_engine": {
         "rsi": 0.10,
         "macd": 0.16,
         "obv": 0.08,
@@ -88,66 +84,30 @@ AGENT_FACTOR_MAP: dict[str, dict[str, float]] = {
         "roc": 0.10,
         "volume": 0.07,
     },
-    "3.1": {
+    "retail_hype_tracker": {
         "fomo_level": 0.35,
         "social_volume": 0.25,
         "divergence_warning": 0.40,
     },
-    "3.2": {
+    "pro_bias_analyst": {
         "etf_trend": 0.40,
         "funding_rate": 0.30,
         "oi_delta": 0.30,
     },
-    "4.1": {
+    "whale_behavior_analyst": {
         "dump_probability": 0.50,
         "concentration_pct": 0.25,
         "wallet_flow": 0.25,
     },
-    "4.2": {
+    "liquidity_order_flow": {
         "slippage_risk": 0.35,
         "order_imbalance": 0.35,
         "depth_skew": 0.30,
     },
 }
 
-
-AGENT_WEIGHTS_DEFAULT: dict[str, float] = {
-    "1.1": 0.25,
-    "1.2": 0.05,
-    "2.1": 0.15,
-    "2.2": 0.10,
-    "2.3": 0.55,
-    "3.1": 0.05,
-    "3.2": 0.05,
-    "4.1": 0.05,
-    "4.2": 0.15,
-}
-
-
-AGENT_LABEL_MAP: dict[str, str] = {
-    "1.1": "Macro Economist",
-    "1.2": "News & Narrative",
-    "2.1": "Pattern Recognition",
-    "2.2": "Statistical Alpha",
-    "2.3": "Technical Analysis",
-    "3.1": "Retail Hype Tracker",
-    "3.2": "Smart Money Tracker",
-    "4.1": "Whale Behavior",
-    "4.2": "Liquidity & Order Flow",
-}
-
-
-AGENT_TYPE_MAP: dict[str, str] = {
-    "1.1": "monetary_sentinel",
-    "1.2": "news_narrative_miner",
-    "2.1": "pattern_recognition",
-    "2.2": "statistical_alpha",
-    "2.3": "technical_ta",
-    "3.1": "retail_hype",
-    "3.2": "pro_bias",
-    "4.1": "whale_behavior",
-    "4.2": "liquidity_order_flow",
-}
+AGENT_WEIGHTS_DEFAULT, AGENT_LABEL_MAP = _registry_maps()
+AGENT_TYPE_MAP: dict[str, str] = {name: name for name in AGENT_FACTOR_MAP}
 
 
 __all__ = [

--- a/src/schemas/tier0_contract.py
+++ b/src/schemas/tier0_contract.py
@@ -8,20 +8,10 @@ from __future__ import annotations
 
 from typing import Any
 
-# LangGraph node id -> AIMM-style agent id string
-TIER0_NODE_TO_AGENT_ID: dict[str, str] = {
-    "monetary_sentinel": "1.1",
-    "news_narrative_miner": "1.2",
-    "pattern_recognition_bot": "2.1",
-    "statistical_alpha_engine": "2.2",
-    "technical_ta_engine": "2.3",
-    "retail_hype_tracker": "3.1",
-    "pro_bias_analyst": "3.2",
-    "whale_behavior_analyst": "4.1",
-    "liquidity_order_flow": "4.2",
-}
+from agents.registry import get_registry
 
 CONTRACT_SCHEMA_VERSION = "tier0/v1"
+TIER0_AGENT_NAMES: frozenset[str] = frozenset(get_registry().names())
 
 
 def _f(x: Any, default: float = 0.0) -> float:
@@ -40,12 +30,12 @@ def _macro_regime_state(liquidity_regime: str) -> int:
     return 1
 
 
-def _contract_1_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+def _contract_monetary_sentinel(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     score = _f(analysis.get("systemic_beta_score"), 50.0)
     regime = str(analysis.get("liquidity_regime") or "neutral")
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "1.1",
+        "agent": "monetary_sentinel",
         "ticker": ticker,
         "status": str(analysis.get("status") or "success"),
         "macro_regime_state": _macro_regime_state(regime),
@@ -54,7 +44,7 @@ def _contract_1_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     }
 
 
-def _contract_1_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+def _contract_news_narrative(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     impact = _f(analysis.get("breaker_score"), 0.0)
     if impact >= 75:
         ev = "Black Swan"
@@ -66,7 +56,7 @@ def _contract_1_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
         ev = "Routine"
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "1.2",
+        "agent": "news_narrative_miner",
         "ticker": ticker,
         "status": str(analysis.get("status") or "success"),
         "News_Impact_Score": int(round(min(100.0, max(0.0, impact)))),
@@ -75,7 +65,7 @@ def _contract_1_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     }
 
 
-def _contract_2_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+def _contract_pattern_recognition(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     setup = _f(analysis.get("setup_confidence_score"), 0.0)
     sr = (
         analysis.get("support_resistance")
@@ -89,7 +79,7 @@ def _contract_2_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     pat = analysis.get("pattern") or analysis.get("macro_regime")
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "2.1",
+        "agent": "pattern_recognition_bot",
         "ticker": ticker,
         "status": str(analysis.get("status") or "success"),
         "Setup_Score": int(round(min(100.0, max(0.0, setup)))),
@@ -98,7 +88,7 @@ def _contract_2_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     }
 
 
-def _contract_2_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+def _contract_statistical_alpha(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     sig = str(analysis.get("alpha_signal") or "hold").lower()
     label_map = {
         "long_bias": "Strong Buy",
@@ -125,7 +115,7 @@ def _contract_2_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
             conf = 55
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "2.2",
+        "agent": "statistical_alpha_engine",
         "ticker": ticker,
         "status": str(analysis.get("status") or "success"),
         "Factor_Confluence": conf,
@@ -134,14 +124,14 @@ def _contract_2_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     }
 
 
-def _contract_2_3(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
-    """Classical TA bundle (Agent 2.3) for Tier-1 ``ta_*`` metric_ids."""
+def _contract_technical_ta(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+    """Classical TA bundle for Tier-1 ``ta_*`` metric_ids."""
     ti = analysis.get("ta_indicators")
     if not isinstance(ti, dict):
         ti = {}
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "2.3",
+        "agent": "technical_ta_engine",
         "ticker": ticker,
         "status": str(analysis.get("status") or "skipped"),
         "ta_period": analysis.get("ta_period"),
@@ -151,10 +141,10 @@ def _contract_2_3(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     }
 
 
-def _contract_3_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+def _contract_retail_hype(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "3.1",
+        "agent": "retail_hype_tracker",
         "ticker": ticker,
         "status": str(analysis.get("status") or "success"),
         "FOMO_Level": int(min(100, max(0, int(_f(analysis.get("fomo_level"), 50))))),
@@ -163,7 +153,7 @@ def _contract_3_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     }
 
 
-def _contract_3_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+def _contract_pro_bias(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     score = _f(analysis.get("pro_bias_score"), 50.0)
     regime = str(analysis.get("regime") or "passive_rotation").lower()
     if "accumulation" in regime:
@@ -174,7 +164,7 @@ def _contract_3_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
         etf = "Neutral"
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "3.2",
+        "agent": "pro_bias_analyst",
         "ticker": ticker,
         "status": str(analysis.get("status") or "success"),
         "Pro_Bias": int(round(min(100.0, max(0.0, score)))),
@@ -183,7 +173,7 @@ def _contract_3_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     }
 
 
-def _contract_4_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+def _contract_whale_behavior(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     dump = _f(analysis.get("dump_probability"), 0.0)
     gauge = int(round(min(100.0, max(0.0, dump * 100.0))))
     dp = str(analysis.get("dry_powder_alert") or "unknown").lower()
@@ -195,7 +185,7 @@ def _contract_4_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
         dpa = "Normal"
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "4.1",
+        "agent": "whale_behavior_analyst",
         "ticker": ticker,
         "status": str(analysis.get("status") or "success"),
         "Sell_Pressure_Gauge": gauge,
@@ -204,7 +194,7 @@ def _contract_4_1(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     }
 
 
-def _contract_4_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
+def _contract_liquidity_order_flow(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
     has_depth = bool(analysis.get("nexus_depth_attached"))
     st = str(analysis.get("status") or "skipped")
     slip = analysis.get("slippage_risk_score")
@@ -212,7 +202,7 @@ def _contract_4_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
         slip = 40 if has_depth and st == "success" else 85
     return {
         "schema_version": CONTRACT_SCHEMA_VERSION,
-        "agent": "4.2",
+        "agent": "liquidity_order_flow",
         "ticker": ticker,
         "status": st,
         "Slippage_Risk_Score": int(slip) if isinstance(slip, (int, float)) else slip,
@@ -222,28 +212,26 @@ def _contract_4_2(analysis: dict[str, Any], ticker: str) -> dict[str, Any]:
 
 
 _BUILDERS: dict[str, Any] = {
-    "1.1": _contract_1_1,
-    "1.2": _contract_1_2,
-    "2.1": _contract_2_1,
-    "2.2": _contract_2_2,
-    "2.3": _contract_2_3,
-    "3.1": _contract_3_1,
-    "3.2": _contract_3_2,
-    "4.1": _contract_4_1,
-    "4.2": _contract_4_2,
+    "monetary_sentinel": _contract_monetary_sentinel,
+    "news_narrative_miner": _contract_news_narrative,
+    "pattern_recognition_bot": _contract_pattern_recognition,
+    "statistical_alpha_engine": _contract_statistical_alpha,
+    "technical_ta_engine": _contract_technical_ta,
+    "retail_hype_tracker": _contract_retail_hype,
+    "pro_bias_analyst": _contract_pro_bias,
+    "whale_behavior_analyst": _contract_whale_behavior,
+    "liquidity_order_flow": _contract_liquidity_order_flow,
 }
 
 
 def build_tier0_contract_json(
     node_id: str, primary_analysis: dict[str, Any], ticker: str
 ) -> dict[str, Any]:
-    """Map node id + primary symbol analysis dict to the canonical Tier-0 JSON object."""
-    aid = TIER0_NODE_TO_AGENT_ID.get(node_id, node_id)
-    fn = _BUILDERS.get(aid)
+    fn = _BUILDERS.get(node_id)
     if fn is None:
         return {
             "schema_version": CONTRACT_SCHEMA_VERSION,
-            "agent": aid,
+            "agent": node_id,
             "ticker": ticker,
             "status": "error",
             "error": f"unknown_tier0_node:{node_id}",
@@ -252,11 +240,13 @@ def build_tier0_contract_json(
 
 
 def tier0_contracts_by_agent(state: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Last-wins index by agent id (e.g. ``1.1``) for Tier-1 convenience."""
     out: dict[str, dict[str, Any]] = {}
     for row in state.get("tier0_contracts") or []:
-        if isinstance(row, dict) and row.get("agent"):
-            out[str(row["agent"])] = row
+        if not isinstance(row, dict):
+            continue
+        aid = row.get("agent") or row.get("agent_id")
+        if aid:
+            out[str(aid)] = row
     return out
 
 
@@ -281,16 +271,16 @@ def tier0_consensus_for_arbitrator(state: dict[str, Any]) -> dict[str, Any]:
     block = False
     parts: list[str] = []
 
-    m = idx.get("1.1") or {}
+    m = idx.get("monetary_sentinel") or {}
     mrs = m.get("macro_regime_state")
     if mrs == 2:
         bull += 1
-        parts.append("1.1_risk_on")
+        parts.append("macro_risk_on")
     elif mrs == 0:
         bear += 1
-        parts.append("1.1_risk_off")
+        parts.append("macro_risk_off")
 
-    n = idx.get("1.2") or {}
+    n = idx.get("news_narrative_miner") or {}
     try:
         ni = int(n.get("News_Impact_Score") or 0)
     except (TypeError, ValueError):
@@ -299,30 +289,30 @@ def tier0_consensus_for_arbitrator(state: dict[str, Any]) -> dict[str, Any]:
     if ni >= 80 or "Black Swan" in et:
         block = True
         bear += 2
-        parts.append("1.2_shock")
+        parts.append("news_shock")
     elif ni >= 55:
         bear += 1
-        parts.append("1.2_elevated_news")
+        parts.append("news_elevated")
 
-    t21 = idx.get("2.1") or {}
+    t21 = idx.get("pattern_recognition_bot") or {}
     try:
         setup = int(t21.get("Setup_Score") or 0)
     except (TypeError, ValueError):
         setup = 0
     if setup >= 70:
         bull += 1
-        parts.append("2.1_setup")
+        parts.append("pattern_setup")
 
-    t22 = idx.get("2.2") or {}
+    t22 = idx.get("statistical_alpha_engine") or {}
     sig = str(t22.get("alpha_signal") or "")
     if "Strong Buy" in sig:
         bull += 1
-        parts.append("2.2_long")
+        parts.append("stat_long")
     elif "Strong Sell" in sig:
         bear += 1
-        parts.append("2.2_short")
+        parts.append("stat_short")
 
-    t23 = idx.get("2.3") or {}
+    t23 = idx.get("technical_ta_engine") or {}
     ti = t23.get("ta_indicators") if isinstance(t23.get("ta_indicators"), dict) else {}
     rsi_v = ti.get("rsi")
     try:
@@ -332,46 +322,46 @@ def tier0_consensus_for_arbitrator(state: dict[str, Any]) -> dict[str, Any]:
     if rsi_f is not None:
         if rsi_f >= 70.0:
             bear += 1
-            parts.append("2.3_rsi_stretched")
+            parts.append("ta_rsi_stretched")
         elif rsi_f <= 30.0:
             bull += 1
-            parts.append("2.3_rsi_oversold")
+            parts.append("ta_rsi_oversold")
 
-    r31 = idx.get("3.1") or {}
+    r31 = idx.get("retail_hype_tracker") or {}
     try:
         fomo = int(r31.get("FOMO_Level") or 0)
     except (TypeError, ValueError):
         fomo = 0
     if r31.get("Divergence_Warning") and fomo >= 85:
         bear += 1
-        parts.append("3.1_hype_div")
+        parts.append("retail_hype_div")
 
-    p32 = idx.get("3.2") or {}
+    p32 = idx.get("pro_bias_analyst") or {}
     etf = str(p32.get("ETF_Trend") or "")
     if etf == "Accumulation":
         bull += 1
-        parts.append("3.2_accum")
+        parts.append("pro_accum")
     elif etf == "Distribution":
         bear += 1
-        parts.append("3.2_dist")
+        parts.append("pro_dist")
 
-    w41 = idx.get("4.1") or {}
+    w41 = idx.get("whale_behavior_analyst") or {}
     try:
         dump = float(w41.get("Dump_Probability") or 0.0)
     except (TypeError, ValueError):
         dump = 0.0
     if dump >= 0.65:
         bear += 1
-        parts.append("4.1_dump")
+        parts.append("whale_dump")
 
-    l42 = idx.get("4.2") or {}
+    l42 = idx.get("liquidity_order_flow") or {}
     try:
         slip = int(l42.get("Slippage_Risk_Score") or 0)
     except (TypeError, ValueError):
         slip = 0
     if slip >= 80:
         bear += 1
-        parts.append("4.2_slip")
+        parts.append("flow_slip")
 
     return {
         "bull_tilt": bull,
@@ -384,7 +374,7 @@ def tier0_consensus_for_arbitrator(state: dict[str, Any]) -> dict[str, Any]:
 
 __all__ = [
     "CONTRACT_SCHEMA_VERSION",
-    "TIER0_NODE_TO_AGENT_ID",
+    "TIER0_AGENT_NAMES",
     "build_tier0_contract_json",
     "tier0_contracts_by_agent",
     "tier0_consensus_for_arbitrator",

--- a/src/tier1/metric_catalog.py
+++ b/src/tier1/metric_catalog.py
@@ -20,7 +20,7 @@ def _ta_metric_rows() -> list[dict[str, Any]]:
     return [
         {
             "metric_id": f"ta_{name}",
-            "tier0_agent": "2.3",
+            "tier0_agent": "technical_ta_engine",
             "contract_path": f"ta_indicators.{name}",
             "family": "technical",
         }
@@ -30,29 +30,65 @@ def _ta_metric_rows() -> list[dict[str, Any]]:
 
 # Non-TA metrics resolved in ``tier1.resolvers.resolve_metric``.
 CORE_METRICS: tuple[dict[str, Any], ...] = (
-    {"metric_id": "circuit_breaker_status", "tier0_agent": "1.2", "family": "macro_news"},
-    {"metric_id": "black_swan_news", "tier0_agent": "1.2", "family": "macro_news"},
-    {"metric_id": "mon_liquidity_score", "tier0_agent": "1.1", "family": "macro"},
-    {"metric_id": "mon_macro_regime_state", "tier0_agent": "1.1", "family": "macro"},
-    {"metric_id": "news_impact", "tier0_agent": "1.2", "family": "macro_news"},
-    {"metric_id": "news_event_type", "tier0_agent": "1.2", "family": "macro_news"},
-    {"metric_id": "pattern_setup", "tier0_agent": "2.1", "family": "structure"},
-    {"metric_id": "pattern_name", "tier0_agent": "2.1", "family": "structure"},
-    {"metric_id": "alpha_z", "tier0_agent": "2.2", "family": "quant"},
-    {"metric_id": "alpha_signal_label", "tier0_agent": "2.2", "family": "quant"},
-    {"metric_id": "alpha_strong_buy", "tier0_agent": "2.2", "family": "quant"},
-    {"metric_id": "alpha_strong_sell", "tier0_agent": "2.2", "family": "quant"},
-    {"metric_id": "factor_confluence", "tier0_agent": "2.2", "family": "quant"},
-    {"metric_id": "retail_fomo", "tier0_agent": "3.1", "family": "behavioral"},
-    {"metric_id": "retail_div", "tier0_agent": "3.1", "family": "behavioral"},
-    {"metric_id": "retail_sent_z", "tier0_agent": "3.1", "family": "behavioral"},
-    {"metric_id": "pro_bias", "tier0_agent": "3.2", "family": "flow"},
-    {"metric_id": "pro_etf_trend", "tier0_agent": "3.2", "family": "flow"},
-    {"metric_id": "whale_dump_prob", "tier0_agent": "4.1", "family": "microstructure"},
-    {"metric_id": "whale_sell_pressure", "tier0_agent": "4.1", "family": "microstructure"},
-    {"metric_id": "liq_slippage", "tier0_agent": "4.2", "family": "microstructure"},
-    {"metric_id": "liq_imbalance", "tier0_agent": "4.2", "family": "microstructure"},
-    {"metric_id": "liq_poc_price", "tier0_agent": "4.2", "family": "microstructure"},
+    {
+        "metric_id": "circuit_breaker_status",
+        "tier0_agent": "news_narrative_miner",
+        "family": "macro_news",
+    },
+    {"metric_id": "black_swan_news", "tier0_agent": "news_narrative_miner", "family": "macro_news"},
+    {"metric_id": "mon_liquidity_score", "tier0_agent": "monetary_sentinel", "family": "macro"},
+    {"metric_id": "mon_macro_regime_state", "tier0_agent": "monetary_sentinel", "family": "macro"},
+    {"metric_id": "news_impact", "tier0_agent": "news_narrative_miner", "family": "macro_news"},
+    {"metric_id": "news_event_type", "tier0_agent": "news_narrative_miner", "family": "macro_news"},
+    {"metric_id": "pattern_setup", "tier0_agent": "pattern_recognition_bot", "family": "structure"},
+    {"metric_id": "pattern_name", "tier0_agent": "pattern_recognition_bot", "family": "structure"},
+    {"metric_id": "alpha_z", "tier0_agent": "statistical_alpha_engine", "family": "quant"},
+    {
+        "metric_id": "alpha_signal_label",
+        "tier0_agent": "statistical_alpha_engine",
+        "family": "quant",
+    },
+    {"metric_id": "alpha_strong_buy", "tier0_agent": "statistical_alpha_engine", "family": "quant"},
+    {
+        "metric_id": "alpha_strong_sell",
+        "tier0_agent": "statistical_alpha_engine",
+        "family": "quant",
+    },
+    {
+        "metric_id": "factor_confluence",
+        "tier0_agent": "statistical_alpha_engine",
+        "family": "quant",
+    },
+    {"metric_id": "retail_fomo", "tier0_agent": "retail_hype_tracker", "family": "behavioral"},
+    {"metric_id": "retail_div", "tier0_agent": "retail_hype_tracker", "family": "behavioral"},
+    {"metric_id": "retail_sent_z", "tier0_agent": "retail_hype_tracker", "family": "behavioral"},
+    {"metric_id": "pro_bias", "tier0_agent": "pro_bias_analyst", "family": "flow"},
+    {"metric_id": "pro_etf_trend", "tier0_agent": "pro_bias_analyst", "family": "flow"},
+    {
+        "metric_id": "whale_dump_prob",
+        "tier0_agent": "whale_behavior_analyst",
+        "family": "microstructure",
+    },
+    {
+        "metric_id": "whale_sell_pressure",
+        "tier0_agent": "whale_behavior_analyst",
+        "family": "microstructure",
+    },
+    {
+        "metric_id": "liq_slippage",
+        "tier0_agent": "liquidity_order_flow",
+        "family": "microstructure",
+    },
+    {
+        "metric_id": "liq_imbalance",
+        "tier0_agent": "liquidity_order_flow",
+        "family": "microstructure",
+    },
+    {
+        "metric_id": "liq_poc_price",
+        "tier0_agent": "liquidity_order_flow",
+        "family": "microstructure",
+    },
 )
 
 

--- a/src/tier1/resolvers.py
+++ b/src/tier1/resolvers.py
@@ -62,15 +62,15 @@ def resolve_metric(metric_id: str, state: dict[str, Any]) -> Any:
     mid = (metric_id or "").strip().lower()
     idx = tier0_by_agent_for_ticker(state)
 
-    c11 = idx.get("1.1") or {}
-    c12 = idx.get("1.2") or {}
-    c21 = idx.get("2.1") or {}
-    c22 = idx.get("2.2") or {}
-    c23 = idx.get("2.3") or {}
-    c31 = idx.get("3.1") or {}
-    c32 = idx.get("3.2") or {}
-    c41 = idx.get("4.1") or {}
-    c42 = idx.get("4.2") or {}
+    c11 = idx.get("monetary_sentinel") or {}
+    c12 = idx.get("news_narrative_miner") or {}
+    c21 = idx.get("pattern_recognition_bot") or {}
+    c22 = idx.get("statistical_alpha_engine") or {}
+    c23 = idx.get("technical_ta_engine") or {}
+    c31 = idx.get("retail_hype_tracker") or {}
+    c32 = idx.get("pro_bias_analyst") or {}
+    c41 = idx.get("whale_behavior_analyst") or {}
+    c42 = idx.get("liquidity_order_flow") or {}
 
     if mid in ("", "none"):
         return None

--- a/src/workflow/desk_debate.py
+++ b/src/workflow/desk_debate.py
@@ -3,9 +3,8 @@
 1. **Deterministic** (always): macro/risk vs tape/alpha summaries from Tier-0 hooks — no API cost,
    visible in live flow events, backtest ``iterations.jsonl``, and downstream LLM arbitrator context.
 
-2. **Optional LLM** (``AIMM_LLM_DESK_DEBATE=1`` when LLM arbitrator is on): two short model turns —
-   Desk_Risk may call ``nexus.fetch_market_depth``; Desk_Tape is narrative-only (no tools) so operators
-   see different tool access patterns in logs.
+2. **Optional LLM** (``execution.desk_debate_llm`` in deploy JSON): two short model turns —
+   Desk_Risk may call ``nexus.fetch_market_depth``; Desk_Tape is narrative-only (no tools).
 """
 
 from __future__ import annotations
@@ -137,8 +136,20 @@ def deterministic_debate_entries(state: HedgeFundState) -> list[dict[str, Any]]:
     ]
 
 
+def _desk_debate_llm_enabled() -> bool:
+    try:
+        from config.deploy_loader import get_desk_debate_llm
+
+        flag = get_desk_debate_llm()
+        if flag is not None:
+            return bool(flag)
+    except Exception:
+        pass
+    return False
+
+
 def llm_desk_debate_entries(state: HedgeFundState) -> list[dict[str, Any]]:
-    if not _env_bool("AIMM_LLM_DESK_DEBATE", default=False):
+    if not _desk_debate_llm_enabled():
         return []
     ctx = _compact_context(state)
     out: list[dict[str, Any]] = []

--- a/src/workflow/tier2_context.py
+++ b/src/workflow/tier2_context.py
@@ -29,7 +29,7 @@ def compact_tier0_for_prompt(state: dict[str, Any]) -> dict[str, Any]:
                 continue
             if isinstance(v, (int, float, str, bool)) or v is None:
                 entry[k] = v
-        if aid == "2.3" and isinstance(row.get("ta_indicators"), dict):
+        if aid == "technical_ta_engine" and isinstance(row.get("ta_indicators"), dict):
             ti = row["ta_indicators"]
             pick = ("rsi", "macd_hist", "macd", "macd_signal", "adx", "ema", "atr", "cci")
             entry["ta_indicators"] = {k: ti[k] for k in pick if k in ti and ti[k] is not None}
@@ -49,24 +49,24 @@ def bull_evidence_lines(state: dict[str, Any]) -> list[str]:
     idx = tier0_contracts_by_agent(state)
     lines: list[str] = []
 
-    m = idx.get("1.1") or {}
+    m = idx.get("monetary_sentinel") or {}
     if m.get("macro_regime_state") == 2:
         lines.append(f"Macro risk-on (liquidity_score={m.get('Liquidity_Score')}, regime_state=2).")
-    n = idx.get("1.2") or {}
+    n = idx.get("news_narrative_miner") or {}
     ni = int(n.get("News_Impact_Score") or 0)
     if ni < 40:
         lines.append(f"News impact contained (News_Impact_Score={ni}).")
 
-    p = idx.get("2.1") or {}
+    p = idx.get("pattern_recognition_bot") or {}
     setup = int(p.get("Setup_Score") or 0)
     if setup >= 55:
         lines.append(f"Pattern setup supportive (Setup_Score={setup}).")
 
-    a = idx.get("2.2") or {}
+    a = idx.get("statistical_alpha_engine") or {}
     if "Strong Buy" in str(a.get("alpha_signal") or ""):
         lines.append("Statistical alpha labels Strong Buy.")
 
-    t = idx.get("2.3") or {}
+    t = idx.get("technical_ta_engine") or {}
     ti = t.get("ta_indicators") if isinstance(t.get("ta_indicators"), dict) else {}
     rsi = ti.get("rsi")
     if rsi is not None and not (isinstance(rsi, float) and math.isnan(rsi)):
@@ -79,21 +79,21 @@ def bull_evidence_lines(state: dict[str, Any]) -> list[str]:
     if mh is not None and _f(mh) > 0:
         lines.append(f"TA MACD histogram positive ({mh}).")
 
-    r = idx.get("3.1") or {}
+    r = idx.get("retail_hype_tracker") or {}
     fomo = int(r.get("FOMO_Level") or 0)
     if fomo < 75 and not r.get("Divergence_Warning"):
         lines.append(f"Retail not in extreme FOMO (FOMO_Level={fomo}).")
 
-    pb = idx.get("3.2") or {}
+    pb = idx.get("pro_bias_analyst") or {}
     if str(pb.get("ETF_Trend") or "") == "Accumulation":
         lines.append("Institutional ETF trend: Accumulation.")
 
-    w = idx.get("4.1") or {}
+    w = idx.get("whale_behavior_analyst") or {}
     dump = _f(w.get("Dump_Probability"), 0.0)
     if dump < 0.45:
         lines.append(f"Whale dump probability moderate ({dump:.2f}).")
 
-    liq = idx.get("4.2") or {}
+    liq = idx.get("liquidity_order_flow") or {}
     slip = int(liq.get("Slippage_Risk_Score") or 0)
     if slip < 75:
         lines.append(f"Execution slippage risk acceptable (Slippage_Risk_Score={slip}).")
@@ -106,28 +106,28 @@ def bear_evidence_lines(state: dict[str, Any]) -> list[str]:
     idx = tier0_contracts_by_agent(state)
     lines: list[str] = []
 
-    m = idx.get("1.1") or {}
+    m = idx.get("monetary_sentinel") or {}
     if m.get("macro_regime_state") == 0:
         lines.append(
             f"Macro risk-off (liquidity_score={m.get('Liquidity_Score')}, regime_state=0)."
         )
 
-    n = idx.get("1.2") or {}
+    n = idx.get("news_narrative_miner") or {}
     ni = int(n.get("News_Impact_Score") or 0)
     et = str(n.get("Event_Type") or "")
     if ni >= 55 or "Black Swan" in et:
         lines.append(f"Headline risk elevated (News_Impact_Score={ni}, Event_Type={et}).")
 
-    p = idx.get("2.1") or {}
+    p = idx.get("pattern_recognition_bot") or {}
     setup = int(p.get("Setup_Score") or 0)
     if setup < 45 and setup > 0:
         lines.append(f"Pattern setup weak (Setup_Score={setup}).")
 
-    a = idx.get("2.2") or {}
+    a = idx.get("statistical_alpha_engine") or {}
     if "Strong Sell" in str(a.get("alpha_signal") or ""):
         lines.append("Statistical alpha labels Strong Sell.")
 
-    t = idx.get("2.3") or {}
+    t = idx.get("technical_ta_engine") or {}
     ti = t.get("ta_indicators") if isinstance(t.get("ta_indicators"), dict) else {}
     rsi = ti.get("rsi")
     if rsi is not None and not (isinstance(rsi, float) and math.isnan(rsi)) and float(rsi) >= 70:
@@ -136,20 +136,20 @@ def bear_evidence_lines(state: dict[str, Any]) -> list[str]:
     if mh is not None and _f(mh) < 0:
         lines.append(f"TA MACD histogram negative ({mh}).")
 
-    r = idx.get("3.1") or {}
+    r = idx.get("retail_hype_tracker") or {}
     if r.get("Divergence_Warning") and int(r.get("FOMO_Level") or 0) >= 80:
         lines.append("Retail hype + divergence warning.")
 
-    pb = idx.get("3.2") or {}
+    pb = idx.get("pro_bias_analyst") or {}
     if str(pb.get("ETF_Trend") or "") == "Distribution":
         lines.append("Institutional ETF trend: Distribution.")
 
-    w = idx.get("4.1") or {}
+    w = idx.get("whale_behavior_analyst") or {}
     dump = _f(w.get("Dump_Probability"), 0.0)
     if dump >= 0.45:
         lines.append(f"Whale dump probability elevated ({dump:.2f}).")
 
-    liq = idx.get("4.2") or {}
+    liq = idx.get("liquidity_order_flow") or {}
     slip = int(liq.get("Slippage_Risk_Score") or 0)
     if slip >= 75:
         lines.append(f"Execution slippage risk high (Slippage_Risk_Score={slip}).")

--- a/src/workflow/weight_assigner.py
+++ b/src/workflow/weight_assigner.py
@@ -16,11 +16,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from agents.registry import get_registry
 from schemas.arbitration import (
     AGENT_FACTOR_MAP,
-    AGENT_LABEL_MAP,
-    AGENT_TYPE_MAP,
-    AGENT_WEIGHTS_DEFAULT,
     AgentWeightedSignal,
     ArbitrationResult,
     FactorSignal,
@@ -63,7 +61,7 @@ def _normalize_linear(val: float, raw_max: float, raw_min: float = 0.0) -> float
 # ---------------------------------------------------------------------------
 
 
-def _agent_1_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _monetary_sentinel_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
     """Monetary Sentinel — macro regime + liquidity score."""
     mrs = _f(contract.get("macro_regime_state"), 1.0)
     ls = _f(contract.get("Liquidity_Score"), 50.0)
@@ -75,7 +73,7 @@ def _agent_1_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     return {"macro_bias": (regime_bull * 0.6 + score_bull * 0.4)}
 
 
-def _agent_1_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _news_narrative_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
     """News & Narrative Miner."""
     ni = _f(contract.get("News_Impact_Score"), 50.0)
     et = str(contract.get("Event_Type") or "Routine")
@@ -93,7 +91,9 @@ def _agent_1_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     }
 
 
-def _agent_2_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _pattern_recognition_factors(
+    contract: dict[str, Any], state: dict[str, Any]
+) -> dict[str, float]:
     """Pattern Recognition Bot."""
     ss = _f(contract.get("Setup_Score"), 50.0)
     # pattern_quality — derive from pattern field
@@ -123,7 +123,7 @@ def _agent_2_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     }
 
 
-def _agent_2_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _statistical_alpha_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
     """Statistical Alpha Engine."""
     sig = str(contract.get("alpha_signal") or "Hold")
     sig_map = {"Strong Buy": 0.85, "Buy": 0.65, "Hold": 0.50, "Sell": 0.35, "Strong Sell": 0.15}
@@ -139,7 +139,7 @@ def _agent_2_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     }
 
 
-def _agent_2_3_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _technical_ta_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
     """Technical TA Engine."""
     ti = contract.get("ta_indicators") if isinstance(contract.get("ta_indicators"), dict) else {}
     rsi = _f(ti.get("rsi"), 50.0)
@@ -203,7 +203,7 @@ def _agent_2_3_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     }
 
 
-def _agent_3_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _retail_hype_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
     """Retail Hype Tracker."""
     fomo = _f(contract.get("FOMO_Level"), 50.0)
     # High FOMO → bearish (retail euphoria), low FOMO → bullish (fear/despair)
@@ -220,7 +220,7 @@ def _agent_3_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     }
 
 
-def _agent_3_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _pro_bias_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
     """Pro Bias / Smart Money Tracker."""
     pb = _f(contract.get("Pro_Bias"), 50.0)
     etf_raw = str(contract.get("ETF_Trend") or "Neutral")
@@ -236,7 +236,7 @@ def _agent_3_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     }
 
 
-def _agent_4_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _whale_behavior_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
     """Whale Behavior."""
     dp = _f(contract.get("Dump_Probability"), 0.0)
     # Higher dump probability → bearish
@@ -251,7 +251,9 @@ def _agent_4_1_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     }
 
 
-def _agent_4_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[str, float]:
+def _liquidity_order_flow_factors(
+    contract: dict[str, Any], state: dict[str, Any]
+) -> dict[str, float]:
     """Liquidity & Order Flow."""
     slip = _f(contract.get("Slippage_Risk_Score"), 50.0)
     # Higher slippage risk → bearish
@@ -266,17 +268,16 @@ def _agent_4_2_factors(contract: dict[str, Any], state: dict[str, Any]) -> dict[
     }
 
 
-# Registry: agent_id → extractor function
 _AGENT_EXTRACTORS: dict[str, Any] = {
-    "1.1": _agent_1_1_factors,
-    "1.2": _agent_1_2_factors,
-    "2.1": _agent_2_1_factors,
-    "2.2": _agent_2_2_factors,
-    "2.3": _agent_2_3_factors,
-    "3.1": _agent_3_1_factors,
-    "3.2": _agent_3_2_factors,
-    "4.1": _agent_4_1_factors,
-    "4.2": _agent_4_2_factors,
+    "monetary_sentinel": _monetary_sentinel_factors,
+    "news_narrative_miner": _news_narrative_factors,
+    "pattern_recognition_bot": _pattern_recognition_factors,
+    "statistical_alpha_engine": _statistical_alpha_factors,
+    "technical_ta_engine": _technical_ta_factors,
+    "retail_hype_tracker": _retail_hype_factors,
+    "pro_bias_analyst": _pro_bias_factors,
+    "whale_behavior_analyst": _whale_behavior_factors,
+    "liquidity_order_flow": _liquidity_order_flow_factors,
 }
 
 # ---------------------------------------------------------------------------
@@ -290,32 +291,20 @@ def compute_agent_weighted_signals(
     agent_weights: dict[str, float] | None = None,
     disabled_agents: set[str] | None = None,
 ) -> list[AgentWeightedSignal]:
-    """Compute per-agent weighted signals from Tier-0 contracts.
-
-    Parameters
-    ----------
-    state : dict
-        HedgeFundState (or any dict with ``tier0_contracts``).
-    agent_weights : dict, optional
-        Override default agent weights (from v4 config or runtime).
-    disabled_agents : set[str], optional
-        Agent IDs to skip (e.g. ``{"4.1"}`` when Whale is disabled).
-
-    Returns
-    -------
-    list[AgentWeightedSignal]
-        One entry per agent, sorted by agent_id.
-    """
+    """Per-agent composites from Tier-0 contracts. Only desks in *agent_weights* are scored."""
     idx = tier0_contracts_by_agent(state)
-    weights = dict(AGENT_WEIGHTS_DEFAULT)
+    labels = get_registry().labels()
     if agent_weights:
-        weights.update(agent_weights)
+        weights = {str(k): float(v) for k, v in agent_weights.items() if float(v or 0) > 0}
+    else:
+        weights = {k: v for k, v in get_registry().default_weights().items() if v > 0}
     disabled = set(disabled_agents or set())
+    iterate = [aid for aid in weights if aid in _AGENT_EXTRACTORS and aid not in disabled]
 
     signals: list[AgentWeightedSignal] = []
 
-    for aid in sorted(AGENT_FACTOR_MAP.keys()):
-        contract = idx.get(aid, {})
+    for aid in sorted(iterate):
+        contract = idx.get(aid) or {}
         extractor = _AGENT_EXTRACTORS.get(aid)
         if extractor is None:
             continue
@@ -323,8 +312,8 @@ def compute_agent_weighted_signals(
         raw_factors = extractor(contract, state)
         factor_map = AGENT_FACTOR_MAP.get(aid, {})
 
-        agent_w = weights.get(aid, 0.0)
-        enabled = aid not in disabled and contract.get("status") not in ("error", "skipped")
+        agent_w = float(weights.get(aid, 0.0) or 0.0)
+        enabled = contract.get("status") not in ("error", "skipped")
 
         factor_signals: list[FactorSignal] = []
         composite = 0.0
@@ -348,7 +337,7 @@ def compute_agent_weighted_signals(
                 )
             )
 
-        # If agent has no defined factors (e.g. 1.1), use raw_factors directly
+        # monetary_sentinel has no AGENT_FACTOR_MAP entries — use extractor output directly
         if total_factor_weight <= 0 and raw_factors:
             for fid, raw_val in raw_factors.items():
                 norm_val = _clamp(raw_val)
@@ -389,8 +378,8 @@ def compute_agent_weighted_signals(
         signals.append(
             AgentWeightedSignal(
                 agent_id=aid,
-                agent_type=AGENT_TYPE_MAP.get(aid, ""),
-                label=AGENT_LABEL_MAP.get(aid, ""),
+                agent_type=aid,
+                label=labels.get(aid, aid),
                 composite=raw_composite,
                 raw_composite=raw_composite,
                 agent_weight=agent_w if enabled else 0.0,
@@ -481,25 +470,7 @@ def compute_weighted_arbitration(
     disabled_agents: set[str] | None = None,
     decision_threshold: dict[str, Any] | None = None,
 ) -> ArbitrationResult:
-    """Full weighted convergence arbitration pipeline.
-
-    Parameters
-    ----------
-    state : dict
-        HedgeFundState.
-    agent_weights : dict, optional
-        Override default weights.
-    disabled_agents : set[str], optional
-        Agents to exclude.
-    decision_threshold : dict, optional
-        Threshold overrides:
-            buy: {min_composite: 60, min_confidence: 50}
-            sell: {max_composite: 40, min_confidence: 50}
-
-    Returns
-    -------
-    ArbitrationResult
-    """
+    """Weighted fusion + buy/sell/hold gates."""
     signals = compute_agent_weighted_signals(
         state, agent_weights=agent_weights, disabled_agents=disabled_agents
     )
@@ -549,7 +520,7 @@ def compute_weighted_arbitration(
         buy_triggered = False
         sell_triggered = False
 
-    # TA-led desk override: agent 2.3 can trigger direction from its own composite.
+    # TA-led desk can fire from its own composite when the global gate holds.
     ta_led_reasons: list[str] = []
     ta_led = decision_threshold.get("ta_led") if decision_threshold else None
     if isinstance(ta_led, dict) and ta_led.get("enabled", True):
@@ -557,7 +528,7 @@ def compute_weighted_arbitration(
 
         tc = tier0_consensus_for_arbitrator(state)
         block_long = bool(tc.get("block_aggressive_long"))
-        ta_id = str(ta_led.get("agent_id") or "2.3")
+        ta_id = str(ta_led.get("agent_id") or "technical_ta_engine")
         ta_sig = next((s for s in enabled_sigs if s.agent_id == ta_id), None)
         if ta_sig is not None:
             buy_min_ta = _f(ta_led.get("buy_min_composite", 57), 57.0) / 100.0

--- a/src/workflow/weighted_arbitrator.py
+++ b/src/workflow/weighted_arbitrator.py
@@ -16,12 +16,16 @@ identical in shape to the LLM path output.
 from __future__ import annotations
 
 import logging
-import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import replace
 from threading import Lock
 from typing import Any
 
-from llm.agent_llm_client import check_api_key, infer_agent
+from llm.agent_llm_client import (
+    check_api_key,
+    infer_agent,
+    infer_arbitrator_decision,
+)
 from schemas.arbitration import ArbitrationResult
 from schemas.state import HedgeFundState
 from schemas.tier0_contract import tier0_contracts_by_agent
@@ -31,9 +35,7 @@ from workflow.weight_assigner import compute_weighted_arbitration
 
 logger = logging.getLogger(__name__)
 
-# v4 config defaults — tuned for OHLCV-only backtests (NEXUS_DISABLE=1).
-# Nexus-heavy agents are disabled; desk is TA-led (2.3) with macro/pattern support.
-# Weights calibrated offline via run_agentic_sweep (macro_tilt preset).
+# Default gates when deploy JSON omits decision_threshold (macro_tilt research profile).
 _V4_DECISION_THRESHOLD: dict[str, Any] = {
     "buy": {"min_composite": 53, "min_confidence": 16},
     "sell": {"max_composite": 41, "min_confidence": 26},
@@ -45,7 +47,7 @@ _V4_DECISION_THRESHOLD: dict[str, Any] = {
     },
     "ta_led": {
         "enabled": True,
-        "agent_id": "2.3",
+        "agent_id": "technical_ta_engine",
         "buy_min_composite": 57,
         "sell_max_composite": 43,
         "min_confidence": 14,
@@ -54,27 +56,16 @@ _V4_DECISION_THRESHOLD: dict[str, Any] = {
 
 
 def _resolve_decision_threshold(state: HedgeFundState) -> dict[str, Any]:
-    """Per-run threshold from state (backtest deploy_config) or v4 defaults."""
     override = state.get("decision_threshold")
     if isinstance(override, dict) and override:
         return dict(override)
     return dict(_V4_DECISION_THRESHOLD)
 
 
-# Agents that require live Nexus feeds (news, OI, sentiment, depth) — skip in backtest.
-_V4_DISABLED_AGENTS: set[str] = {"1.2", "2.2", "3.1", "3.2", "4.1", "4.2"}
+def _default_agent_weights() -> dict[str, float]:
+    from agents.registry import get_registry
 
-_V4_AGENT_WEIGHTS: dict[str, float] = {
-    "1.1": 0.25,
-    "1.2": 0.05,
-    "2.1": 0.15,
-    "2.2": 0.10,
-    "2.3": 0.55,
-    "3.1": 0.05,
-    "3.2": 0.05,
-    "4.1": 0.05,
-    "4.2": 0.15,
-}
+    return {k: v for k, v in get_registry().default_weights().items() if v > 0}
 
 
 def _reasoning_entry(
@@ -180,111 +171,130 @@ def _arbitration_to_proposed_signal(
 
 
 def _resolve_agent_weights(state: HedgeFundState) -> dict[str, float]:
-    """Resolve effective agent weights, supporting Profile Agent injection.
-
-    Priority:
-    1. ``state.profile_weights`` (from Profile Agent) — full override
-    2. ``_V4_AGENT_WEIGHTS`` — built-in default
-
-    Returns a copy safe for mutation.
-    """
+    """Deploy / profile weights only — do not merge leftover registry defaults."""
     profile = state.get("profile_weights") or {}
-    if profile:
-        merged = dict(_V4_AGENT_WEIGHTS)
-        merged.update(profile)
-        # Re-normalise to sum 1.0
-        total = sum(merged.values())
+    if isinstance(profile, dict) and profile:
+        weights = {str(k): float(v) for k, v in profile.items() if float(v or 0) > 0}
+        total = sum(weights.values())
         if total > 0:
-            return {k: round(v / total, 4) for k, v in merged.items()}
-    return dict(_V4_AGENT_WEIGHTS)
+            return {k: round(v / total, 4) for k, v in weights.items()}
+        return weights
+    try:
+        from config.deploy_loader import get_effective_weights
+
+        ew = get_effective_weights()
+        if ew:
+            weights = {k: float(v) for k, v in ew.items() if float(v or 0) > 0}
+            total = sum(weights.values())
+            if total > 0:
+                return {k: round(v / total, 4) for k, v in weights.items()}
+    except (ImportError, TypeError, ValueError):
+        pass
+    return _default_agent_weights()
 
 
 def _resolve_arbitrator_mode(state: HedgeFundState) -> str:
-    """Resolve the arbitrator mode.
+    """``agent_llm`` or ``weighted_convergence`` from state, then deploy JSON."""
+    if "use_llm_synthesis" in state:
+        return "agent_llm" if state.get("use_llm_synthesis") else "weighted_convergence"
+    mode = str(state.get("arbitrator_mode") or "").strip().lower()
+    if mode in ("agent_llm", "llm", "full_agentic"):
+        return "agent_llm"
+    if mode in ("weighted_convergence", "weighted", "measurement"):
+        return "weighted_convergence"
 
-    Priority:
-    1. ``state.arbitrator_mode`` (from runtime settings)
-    2. Deploy config active file
-    3. Default: ``agent_llm``
-    """
-    mode = state.get("arbitrator_mode") or ""
-    if mode in ("agent_llm", "weighted_convergence"):
-        if mode == "weighted_convergence":
-            logger.warning("weighted_convergence requested; using agent_llm (LLM required).")
-            return "agent_llm"
-        return mode
     try:
-        from config.deploy_loader import get_arbitrator_mode
+        from config.deploy_loader import get_use_llm_synthesis
 
-        deploy_mode = get_arbitrator_mode()
-        if deploy_mode in ("agent_llm", "weighted_convergence"):
-            if deploy_mode == "weighted_convergence":
-                return "agent_llm"
-            return deploy_mode
+        use_llm = get_use_llm_synthesis()
+        if use_llm is True:
+            return "agent_llm"
+        if use_llm is False:
+            return "weighted_convergence"
     except Exception:
         pass
 
-    env_mode = (os.environ.get("AIMM_ARBITRATOR_MODE") or "").strip().lower()
-    if env_mode == "agent_llm":
-        return "agent_llm"
-    if env_mode == "weighted_convergence":
-        return "agent_llm"
+    return "weighted_convergence"
 
-    return "agent_llm"
+
+def _execution_llm_flag(state: HedgeFundState, name: str) -> bool:
+    if name in state:
+        return bool(state.get(name))
+    try:
+        from config import deploy_loader
+
+        getter = getattr(deploy_loader, f"get_{name}", None)
+        if callable(getter):
+            return bool(getter())
+    except Exception:
+        pass
+    return False
+
+
+def _apply_llm_arbitration(
+    state: HedgeFundState, result: ArbitrationResult
+) -> tuple[ArbitrationResult, dict[str, Any] | None]:
+    if not _execution_llm_flag(state, "arbitrator_llm"):
+        return result, None
+    if check_api_key():
+        logger.warning("arbitrator_llm requested but no API key; using weighted math")
+        return result, None
+    overlay = infer_arbitrator_decision(
+        _compact_arbitration_for_reasoning(result),
+        dict(state),
+        ticker=str(state.get("ticker") or ""),
+    )
+    if overlay.get("source") != "agent_llm":
+        return result, overlay
+    action = str(overlay.get("action") or "HOLD").upper()
+    reasons = list(result.reasons)
+    reasons.extend(str(r) for r in (overlay.get("reasons") or []) if r)
+    if result.alignment_gated and action in ("BUY", "SELL"):
+        reasons.append("alignment_gated: LLM directional blocked")
+        action = "HOLD"
+    stance = str(overlay.get("stance") or result.stance)
+    conf = float(
+        overlay.get("confidence") if overlay.get("confidence") is not None else result.confidence
+    )
+    return (
+        replace(
+            result,
+            stance=stance,
+            confidence=conf,
+            reasons=reasons[:16],
+            buy_triggered=action == "BUY",
+            sell_triggered=action == "SELL",
+            hold_triggered=action == "HOLD",
+        ),
+        overlay,
+    )
 
 
 def _get_llm_enabled_agents(state: HedgeFundState) -> list[str]:
-    """Get agents with llm_enabled=True.
-
-    Priority:
-    1. ``AIMM_LLM_AGENTS`` env var — comma-separated agent IDs
-       (e.g. ``AIMM_LLM_AGENTS=2.1,2.3``). Overrides deploy config.
-    2. ``config/deploy.active.json`` → ``agents[id].llm_enabled: true``
-    3. ``state.profile_weights`` — agents with weight > 0 in the active preset
-    4. All known agents when no combination is configured.
-    """
-    # 1. Env var override (highest priority)
-    env_agents = os.environ.get("AIMM_LLM_AGENTS", "").strip()
-    if env_agents:
-        return [a.strip() for a in env_agents.split(",") if a.strip()]
-
-    # 2. Deploy config
+    """Agents allowed to call LLM — from deploy JSON, else weighted desks in state."""
     try:
-        from config.deploy_loader import get_deploy_agents
+        from config.deploy_loader import get_llm_enabled_agent_names
 
-        deploy_agents = get_deploy_agents()
-        if deploy_agents:
-            enabled = []
-            for aid, cfg in deploy_agents.items():
-                if isinstance(cfg, dict) and cfg.get("llm_enabled", False):
-                    enabled.append(aid)
-            if enabled:
-                return enabled
+        names = get_llm_enabled_agent_names()
+        if names is not None:
+            return list(names)
     except Exception:
         pass
 
-    # 3. Profile / preset weights — only LLM-call agents in the active combination.
     profile = state.get("profile_weights") or {}
     if isinstance(profile, dict) and profile:
         return [str(aid) for aid, w in profile.items() if float(w or 0) > 0]
 
-    # 4. Full-agentic fallback when no combination is configured.
-    _KNOWN_AGENTS = ["1.1", "1.2", "2.1", "2.2", "2.3", "3.1", "3.2", "4.1", "4.2"]
-    return list(_KNOWN_AGENTS)
+    try:
+        from config.deploy_loader import get_effective_weights
 
+        ew = get_effective_weights()
+        if ew:
+            return [k for k, w in ew.items() if float(w or 0) > 0]
+    except Exception:
+        pass
 
-def _tier0_contracts_by_agent(state: HedgeFundState) -> dict[str, dict[str, Any]]:
-    """Index tier0_contracts list by agent ID for fast lookup."""
-    contracts = state.get("tier0_contracts") or []
-    if not isinstance(contracts, list):
-        return {}
-    result: dict[str, dict[str, Any]] = {}
-    for c in contracts:
-        if isinstance(c, dict):
-            aid = c.get("agent", c.get("agent_id", ""))
-            if aid:
-                result[aid] = c
-    return result
+    return []
 
 
 def _inject_llm_signals(state: HedgeFundState) -> tuple[HedgeFundState, list[dict[str, Any]]]:
@@ -309,7 +319,7 @@ def _inject_llm_signals(state: HedgeFundState) -> tuple[HedgeFundState, list[dic
         len(llm_agents),
         llm_agents,
     )
-    deterministic = _tier0_contracts_by_agent(state)
+    deterministic = tier0_contracts_by_agent(state)
     primary_ticker = state.get("ticker", "")
 
     results: list[dict[str, Any] | None] = [None] * len(llm_agents)
@@ -357,6 +367,10 @@ def _inject_llm_signals(state: HedgeFundState) -> tuple[HedgeFundState, list[dic
         if result is None:
             continue
         llm_deltas.append(result)
+        if str(result.get("source") or "") == "error":
+            # Keep the deterministic desk contract. Replacing it with a
+            # neutral error stub zeros TA and can flip the bar's trade.
+            continue
         tier0 = list(state.get("tier0_contracts") or [])
         replaced = False
         for j, c in enumerate(tier0):
@@ -389,17 +403,13 @@ def weighted_arbitrator_node(state: HedgeFundState) -> dict[str, Any]:
       - ``trade_intent``   — derived via ``derive_trade_intent``
       - ``reasoning_logs`` — per-agent scores + final decision
     """
-    # agent_llm mode: inject LLM signals before arbitration
     state, llm_deltas = _inject_llm_signals(state)
 
-    # Resolve weights (supports Profile Agent injection)
     agent_weights = _resolve_agent_weights(state)
     profile_id = state.get("profile_id") or ""
 
-    # Check if tier0 contracts exist
     idx = tier0_contracts_by_agent(state)
     if not idx:
-        # Fallback: no Tier-0 data, return neutral
         result = ArbitrationResult(
             composite_score=0.5,
             confidence=0.0,
@@ -408,21 +418,29 @@ def weighted_arbitrator_node(state: HedgeFundState) -> dict[str, Any]:
             reasons=["weighted_arbitrator: no Tier-0 contracts available"],
             agent_signals=[],
         )
+        arb_overlay = None
     else:
         result = compute_weighted_arbitration(
             state,
             agent_weights=agent_weights,
-            disabled_agents=_V4_DISABLED_AGENTS,
             decision_threshold=_resolve_decision_threshold(state),
         )
+        result, arb_overlay = _apply_llm_arbitration(state, result)
 
     proposed_signal = _arbitration_to_proposed_signal(result, state)
+    if arb_overlay and arb_overlay.get("source") == "agent_llm":
+        params = dict(proposed_signal.get("params") or {})
+        params["llm_arbitrator"] = True
+        proposed_signal["params"] = params
+        meta = dict(proposed_signal.get("meta") or {})
+        meta["source"] = "weighted_arbitrator+llm"
+        proposed_signal["meta"] = meta
     intent = derive_trade_intent(state, proposed_signal)
 
     compact = _compact_arbitration_for_reasoning(result)
     board = build_synthesis_board(state)
 
-    weight_source = "profile" if profile_id else "default"
+    weight_source = "profile" if profile_id else "deploy"
 
     reasoning_logs = [
         _reasoning_entry(
@@ -431,6 +449,11 @@ def weighted_arbitrator_node(state: HedgeFundState) -> dict[str, Any]:
                 f"Weighted convergence arbitration complete. "
                 f"Stance={result.stance}, composite={result.composite_score:.4f}, "
                 f"confidence={result.confidence:.4f}, conviction={result.conviction_level}."
+                + (
+                    f" LLM arbitrator: {arb_overlay.get('action')} ({arb_overlay.get('stance')})."
+                    if arb_overlay and arb_overlay.get("source") == "agent_llm"
+                    else ""
+                )
             ),
             decision=compact,
             extra={
@@ -441,6 +464,7 @@ def weighted_arbitrator_node(state: HedgeFundState) -> dict[str, Any]:
                 "buy_triggered": result.buy_triggered,
                 "sell_triggered": result.sell_triggered,
                 "synthesis_board_present": bool(board.get("bull_case")),
+                "arbitrator_llm": bool(arb_overlay and arb_overlay.get("source") == "agent_llm"),
             },
         ),
         _reasoning_entry(
@@ -451,7 +475,7 @@ def weighted_arbitrator_node(state: HedgeFundState) -> dict[str, Any]:
         ),
     ]
 
-    # Per-agent reasoning entries for transparency
+    # Per-agent reasoning for the transcript
     for sig in result.agent_signals:
         if not sig.enabled:
             continue

--- a/tests/test_agent_llm_parse_retry.py
+++ b/tests/test_agent_llm_parse_retry.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from llm.agent_llm_client import infer_agent
+from workflow.weighted_arbitrator import _inject_llm_signals
+
+
+class _FakeCompletions:
+    def __init__(self, contents: list[str]) -> None:
+        self.contents = list(contents)
+        self.kwargs: list[dict] = []
+
+    def create(self, **kwargs):
+        self.kwargs.append(kwargs)
+        text = self.contents.pop(0) if self.contents else ""
+        msg = SimpleNamespace(content=text)
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        return SimpleNamespace(choices=[choice])
+
+
+def _fake_client(contents: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(chat=SimpleNamespace(completions=_FakeCompletions(contents)))
+
+
+def test_infer_agent_parses_json(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "llm.agent_llm_client._get_client",
+        lambda: _fake_client(['{"ta_indicators": {"rsi": 61}}']),
+    )
+    monkeypatch.setattr("llm.agent_llm_client.get_default_model", lambda: "test-model")
+    monkeypatch.setattr("llm.agent_llm_client._get_decision_cache", lambda: {})
+    out = infer_agent("technical_ta_engine", {"ticker": "BTC/USDT"}, ticker="BTC/USDT")
+    assert out["source"] == "agent_llm"
+    assert out["ta_indicators"]["rsi"] == 61
+
+
+def test_infer_agent_retries_unparseable(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "llm.agent_llm_client._get_client",
+        lambda: _fake_client(["not json", '{"ta_indicators": {"rsi": 61}}']),
+    )
+    monkeypatch.setattr("llm.agent_llm_client.get_default_model", lambda: "test-model")
+    monkeypatch.setattr("llm.agent_llm_client._get_decision_cache", lambda: {})
+    out = infer_agent("technical_ta_engine", {"ticker": "BTC/USDT"}, ticker="BTC/USDT")
+    assert out["source"] == "agent_llm"
+    assert out["ta_indicators"]["rsi"] == 61
+
+
+def test_infer_agent_disables_thinking(monkeypatch) -> None:
+    fake = _fake_client(['{"ta_indicators": {"rsi": 50}}'])
+    monkeypatch.setattr("llm.agent_llm_client._get_client", lambda: fake)
+    monkeypatch.setattr("llm.agent_llm_client.get_default_model", lambda: "test-model")
+    monkeypatch.setattr("llm.agent_llm_client._get_decision_cache", lambda: {})
+    infer_agent("technical_ta_engine", {"ticker": "BTC/USDT"}, ticker="BTC/USDT")
+    assert fake.chat.completions.kwargs[0]["extra_body"] == {"thinking": {"type": "disabled"}}
+
+
+def test_llm_error_keeps_deterministic_contract(monkeypatch) -> None:
+    monkeypatch.setattr("workflow.weighted_arbitrator.check_api_key", lambda: None)
+    monkeypatch.setattr(
+        "workflow.weighted_arbitrator._get_llm_enabled_agents",
+        lambda _s: ["technical_ta_engine"],
+    )
+    monkeypatch.setattr(
+        "workflow.weighted_arbitrator.infer_agent",
+        lambda *_a, **_k: {
+            "agent_id": "technical_ta_engine",
+            "source": "error",
+            "composite": 50,
+            "confidence": 0.0,
+        },
+    )
+    state = {
+        "use_llm_synthesis": True,
+        "arbitrator_mode": "agent_llm",
+        "tier0_contracts": [
+            {
+                "agent_id": "technical_ta_engine",
+                "source": "tier0",
+                "ta_indicators": {"rsi": 61.0},
+            }
+        ],
+    }
+    out, deltas = _inject_llm_signals(state)
+    assert out["tier0_contracts"][0]["ta_indicators"]["rsi"] == 61.0
+    assert deltas[0]["source"] == "error"
+
+
+def test_apply_llm_arbitration_alignment_blocks_buy(monkeypatch) -> None:
+    from schemas.arbitration import ArbitrationResult
+    from workflow.weighted_arbitrator import _apply_llm_arbitration
+
+    monkeypatch.setattr("workflow.weighted_arbitrator.check_api_key", lambda: None)
+    monkeypatch.setattr(
+        "workflow.weighted_arbitrator.infer_arbitrator_decision",
+        lambda *_a, **_k: {
+            "source": "agent_llm",
+            "action": "BUY",
+            "stance": "bullish",
+            "confidence": 0.8,
+            "reasons": ["llm buy"],
+        },
+    )
+    math = ArbitrationResult(
+        composite_score=0.4,
+        confidence=0.2,
+        stance="neutral",
+        conviction_level="low",
+        reasons=["math hold"],
+        alignment_gated=True,
+        buy_triggered=False,
+        sell_triggered=False,
+        hold_triggered=True,
+    )
+    out, overlay = _apply_llm_arbitration({"arbitrator_llm": True, "ticker": "BTC/USDT"}, math)
+    assert overlay["source"] == "agent_llm"
+    assert out.buy_triggered is False
+    assert out.hold_triggered is True
+    assert any("alignment_gated" in r for r in out.reasons)

--- a/tests/test_agent_registry_deploy.py
+++ b/tests/test_agent_registry_deploy.py
@@ -1,0 +1,130 @@
+"""Agent registry + deploy-JSON agentic config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agents.registry import get_registry
+
+
+def test_registry_resolves_names_only():
+    reg = get_registry()
+    spec = reg.get("technical_ta_engine")
+    assert spec is not None
+    assert spec.name == "technical_ta_engine"
+    assert spec.label == "Technical Analysis"
+    assert reg.get("2.3") is None
+
+
+def test_deploy_loader_agents_and_weights(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    deploy = {
+        "agents": {
+            "technical_ta_engine": {"weight": 0.6, "llm_enabled": True, "enabled": True},
+            "pattern_recognition_bot": {"weight": 0.4, "llm_enabled": False},
+            "statistical_alpha_engine": {"weight": 0.0, "enabled": False},
+        },
+        "execution": {"use_llm_synthesis": True, "desk_debate_llm": False, "arbitrator_llm": True},
+    }
+    path = tmp_path / "deploy.active.json"
+    path.write_text(json.dumps(deploy), encoding="utf-8")
+    monkeypatch.setenv("AIMM_DEPLOY_CONFIG_PATH", str(path))
+
+    from config import deploy_loader
+
+    agents = deploy_loader.get_deploy_agents()
+    assert agents is not None
+    assert "technical_ta_engine" in agents
+    assert agents["technical_ta_engine"]["llm_enabled"] is True
+
+    weights = deploy_loader.get_effective_weights()
+    assert weights is not None
+    assert weights.get("technical_ta_engine") == pytest.approx(0.6)
+    assert weights.get("pattern_recognition_bot") == pytest.approx(0.4)
+    assert "statistical_alpha_engine" not in weights
+
+    assert deploy_loader.get_use_llm_synthesis() is True
+    assert deploy_loader.get_desk_debate_llm() is False
+    assert deploy_loader.get_arbitrator_mode() == "agent_llm"
+    assert deploy_loader.get_arbitrator_llm() is True
+    assert deploy_loader.get_llm_enabled_agent_names() == ["technical_ta_engine"]
+    assert deploy_loader.get_enabled_agent_names() == [
+        "technical_ta_engine",
+        "pattern_recognition_bot",
+    ]
+    assert deploy_loader.resolve_tier0_graph_nodes() == [
+        "pattern_recognition_bot",
+        "technical_ta_engine",
+    ]
+
+
+def test_deploy_loader_drops_unknown_agent_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    path = tmp_path / "deploy.active.json"
+    path.write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "technical_ta_engine": {"weight": 1.0, "enabled": True},
+                    "not_a_real_agent": {"weight": 0.5, "enabled": True},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AIMM_DEPLOY_CONFIG_PATH", str(path))
+    from config import deploy_loader
+
+    agents = deploy_loader.get_deploy_agents()
+    assert agents is not None
+    assert "not_a_real_agent" not in agents
+    assert "technical_ta_engine" in agents
+
+
+def test_resolve_agent_weights_does_not_merge_defaults():
+    from workflow.weighted_arbitrator import _resolve_agent_weights
+
+    w = _resolve_agent_weights(
+        {"profile_weights": {"technical_ta_engine": 0.75, "pattern_recognition_bot": 0.25}}
+    )
+    assert set(w) == {"technical_ta_engine", "pattern_recognition_bot"}
+    assert w["technical_ta_engine"] == pytest.approx(0.75)
+    assert w["pattern_recognition_bot"] == pytest.approx(0.25)
+
+
+def test_resolve_arbitrator_mode_defaults_to_weighted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setenv("AIMM_DEPLOY_CONFIG_PATH", str(tmp_path / "missing.json"))
+    from workflow.weighted_arbitrator import _resolve_arbitrator_mode
+
+    assert _resolve_arbitrator_mode({}) == "weighted_convergence"
+
+
+def test_get_effective_weights_ignores_legacy_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "deploy.active.json"
+    path.write_text(
+        json.dumps(
+            {
+                "effective_weights": {"technical_ta_engine": 0.9},
+                "execution": {"use_llm_synthesis": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AIMM_DEPLOY_CONFIG_PATH", str(path))
+    from config import deploy_loader
+
+    assert deploy_loader.get_effective_weights() is None
+
+
+def test_omitted_overlay_flags_default_false(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    path = tmp_path / "deploy.active.json"
+    path.write_text(json.dumps({"execution": {"use_llm_synthesis": True}}), encoding="utf-8")
+    monkeypatch.setenv("AIMM_DEPLOY_CONFIG_PATH", str(path))
+    from config import deploy_loader
+
+    assert deploy_loader.get_arbitrator_llm() is False

--- a/tests/test_agentic_trading_e2e.py
+++ b/tests/test_agentic_trading_e2e.py
@@ -14,7 +14,7 @@ from nexus_agentic_fixtures import (
 import main as main_mod
 from config.run_mode import RunMode
 from schemas.state import initial_hedge_fund_state
-from schemas.tier0_contract import TIER0_NODE_TO_AGENT_ID, tier0_consensus_for_arbitrator
+from schemas.tier0_contract import TIER0_AGENT_NAMES, tier0_consensus_for_arbitrator
 
 
 class _StubMarketScanAgent:
@@ -92,7 +92,6 @@ class _StubNexusAdapter:
 @pytest.fixture
 def agentic_stubs(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-stub")
-    monkeypatch.setenv("AIMM_ARBITRATOR_MODE", "agent_llm")
 
     def _stub_llm_proposal(state):
         tk = state.get("ticker", "BTC/USDT")
@@ -126,15 +125,19 @@ def agentic_stubs(monkeypatch):
                 "status": "success",
             }
         )
-        if agent_id == "2.1" and "Setup_Score" not in out:
+        if agent_id == "pattern_recognition_bot" and "Setup_Score" not in out:
             out["Setup_Score"] = 65
-        if agent_id == "2.3" and "ta_indicators" not in out:
+        if agent_id == "technical_ta_engine" and "ta_indicators" not in out:
             out["ta_indicators"] = {"rsi": 55, "macd_signal": "buy"}
         return out
 
     monkeypatch.setattr(main_mod, "llm_portfolio_proposal", _stub_llm_proposal)
     monkeypatch.setattr(main_mod, "llm_portfolio_execute", _stub_llm_execute)
     monkeypatch.setattr("workflow.weighted_arbitrator.infer_agent", _stub_infer_agent)
+    monkeypatch.setattr(
+        "workflow.weighted_arbitrator.infer_arbitrator_decision",
+        lambda *_a, **_k: {"source": "error"},
+    )
     monkeypatch.setattr(main_mod, "MarketScanAgent", _StubMarketScanAgent)
     monkeypatch.setattr(main_mod, "RiskManagementAgent", _StubRiskManagementAgent)
     monkeypatch.setattr(main_mod, "RiskGuardAgent", _StubRiskGuardAgent)
@@ -162,12 +165,12 @@ def test_agentic_graph_emits_all_tier0_contracts(agentic_stubs, monkeypatch):
 
     state = _base_state(nexus_bundle=nexus_bundle_bullish_btc())
     state["arbitrator_mode"] = "agent_llm"
-    app = main_mod.build_workflow().compile()
+    app = main_mod.build_workflow(tier0_nodes=sorted(TIER0_AGENT_NAMES)).compile()
     out = app.invoke(state)
 
     contracts = out.get("tier0_contracts") or []
     agents = {str(c.get("agent")) for c in contracts if isinstance(c, dict) and c.get("agent")}
-    assert agents == set(TIER0_NODE_TO_AGENT_ID.values())
+    assert agents == set(TIER0_AGENT_NAMES)
 
 
 def test_agentic_bullish_nexus_drives_buy_intent(agentic_stubs, monkeypatch):
@@ -175,7 +178,7 @@ def test_agentic_bullish_nexus_drives_buy_intent(agentic_stubs, monkeypatch):
 
     state = _base_state(nexus_bundle=nexus_bundle_bullish_btc())
     state["arbitrator_mode"] = "agent_llm"
-    app = main_mod.build_workflow().compile()
+    app = main_mod.build_workflow(tier0_nodes=sorted(TIER0_AGENT_NAMES)).compile()
     out = app.invoke(state)
 
     tc = tier0_consensus_for_arbitrator(out)
@@ -200,7 +203,7 @@ def test_agentic_risk_off_nexus_suppresses_buy(agentic_stubs, monkeypatch):
 
     state = _base_state(nexus_bundle=nexus_bundle_risk_off_btc())
     state["arbitrator_mode"] = "agent_llm"
-    app = main_mod.build_workflow().compile()
+    app = main_mod.build_workflow(tier0_nodes=sorted(TIER0_AGENT_NAMES)).compile()
     out = app.invoke(state)
 
     tc = tier0_consensus_for_arbitrator(out)

--- a/tests/test_backtest_config.py
+++ b/tests/test_backtest_config.py
@@ -11,6 +11,7 @@ import pytest
 
 from backtest.config import (
     ARBITRATOR_AGENT_LLM,
+    ARBITRATOR_WEIGHTED_CONVERGENCE,
     resolve_backtest_config,
     resolve_tp_sl_pct,
     set_env_from_config,
@@ -25,7 +26,6 @@ def _sample_deploy_config(
     lev: float = 5.0,
 ) -> dict:
     return {
-        "effective_weights": {"agent_1": 0.15, "agent_2": 0.2},
         "execution": {
             "arbitrator_mode": mode,
             "take_profit_pct": tp,
@@ -33,17 +33,24 @@ def _sample_deploy_config(
             "leverage": lev,
         },
         "profile": {"profile_id": "test-profile-v1"},
-        "agents": {},
+        "agents": {
+            "technical_ta_engine": {"weight": 0.15, "enabled": True},
+            "pattern_recognition_bot": {"weight": 0.2, "enabled": True},
+        },
     }
 
 
 class TestResolveBacktestConfig:
     def test_defaults(self):
         cfg = resolve_backtest_config(deploy_path="/nonexistent/aimm-deploy-missing.json")
-        assert cfg["arbitrator_mode"] == ARBITRATOR_AGENT_LLM
-        assert cfg["use_llm"] is True
+        assert cfg["arbitrator_mode"] == ARBITRATOR_WEIGHTED_CONVERGENCE
+        assert cfg["use_llm"] is False
         assert cfg["deploy_loaded"] is False
-        assert cfg["profile_weights"] == {"2.3": 0.55, "2.1": 0.15, "1.1": 0.25}
+        assert cfg["profile_weights"] == {
+            "technical_ta_engine": 0.55,
+            "pattern_recognition_bot": 0.15,
+            "monetary_sentinel": 0.25,
+        }
         assert cfg["profile_id"] == "macro_tilt"
         assert cfg["allows_short"] is True
         assert cfg["decision_threshold"]["ta_led"]["enabled"] is True
@@ -56,7 +63,11 @@ class TestResolveBacktestConfig:
         cfg = resolve_backtest_config(deploy_path=str(deploy))
         assert cfg["deploy_loaded"] is True
         assert cfg["profile_id"] == "macro_tilt"
-        assert cfg["profile_weights"] == {"2.3": 0.55, "2.1": 0.15, "1.1": 0.25}
+        assert cfg["profile_weights"] == {
+            "technical_ta_engine": 0.55,
+            "pattern_recognition_bot": 0.15,
+            "monetary_sentinel": 0.25,
+        }
         assert cfg["leverage"] == 2.0
 
     def test_deploy_config_loaded(self):
@@ -71,7 +82,10 @@ class TestResolveBacktestConfig:
             assert cfg["stop_loss_pct"] == 5.0
             assert cfg["leverage"] == 5.0
             assert cfg["profile_id"] == "test-profile-v1"
-            assert cfg["profile_weights"] == {"agent_1": 0.15, "agent_2": 0.2}
+            assert cfg["profile_weights"] == {
+                "technical_ta_engine": 0.15,
+                "pattern_recognition_bot": 0.2,
+            }
 
     def test_cli_override_wins_over_deploy(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -82,26 +96,25 @@ class TestResolveBacktestConfig:
                 cli_arbitrator_mode="weighted_convergence",
                 cli_tp_sl_pct=3.0,
             )
-            assert cfg["arbitrator_mode"] == ARBITRATOR_AGENT_LLM
-            assert cfg["use_llm"] is True
+            assert cfg["arbitrator_mode"] == ARBITRATOR_WEIGHTED_CONVERGENCE
+            assert cfg["use_llm"] is False
             assert cfg["take_profit_pct"] == 3.0
             assert cfg["stop_loss_pct"] == 3.0
             assert cfg["deploy_loaded"] is True
 
-    def test_env_arbitrator_mode(self):
-        cfg = resolve_backtest_config(env={"AIMM_ARBITRATOR_MODE": "agent_llm"})
-        assert cfg["arbitrator_mode"] == ARBITRATOR_AGENT_LLM
-        assert cfg["use_llm"] is True
-
-    def test_env_use_llm(self):
-        cfg = resolve_backtest_config(env={"AI_MARKET_MAKER_USE_LLM": "1"})
-        assert cfg["arbitrator_mode"] == ARBITRATOR_AGENT_LLM
-        assert cfg["use_llm"] is True
+    def test_env_strategy_flags_ignored(self):
+        cfg = resolve_backtest_config(
+            deploy_path="/nonexistent/deploy.json",
+            env={"AIMM_ARBITRATOR_MODE": "agent_llm", "AI_MARKET_MAKER_USE_LLM": "1"},
+        )
+        assert cfg["deploy_loaded"] is False
+        assert cfg["arbitrator_mode"] == ARBITRATOR_WEIGHTED_CONVERGENCE
+        assert cfg["use_llm"] is False
 
     def test_deploy_no_file_fallback(self):
         cfg = resolve_backtest_config(deploy_path="/nonexistent/deploy.json")
         assert cfg["deploy_loaded"] is False
-        assert cfg["arbitrator_mode"] == ARBITRATOR_AGENT_LLM
+        assert cfg["arbitrator_mode"] == ARBITRATOR_WEIGHTED_CONVERGENCE
 
     def test_cli_leverage(self):
         cfg = resolve_backtest_config(
@@ -123,9 +136,11 @@ class TestResolveBacktestConfig:
             deploy_path.write_text(
                 json.dumps(
                     {
-                        "effective_weights": {"2.3": 1.0},
                         "execution": {"arbitrator_mode": "agent_llm", "leverage": 2.0},
                         "profile": {"profile_id": "no-tp-sl"},
+                        "agents": {
+                            "technical_ta_engine": {"weight": 1.0, "enabled": True},
+                        },
                     }
                 ),
                 encoding="utf-8",
@@ -178,17 +193,21 @@ class TestResolveTpSlPct:
 
 
 class TestSetEnvFromConfig:
-    def test_sets_agent_llm_env(self):
+    def test_clears_strategy_env(self):
+        os.environ["AIMM_ARBITRATOR_MODE"] = "agent_llm"
+        os.environ["AIMM_LLM_AGENTS"] = "technical_ta_engine"
         cfg = resolve_backtest_config(cli_arbitrator_mode="agent_llm")
         set_env_from_config(cfg)
-        assert os.environ.get("AIMM_ARBITRATOR_MODE") == "agent_llm"
-        assert os.environ.get("AI_MARKET_MAKER_USE_LLM") is None
-        assert os.environ.get("AIMM_LLM_MODE") is None
+        assert os.environ.get("AIMM_ARBITRATOR_MODE") is None
+        assert os.environ.get("AIMM_LLM_AGENTS") is None
+        assert os.environ.get("MODE") == "backtest"
 
-    def test_weighted_convergence_upgrades_to_agent_llm(self):
+    def test_weighted_cli_preserved_in_cfg(self):
         cfg = resolve_backtest_config(cli_arbitrator_mode="weighted_convergence")
+        assert cfg["arbitrator_mode"] == ARBITRATOR_WEIGHTED_CONVERGENCE
+        assert cfg["use_llm"] is False
         set_env_from_config(cfg)
-        assert os.environ.get("AIMM_ARBITRATOR_MODE") == "agent_llm"
+        assert os.environ.get("AIMM_ARBITRATOR_MODE") is None
 
     def test_deploy_active_signal(self):
         cfg = resolve_backtest_config(deploy_path="/nonexistent")
@@ -201,6 +220,7 @@ class TestSetEnvFromConfig:
         os.environ.pop("AIMM_DEPLOY_ACTIVE", None)
         os.environ.pop("AI_MARKET_MAKER_USE_LLM", None)
         os.environ.pop("AIMM_LLM_MODE", None)
+        os.environ.pop("AIMM_LLM_AGENTS", None)
 
 
 class TestLoopResolvedConfigStamp:

--- a/tests/test_backtest_parity_integration.py
+++ b/tests/test_backtest_parity_integration.py
@@ -10,28 +10,34 @@ from pathlib import Path
 from backtest.config import resolve_backtest_config, set_env_from_config
 
 DEPLOY_AGENT_LLM = {
-    "effective_weights": {"agent_a": 0.3, "agent_b": 0.2},
     "execution": {
-        "arbitrator_mode": "agent_llm",
-        "take_profit_pct": 0.05,  # fraction → 5.0%
+        "use_llm_synthesis": True,
+        "arbitrator_llm": True,
+        "take_profit_pct": 0.05,
         "stop_loss_pct": 0.05,
         "leverage": 5.0,
         "max_hold_bars": 48,
     },
     "profile": {"profile_id": "prod-v2"},
-    "agents": {"agent_a": {}, "agent_b": {}},
+    "agents": {
+        "technical_ta_engine": {"weight": 0.3, "enabled": True},
+        "pattern_recognition_bot": {"weight": 0.2, "enabled": True},
+    },
 }
 
 DEPLOY_WEIGHTED = {
-    "effective_weights": {"trend": 0.5, "momentum": 0.5},
     "execution": {
-        "arbitrator_mode": "weighted_convergence",
-        "take_profit_pct": 0.03,  # fraction → 3.0%
+        "use_llm_synthesis": False,
+        "arbitrator_llm": False,
+        "take_profit_pct": 0.03,
         "stop_loss_pct": 0.03,
         "leverage": 3.0,
     },
     "profile": {"profile_id": "quant-v1"},
-    "agents": {},
+    "agents": {
+        "technical_ta_engine": {"weight": 0.5, "enabled": True},
+        "pattern_recognition_bot": {"weight": 0.5, "enabled": True},
+    },
 }
 
 
@@ -46,19 +52,19 @@ class TestConfigParity:
             assert cfg["use_llm"] is True
             assert cfg["deploy_loaded"] is True
             assert cfg["profile_id"] == "prod-v2"
-            assert cfg["profile_weights"] == {"agent_a": 0.3, "agent_b": 0.2}
+            assert cfg["profile_weights"]["technical_ta_engine"] == 0.3
             assert cfg["take_profit_pct"] == 5.0
             assert cfg["stop_loss_pct"] == 5.0
             assert cfg["max_hold_bars"] == 48
 
-    def test_weighted_mode_upgrades_to_agent_llm(self):
+    def test_weighted_mode_stays_weighted(self):
         with tempfile.TemporaryDirectory() as tmp:
             dp = Path(tmp) / "deploy.active.json"
             dp.write_text(json.dumps(DEPLOY_WEIGHTED), encoding="utf-8")
             cfg = resolve_backtest_config(deploy_path=str(dp))
 
-            assert cfg["arbitrator_mode"] == "agent_llm"
-            assert cfg["use_llm"] is True
+            assert cfg["arbitrator_mode"] == "weighted_convergence"
+            assert cfg["use_llm"] is False
             assert cfg["take_profit_pct"] == 3.0
             assert cfg["leverage"] == 3.0
 
@@ -73,16 +79,17 @@ class TestConfigParity:
             assert cfg["arbitrator_mode"] == "agent_llm"
             assert cfg["use_llm"] is True
 
-    def test_set_env_agent_llm(self):
+    def test_set_env_clears_strategy_env(self):
+        os.environ["AIMM_ARBITRATOR_MODE"] = "agent_llm"
         cfg = resolve_backtest_config(cli_arbitrator_mode="agent_llm")
         set_env_from_config(cfg)
-        assert os.environ.get("AIMM_ARBITRATOR_MODE") == "agent_llm"
+        assert os.environ.get("AIMM_ARBITRATOR_MODE") is None
 
-    def test_set_env_weighted_upgrades(self):
+    def test_set_env_weighted_does_not_force_llm_env(self):
         cfg = resolve_backtest_config(cli_arbitrator_mode="weighted_convergence")
         set_env_from_config(cfg)
-        assert os.environ.get("AIMM_ARBITRATOR_MODE") == "agent_llm"
-        assert os.environ.get("AI_MARKET_MAKER_USE_LLM") is None
+        assert os.environ.get("AIMM_ARBITRATOR_MODE") is None
+        assert cfg["use_llm"] is False
 
 
 class TestDefaultDeployPath:
@@ -104,8 +111,6 @@ class TestDefaultDeployPath:
         if "AIMM_DEPLOY_CONFIG_PATH" in os.environ:
             del os.environ["AIMM_DEPLOY_CONFIG_PATH"]
 
-        # Default path is config/deploy.active.json relative to CWD; use an empty
-        # temp tree so the shipped repo file does not count as "loaded".
         with tempfile.TemporaryDirectory() as tmp:
             orig_cwd = os.getcwd()
             try:
@@ -114,22 +119,16 @@ class TestDefaultDeployPath:
             finally:
                 os.chdir(orig_cwd)
         assert cfg["deploy_loaded"] is False
-        assert cfg["arbitrator_mode"] == "agent_llm"
-        assert cfg["use_llm"] is True
+        assert cfg["arbitrator_mode"] == "weighted_convergence"
+        assert cfg["use_llm"] is False
 
 
 class TestEnvParity:
-    def test_env_ai_market_maker_use_llm(self):
-        cfg = resolve_backtest_config(env={"AI_MARKET_MAKER_USE_LLM": "1"})
-        assert cfg["arbitrator_mode"] == "agent_llm"
-        assert cfg["use_llm"] is True
-
     def test_env_deploy_path(self):
         with tempfile.TemporaryDirectory() as tmp:
             dp = Path(tmp) / "my_deploy.json"
             dp.write_text(json.dumps(DEPLOY_AGENT_LLM), encoding="utf-8")
             cfg = resolve_backtest_config(
-                deploy_path=str(dp),
                 env={"AIMM_DEPLOY_CONFIG_PATH": str(dp)},
             )
             assert cfg["deploy_loaded"] is True

--- a/tests/test_backtest_ta_warmup_engine.py
+++ b/tests/test_backtest_ta_warmup_engine.py
@@ -50,7 +50,7 @@ def test_warmup_bars_skip_workflow(monkeypatch):
                 "min_warmup_bars": 5,
                 "eval_steps": 8,
                 "ta_warmup_bars": 5,
-                "deploy_profile_weights": {"2.3": 1.0},
+                "deploy_profile_weights": {"technical_ta_engine": 1.0},
                 "interval_sec": 86_400,
             }
         )

--- a/tests/test_backtest_terminal_log.py
+++ b/tests/test_backtest_terminal_log.py
@@ -18,17 +18,21 @@ def test_print_bar_decision_includes_cot(monkeypatch):
     configure_backtest_terminal_logging()
     buf = io.StringIO()
     wf = {
-        "profile_weights": {"2.3": 0.55, "2.1": 0.15, "1.1": 0.25},
+        "profile_weights": {
+            "technical_ta_engine": 0.55,
+            "pattern_recognition_bot": 0.15,
+            "monetary_sentinel": 0.25,
+        },
         "tier0_contracts": [
             {
-                "agent_id": "2.3",
+                "agent_id": "technical_ta_engine",
                 "label": "Technical TA Engine",
                 "composite": 61.2,
                 "stance": "bullish",
                 "source": "agent_llm",
                 "reasoning": "RSI neutral; MACD histogram turning positive.",
             },
-            {"agent_id": "4.2", "status": "skipped", "source": None},
+            {"agent_id": "liquidity_order_flow", "status": "skipped", "source": None},
         ],
         "arbitration_result": {"composite": 58.0, "confidence": 0.68, "stance": "bullish"},
         "trade_intent": {"action": "BUY", "confidence": 0.68},
@@ -49,9 +53,9 @@ def test_print_bar_decision_includes_cot(monkeypatch):
     text = buf.getvalue()
     assert "Bar   10/90" in text
     assert "BTC/USDT" in text
-    assert "2.3" in text
+    assert "technical_ta_engine" in text
     assert "MACD histogram" in text
-    assert "4.2" not in text
+    assert "liquidity_order_flow" not in text
     assert "Desk deliberation" in text
     assert "Decision: BUY" in text
     assert "equity $10,842.00" in text
@@ -65,10 +69,10 @@ def test_print_bar_enriches_scores_from_reasoning_logs(monkeypatch):
     configure_backtest_terminal_logging()
     buf = io.StringIO()
     wf = {
-        "profile_weights": {"2.3": 0.55, "1.1": 0.25},
+        "profile_weights": {"technical_ta_engine": 0.55, "monetary_sentinel": 0.25},
         "tier0_contracts": [
             {
-                "agent_id": "2.3",
+                "agent_id": "technical_ta_engine",
                 "label": "Technical TA Engine",
                 "source": "agent_llm",
                 "reasoning": "RSI at 51; MACD hist positive.",
@@ -77,7 +81,7 @@ def test_print_bar_enriches_scores_from_reasoning_logs(monkeypatch):
         "reasoning_logs": [
             {
                 "node": "weighted_arbitrator",
-                "extra": {"agent_id": "2.3"},
+                "extra": {"agent_id": "technical_ta_engine"},
                 "decision": {"composite": 0.57, "confidence": 0.64, "stance": "bullish"},
             }
         ],
@@ -100,6 +104,29 @@ def test_print_bar_enriches_scores_from_reasoning_logs(monkeypatch):
     assert "▲ bullish" in text
     assert "MACD hist" in text
     assert "desks neutral" in text or "TA-led" in text or "composite gates" in text
+
+
+def test_print_bar_hold_still_logs(monkeypatch):
+    monkeypatch.setenv("MODE", "backtest")
+    monkeypatch.setenv("AIMM_BACKTEST_TERMINAL_LOG", "1")
+    configure_backtest_terminal_logging()
+    buf = io.StringIO()
+    print_bar_decision(
+        bar_index=51,
+        total_bars=80,
+        symbol="BTC/USDT",
+        close=59577.0,
+        ts_ms=1_783_036_800_000,
+        wf_output={
+            "arbitration_result": {"composite": 0.4, "confidence": 0.05, "stance": "neutral"}
+        },
+        action="HOLD",
+        confidence=0.05,
+        equity=10_000.0,
+        stream=buf,
+    )
+    assert "Bar   51/80" in buf.getvalue()
+    assert "Decision: HOLD" in buf.getvalue()
 
 
 def test_terminal_log_disabled(monkeypatch):

--- a/tests/test_config_designer.py
+++ b/tests/test_config_designer.py
@@ -1,0 +1,18 @@
+"""Config Designer validation (outside-graph)."""
+
+from agents.config_designer import ConfigDesignerAgent, validate_deploy_draft
+
+
+def test_unknown_agent_key_warns():
+    warnings = validate_deploy_draft(
+        {"agents": {"not_a_real_agent": {"weight": 1.0, "enabled": True}}}
+    )
+    assert any("Unknown agent key: not_a_real_agent" in w for w in warnings)
+
+
+def test_seed_macro_tilt_is_valid():
+    result = ConfigDesignerAgent().seed_style("macro_tilt")
+    assert result.draft_config is not None
+    assert "technical_ta_engine" in result.draft_config["agents"]
+    assert result.draft_config["execution"]["arbitrator_llm"] is True
+    assert result.warnings == []

--- a/tests/test_decision_cache.py
+++ b/tests/test_decision_cache.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from llm.agent_llm_client import _date_tag_from_state, _prompt_hash
+from llm.decision_cache import read_cached_decision, write_cached_decision
+
+
+def test_date_tag_prefers_backtest_window_ts() -> None:
+    state = {
+        "ts_ms": 1,
+        "shared_memory": {"backtest": {"window_last_ts_ms": 1_700_000_000_000}},
+    }
+    assert _date_tag_from_state(state) == "1700000000000"
+
+
+def test_date_tag_falls_back_to_ts_ms() -> None:
+    assert _date_tag_from_state({"ts_ms": 42}) == "42"
+
+
+def test_date_tag_na_when_missing() -> None:
+    assert _date_tag_from_state({}) == "na"
+
+
+def test_decision_cache_roundtrip(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIMM_DECISION_CACHE_DIR", str(tmp_path))
+    prompt_hash = _prompt_hash("sys\nuser")
+    decision = {"stance": "bullish", "confidence": 0.7}
+    write_cached_decision("technical_ta_engine", "BTC/USDT", "1", prompt_hash, decision)
+    hit = read_cached_decision("technical_ta_engine", "BTC/USDT", "1", prompt_hash)
+    assert hit == decision
+    assert read_cached_decision("technical_ta_engine", "BTC/USDT", "2", prompt_hash) is None

--- a/tests/test_llm_env.py
+++ b/tests/test_llm_env.py
@@ -23,11 +23,11 @@ def test_use_llm_returns_false_when_no_key():
     assert use_llm_arbitrator(env={"AI_MARKET_MAKER_USE_LLM": "1"}) is False
 
 
-def test_use_llm_returns_false_when_explicitly_disabled():
-    """Legacy ``0`` / ``false`` / ``no`` / ``off`` forces off, even with a key."""
+def test_use_llm_legacy_flag_is_not_a_strategy_switch():
+    """Env force-off was retired; a key still enables the provider helper."""
     for val in ("0", "false", "no", "off"):
         env = {"AI_MARKET_MAKER_USE_LLM": val, **_KEY}
-        assert use_llm_arbitrator(env=env) is False, f"{val=} should force off"
+        assert use_llm_arbitrator(env=env) is True
 
 
 def test_use_llm_returns_true_when_key_present():

--- a/tests/test_llm_json_parse.py
+++ b/tests/test_llm_json_parse.py
@@ -21,6 +21,11 @@ def test_parse_json_object_preamble_and_trailing_text() -> None:
     assert parse_json_object(txt) == {"a": 1}
 
 
+def test_parse_json_object_think_wrapper() -> None:
+    txt = '<think>let me reason</think>\n{"ta_indicators": {"rsi": 61}}'
+    assert parse_json_object(txt) == {"ta_indicators": {"rsi": 61}}
+
+
 def test_parse_json_object_non_object_returns_none() -> None:
     assert parse_json_object("[1,2,3]") is None
     assert parse_json_object("null") is None

--- a/tests/test_llm_mode.py
+++ b/tests/test_llm_mode.py
@@ -6,8 +6,13 @@ from config.llm_env import llm_key_available, require_llm_key
 
 
 def test_llm_key_available_false_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    for name in (
+        "OPENAI_API_KEY",
+        "LLM_API_KEY",
+        "ATLASCLOUD_API_KEY",
+        "ATLAS_CLOUD_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
     assert llm_key_available() is False
 
 
@@ -17,6 +22,12 @@ def test_llm_key_available_true_with_key(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_require_llm_key_skips_under_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    for name in (
+        "OPENAI_API_KEY",
+        "LLM_API_KEY",
+        "ATLASCLOUD_API_KEY",
+        "ATLAS_CLOUD_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests/test_llm_mode.py::test")
     require_llm_key()  # must not exit

--- a/tests/test_tier0_consensus.py
+++ b/tests/test_tier0_consensus.py
@@ -13,7 +13,11 @@ def test_consensus_empty_state():
 def test_consensus_news_shock_blocks():
     state = {
         "tier0_contracts": [
-            {"agent": "1.2", "News_Impact_Score": 85, "Event_Type": "Major Catalyst"},
+            {
+                "agent": "news_narrative_miner",
+                "News_Impact_Score": 85,
+                "Event_Type": "Major Catalyst",
+            },
         ]
     }
     c = tier0_consensus_for_arbitrator(state)

--- a/tests/test_tier0_contract.py
+++ b/tests/test_tier0_contract.py
@@ -13,7 +13,7 @@ def test_each_agent_emits_schema_version_and_id():
         {"status": "success", "systemic_beta_score": 85, "liquidity_regime": "risk_on"},
         "BTC/USDT",
     )
-    assert m["agent"] == "1.1"
+    assert m["agent"] == "monetary_sentinel"
     assert m["schema_version"] == CONTRACT_SCHEMA_VERSION
     assert m["Liquidity_Score"] == 85
     assert m["macro_regime_state"] == 2
@@ -23,7 +23,7 @@ def test_each_agent_emits_schema_version_and_id():
         {"status": "success", "breaker_score": 90, "breaker_state": "active"},
         "BTC/USDT",
     )
-    assert n["agent"] == "1.2"
+    assert n["agent"] == "news_narrative_miner"
     assert n["News_Impact_Score"] == 90
     assert n["Event_Type"] == "Black Swan"
 
@@ -38,17 +38,17 @@ def test_each_agent_emits_schema_version_and_id():
         },
         "BTC/USDT",
     )
-    assert ta["agent"] == "2.3"
+    assert ta["agent"] == "technical_ta_engine"
     assert ta["ta_indicators"]["rsi"] == 55.2
 
 
 def test_tier0_contracts_by_agent_last_wins():
     state = {
         "tier0_contracts": [
-            {"agent": "1.1", "Liquidity_Score": 10},
-            {"agent": "1.2", "News_Impact_Score": 20},
+            {"agent": "monetary_sentinel", "Liquidity_Score": 10},
+            {"agent": "news_narrative_miner", "News_Impact_Score": 20},
         ]
     }
     idx = tier0_contracts_by_agent(state)
-    assert idx["1.1"]["Liquidity_Score"] == 10
-    assert idx["1.2"]["News_Impact_Score"] == 20
+    assert idx["monetary_sentinel"]["Liquidity_Score"] == 10
+    assert idx["news_narrative_miner"]["News_Impact_Score"] == 20

--- a/tests/test_workflow_routing.py
+++ b/tests/test_workflow_routing.py
@@ -35,22 +35,23 @@ def test_workflow_compiles():
 
 
 def test_tier1_parallel_fanout_and_fanin_edges_present():
-    g = build_workflow()
+    from agents.registry import get_registry
+
+    names = get_registry().names()
+    g = build_workflow(tier0_nodes=names)
     edges = g.edges
-    tier0 = {
-        "monetary_sentinel",
-        "news_narrative_miner",
-        "pattern_recognition_bot",
-        "statistical_alpha_engine",
-        "technical_ta_engine",
-        "retail_hype_tracker",
-        "pro_bias_analyst",
-        "whale_behavior_analyst",
-        "liquidity_order_flow",
-    }
-    for node in tier0:
+    for node in names:
         assert ("desk_market_scan", node) in edges
         assert (node, "desk_risk") in edges
+
+
+def test_workflow_prunes_disabled_desks():
+    g = build_workflow(tier0_nodes=["technical_ta_engine", "pattern_recognition_bot"])
+    edges = g.edges
+    assert ("desk_market_scan", "technical_ta_engine") in edges
+    assert ("desk_market_scan", "pattern_recognition_bot") in edges
+    assert ("desk_market_scan", "news_narrative_miner") not in edges
+    assert ("desk_market_scan", "whale_behavior_analyst") not in edges
 
 
 def test_tier2_risk_to_arbitrator_edge_present():


### PR DESCRIPTION
## Summary

Consolidate agentic toggles into deploy JSON as the single source of truth. Allow optional LLM overlays for weights and trade decisions to match the desk-weight-arbitrator design.

## Motivation

- Move agentic toggles from .env and code defaults to deploy JSON.
- Make deploy JSON the single source of truth for strategy configuration.
- Add optional LLM overlays for weight assignment and trade actions.
- Align the graph with the desk-weight-arbitrator design.

## How to Test

uv run pre-commit run --all-files
uv run ruff format --check .
uv run ruff check .

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (add `--runslow` if you touched slow tests)
- [x] Documentation updated if behavior or public API changed
- [x] No API keys or secrets committed