### PR TITLE
fix: enforce Flow API auth and generate unique keys on first boot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@ dist/
 
 # Runtime artifacts
 .runs/
+.secrets/
 
 # Frontend (when building API/worker with context: .)
 web/node_modules/

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@
 # Flow / DB
 NEXT_PUBLIC_FLOW_API_BASE_URL=http://127.0.0.1:8001
 DATABASE_URL=postgresql+psycopg://aimm:aimm@db:5432/aimm
-AIMM_AUTH_SECRET=dev-secret-change-me
+# Empty = generated into .secrets/ on first boot
+AIMM_AUTH_SECRET=
+AIMM_API_KEY=
 # AIMM_RUNS_DIR=
 # AIMM_DEPLOY_CONFIG_PATH=config/deploy.active.json
 
@@ -26,7 +28,7 @@ OPENAI_MODEL=gpt-4o-mini
 # AIMM_DESK_STRATEGY_PRESET=default
 STRATEGY_INTERVAL_SEC=900
 
-# Nexus
+# Shared Nexus demo key (rate-limited), replace with your own
 NEXUS_API_KEY=4Qbp6biPAKPS1gOksAySOlqK
 NEXUS_DISABLE=0
 NEXUS_JWT=
@@ -36,8 +38,7 @@ OLAXBT_NEXUS_DATA_BASE_URL=
 
 # API
 BACKTEST_API_MAX_STEPS=5000
-# AIMM_API_KEY=
-# AIMM_CORS_ORIGINS=*
+# AIMM_CORS_ORIGINS=
 # TWITTER_BEARER_TOKEN=
 
 # Execution

--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,12 @@
 
 # Flow / DB
 NEXT_PUBLIC_FLOW_API_BASE_URL=http://127.0.0.1:8001
-DATABASE_URL=postgresql+psycopg://aimm:aimm@db:5432/aimm
-# Empty = generated into .secrets/ on first boot
+# Empty = generated into .secrets/ on first boot (api_key, auth_secret, postgres_password)
 AIMM_AUTH_SECRET=
 AIMM_API_KEY=
+POSTGRES_PASSWORD=
+# Compose Postgres is on 5433. Only set DATABASE_URL for an external DB.
+# DATABASE_URL=
 # AIMM_RUNS_DIR=
 # AIMM_DEPLOY_CONFIG_PATH=config/deploy.active.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ data/news_sentiment/raw/
 # Local output
 out/
 
+.secrets/
+
 # experimental configs
 config/experiments/
 config/grid/

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -16,8 +16,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY src /app/src
 COPY config /app/config
 COPY scripts /app/scripts
+COPY docker /app/docker
 COPY alembic.ini /app/alembic.ini
 COPY alembic /app/alembic
+
+RUN chmod +x /app/docker/api-entrypoint.sh
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --no-deps -e .

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,6 +16,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY src /app/src
 COPY config /app/config
 COPY scripts /app/scripts
+COPY docker /app/docker
+
+RUN chmod +x /app/docker/api-entrypoint.sh
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system --no-deps -e .

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -8,16 +8,16 @@ This repo can run as a small production platform:
 
 ### Requirements
 - Docker + Docker Compose
-- Unique `AIMM_API_KEY` and `AIMM_AUTH_SECRET`. If you leave them
+- Unique `AIMM_API_KEY`, `AIMM_AUTH_SECRET`, and `POSTGRES_PASSWORD`. If you leave them
   empty, `docker compose` generates them into `./.secrets/` on first boot.
 
 ### Environment variables
 Create a `.env` next to `docker-compose.prod.yml`:
 
 ```bash
-# Database
-POSTGRES_PASSWORD=change-me
-DATABASE_URL=postgresql+psycopg://aimm:${POSTGRES_PASSWORD}@db:5432/aimm
+# Database (empty POSTGRES_PASSWORD = generate into .secrets/)
+POSTGRES_PASSWORD=
+# DATABASE_URL=
 
 # Auth (empty = auto-generate into .secrets/)
 AIMM_ENV=production
@@ -70,3 +70,4 @@ Notes:
 - Put a reverse proxy with TLS in front of any public bind
 - Leave `AIMM_CORS_ORIGINS` empty unless a browser must call the API cross-origin
 - Keep `PLATFORM_WORKER_AUTO_EXECUTE=0` unless you explicitly want it
+- Set `POSTGRES_PASSWORD` to a long random value, or leave it empty to generate one (do not map `5433` to `0.0.0.0`)

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -8,7 +8,8 @@ This repo can run as a small production platform:
 
 ### Requirements
 - Docker + Docker Compose
-- A real `AIMM_AUTH_SECRET` (do not use dev fallback)
+- Unique `AIMM_API_KEY` and `AIMM_AUTH_SECRET`. If you leave them
+  empty, `docker compose` generates them into `./.secrets/` on first boot.
 
 ### Environment variables
 Create a `.env` next to `docker-compose.prod.yml`:
@@ -18,19 +19,15 @@ Create a `.env` next to `docker-compose.prod.yml`:
 POSTGRES_PASSWORD=change-me
 DATABASE_URL=postgresql+psycopg://aimm:${POSTGRES_PASSWORD}@db:5432/aimm
 
-# Auth (required)
+# Auth (empty = auto-generate into .secrets/)
 AIMM_ENV=production
-AIMM_AUTH_SECRET=change-this-to-a-long-random-string
-
-# Optional: protect API behind a shared key (recommended for internet exposure)
-# If set, non-local requests to the API require x-api-key / Authorization: Bearer.
+AIMM_AUTH_SECRET=
 AIMM_API_KEY=
 
 # Web -> API
 FLOW_API_BASE_URL=http://api:8001
 
-# CORS (set to your dashboard origin)
-AIMM_CORS_ORIGINS=http://localhost:3000
+# AIMM_CORS_ORIGINS=
 
 # Worker
 PLATFORM_WORKER_AUTO_EXECUTE=0
@@ -38,6 +35,9 @@ PLATFORM_WORKER_INTERVAL_SEC=2.0
 PLATFORM_WORKER_BATCH=200
 PLATFORM_WORKER_CURSOR=default
 ```
+
+The dashboard talks to Flow through Next.js (`/api/flow`) so the API key stays
+server-side. Direct calls to the FastAPI port need `x-api-key` (see `.secrets/api_key`).
 
 ### Start
 
@@ -58,15 +58,15 @@ Notes:
 - If you want dev convenience, set `AIMM_DB_AUTOCREATE=1` locally.
 
 ### Operational endpoints
-- API health: `GET /health`
-- Latest run payload: `GET /runs/latest/payload`
-- Leaderboard: `GET /leadpage/leaderboard`
-- Feed: `GET /signals/feed`
+- API health: `GET /health` (unauthenticated)
+- Latest run payload: `GET /runs/latest/payload` (requires `x-api-key`)
+- Leaderboard: `GET /leadpage/leaderboard` (requires `x-api-key`)
+- Feed: `GET /signals/feed` (requires `x-api-key`)
 
 ### Security checklist
-- Set `AIMM_AUTH_SECRET` and keep it private
-- Put the API behind a reverse proxy with TLS
-- Set `AIMM_CORS_ORIGINS` to your real dashboard origin
-- If exposed publicly, set `AIMM_API_KEY` and restrict network ingress
+- Leave `AIMM_API_KEY` / `AIMM_AUTH_SECRET` empty to generate unique keys, or set your own long random values
+- Keep `.secrets/` private and out of git
+- Dashboard and API bind to `127.0.0.1` by default; override `AIMM_WEB_PUBLISH` / `AIMM_API_PUBLISH` only behind TLS
+- Put a reverse proxy with TLS in front of any public bind
+- Leave `AIMM_CORS_ORIGINS` empty unless a browser must call the API cross-origin
 - Keep `PLATFORM_WORKER_AUTO_EXECUTE=0` unless you explicitly want it
-

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ uv run pre-commit install
 # 5. Set up environment
 cp .env.example .env
 # Edit .env — set OPENAI_API_KEY or ATLASCLOUD_API_KEY (required for LLM calls)
-# AIMM_API_KEY / AIMM_AUTH_SECRET: leave empty to generate, or set your own
+# AIMM_API_KEY / AIMM_AUTH_SECRET / POSTGRES_PASSWORD: leave empty to generate, or set your own
 # Strategy (desks, weights, LLM overlays) lives in config/deploy.active.json
 
 # 6. Run the platform stack: DB + migrate + API + worker + web
@@ -129,7 +129,8 @@ docker compose up --build -d
 Open http://127.0.0.1:3000 to view the dashboard (bound to localhost by default).
 
 Migrations run automatically on first `docker compose up` (service `migrate`).
-If `AIMM_API_KEY` / `AIMM_AUTH_SECRET` are set in `.env`, those values are used. If you left them empty, first boot writes unique keys into `.secrets/` (gitignored) and reuses them. Direct calls to `:8001` need `x-api-key`; the dashboard proxies through Next.js with that key.
+Compose Postgres listens on **5433** (new volume; old `5432` data is left untouched).
+If `AIMM_API_KEY` / `AIMM_AUTH_SECRET` / `POSTGRES_PASSWORD` are set in `.env`, those values are used. If you left them empty, first boot writes unique values into `.secrets/` (gitignored) and reuses them. Direct calls to `:8001` need `x-api-key`; the dashboard proxies through Next.js with that key.
 First boot may show an empty Leaderboard until you run a backtest (Nexus → **Research**) or publish results.
 
 For CLI-only trading mode:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ uv run pre-commit install
 # 5. Set up environment
 cp .env.example .env
 # Edit .env — set OPENAI_API_KEY or ATLASCLOUD_API_KEY (required for LLM calls)
+# AIMM_API_KEY / AIMM_AUTH_SECRET: leave empty to generate, or set your own
 # Strategy (desks, weights, LLM overlays) lives in config/deploy.active.json
 
 # 6. Run the platform stack: DB + migrate + API + worker + web
@@ -125,9 +126,10 @@ docker compose up --build -d
 # http://localhost:3000/get-started
 ```
 
-Open http://localhost:3000 to view the dashboard.
+Open http://127.0.0.1:3000 to view the dashboard (bound to localhost by default).
 
 Migrations run automatically on first `docker compose up` (service `migrate`).
+If `AIMM_API_KEY` / `AIMM_AUTH_SECRET` are set in `.env`, those values are used. If you left them empty, first boot writes unique keys into `.secrets/` (gitignored) and reuses them. Direct calls to `:8001` need `x-api-key`; the dashboard proxies through Next.js with that key.
 First boot may show an empty Leaderboard until you run a backtest (Nexus → **Research**) or publish results.
 
 For CLI-only trading mode:

--- a/docker-compose.leaderboard.yml
+++ b/docker-compose.leaderboard.yml
@@ -10,6 +10,7 @@ services:
       AIMM_SECRETS_DIR: /run/aimm-secrets
       AIMM_API_KEY: ${AIMM_API_KEY:-}
       AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
     volumes:
       - ./.secrets:/run/aimm-secrets
     command: ["python", "-m", "api.control_plane_secrets", "--write"]
@@ -18,15 +19,20 @@ services:
   db:
     image: postgres:16-alpine
     environment:
+      PGPORT: "5433"
       POSTGRES_DB: aimm
       POSTGRES_USER: aimm
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-aimm}
+      POSTGRES_PASSWORD_FILE: /run/aimm-secrets/postgres_password
     volumes:
-      - lb_pgdata:/var/lib/postgresql/data
+      - lb_pg5433:/var/lib/postgresql/data
+      - ./.secrets:/run/aimm-secrets:ro
     ports:
-      - "${POSTGRES_PUBLISH:-127.0.0.1:5432}:5432"
+      - "${POSTGRES_PUBLISH:-127.0.0.1:5433}:5433"
+    depends_on:
+      secrets-init:
+        condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U aimm -d aimm"]
+      test: ["CMD-SHELL", "pg_isready -U aimm -d aimm -p 5433"]
       interval: 5s
       timeout: 3s
       retries: 20
@@ -43,9 +49,12 @@ services:
     env_file:
       - .env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://aimm:aimm@db:5432/aimm}
+      DATABASE_URL: ${DATABASE_URL:-}
       AIMM_DB_AUTOCREATE: "1"
       AIMM_SECRETS_DIR: /run/aimm-secrets
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5433"
       AIMM_API_KEY: ${AIMM_API_KEY:-}
       AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-}
       LEADPAGE_PROVIDER_KEYS: ${LEADPAGE_PROVIDER_KEYS:-}
@@ -69,4 +78,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  lb_pgdata:
+  lb_pg5433:

--- a/docker-compose.leaderboard.yml
+++ b/docker-compose.leaderboard.yml
@@ -1,6 +1,20 @@
-# Leaderboard API stack (DB + Flow API). No separate UI tree — use the main Next `web/` via
-# `docker compose up` when you want a portal, or hit the API directly.
+# Leaderboard API (DB + Flow). Dashboard is the main `web/` compose file.
 services:
+  secrets-init:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    env_file:
+      - .env
+    environment:
+      AIMM_SECRETS_DIR: /run/aimm-secrets
+      AIMM_API_KEY: ${AIMM_API_KEY:-}
+      AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-}
+    volumes:
+      - ./.secrets:/run/aimm-secrets
+    command: ["python", "-m", "api.control_plane_secrets", "--write"]
+    restart: "no"
+
   db:
     image: postgres:16-alpine
     environment:
@@ -10,7 +24,7 @@ services:
     volumes:
       - lb_pgdata:/var/lib/postgresql/data
     ports:
-      - "${POSTGRES_HOST_PORT:-5432}:5432"
+      - "${POSTGRES_PUBLISH:-127.0.0.1:5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U aimm -d aimm"]
       interval: 5s
@@ -31,20 +45,27 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://aimm:aimm@db:5432/aimm}
       AIMM_DB_AUTOCREATE: "1"
+      AIMM_SECRETS_DIR: /run/aimm-secrets
+      AIMM_API_KEY: ${AIMM_API_KEY:-}
+      AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-}
       LEADPAGE_PROVIDER_KEYS: ${LEADPAGE_PROVIDER_KEYS:-}
       LEADPAGE_REQUIRE_KEYS: ${LEADPAGE_REQUIRE_KEYS:-1}
       LEADPAGE_REQUIRE_SIGNED: ${LEADPAGE_REQUIRE_SIGNED:-0}
-      AIMM_CORS_ORIGINS: ${AIMM_CORS_ORIGINS:-*}
+      AIMM_CORS_ORIGINS: ${AIMM_CORS_ORIGINS:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       OPENAI_MODEL: ${OPENAI_MODEL:-}
     depends_on:
       db:
         condition: service_healthy
+      secrets-init:
+        condition: service_completed_successfully
+    entrypoint: ["/app/docker/api-entrypoint.sh"]
     ports:
-      - "${LEADERBOARD_PORT:-8001}:8001"
+      - "${AIMM_API_PUBLISH:-127.0.0.1:8001}:8001"
     volumes:
       - ./.runs:/app/.runs
+      - ./.secrets:/run/aimm-secrets:ro
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,22 @@
-# Postgres + API + worker + web. Copy `.env.example` → `.env` first.
-# Optional profiles: `with-futu` (OpenD), `engine` (live loop)
+# Copy `.env.example` → `.env` first. Profiles: `with-futu`, `engine`.
+# Empty AIMM_API_KEY / AIMM_AUTH_SECRET → secrets-init writes ./.secrets/
 
 services:
+  secrets-init:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    env_file:
+      - .env
+    environment:
+      AIMM_SECRETS_DIR: /run/aimm-secrets
+      AIMM_API_KEY: ${AIMM_API_KEY:-}
+      AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-}
+    volumes:
+      - ./.secrets:/run/aimm-secrets
+    command: ["python", "-m", "api.control_plane_secrets", "--write"]
+    restart: "no"
+
   db:
     image: postgres:16
     environment:
@@ -39,9 +54,10 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://aimm:aimm@db:5432/aimm}
       AIMM_DB_AUTOCREATE: "0"
-      AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-dev-secret-change-me}
+      AIMM_SECRETS_DIR: /run/aimm-secrets
+      AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-}
       AIMM_API_KEY: ${AIMM_API_KEY:-}
-      AIMM_CORS_ORIGINS: ${AIMM_CORS_ORIGINS:-*}
+      AIMM_CORS_ORIGINS: ${AIMM_CORS_ORIGINS:-}
       # LLM keys duplicated here for compose variable interpolation.
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
@@ -55,17 +71,21 @@ services:
       FUTU_OPEND_TRADE_PORT: ${FUTU_OPEND_TRADE_PORT:-11112}
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    entrypoint: ["/app/docker/api-entrypoint.sh"]
     depends_on:
       db:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
+      secrets-init:
+        condition: service_completed_successfully
     ports:
-      - "8001:8001"
+      - "${AIMM_API_PUBLISH:-127.0.0.1:8001}:8001"
     volumes:
       - ./.runs:/app/.runs
       - ./config:/app/config:ro
       - ./scripts:/app/scripts:ro
+      - ./.secrets:/run/aimm-secrets:ro
 
   worker:
     build:
@@ -127,13 +147,19 @@ services:
     environment:
       FLOW_API_BASE_URL: http://api:8001
       AIMM_API_KEY: ${AIMM_API_KEY:-}
+      AIMM_SECRETS_DIR: /run/aimm-secrets
       NODE_ENV: production
       FLOW_ALLOW_MOCK_FALLBACK: "0"
       NEXT_PUBLIC_FLOW_ALLOW_MOCK_FALLBACK: "0"
     depends_on:
-      - api
+      secrets-init:
+        condition: service_completed_successfully
+      api:
+        condition: service_started
+    volumes:
+      - ./.secrets:/run/aimm-secrets:ro
     ports:
-      - "3000:3000"
+      - "${AIMM_WEB_PUBLISH:-127.0.0.1:3000}:3000"
 
   futu-opend:
     profiles: ["with-futu"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # Copy `.env.example` → `.env` first. Profiles: `with-futu`, `engine`.
-# Empty AIMM_API_KEY / AIMM_AUTH_SECRET → secrets-init writes ./.secrets/
+# Empty AIMM_API_KEY / AIMM_AUTH_SECRET / POSTGRES_PASSWORD → secrets-init writes ./.secrets/
+# Compose Postgres listens on 5433 (volume aimm_pg5433). Not published on the host.
 
 services:
   secrets-init:
@@ -12,6 +13,7 @@ services:
       AIMM_SECRETS_DIR: /run/aimm-secrets
       AIMM_API_KEY: ${AIMM_API_KEY:-}
       AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
     volumes:
       - ./.secrets:/run/aimm-secrets
     command: ["python", "-m", "api.control_plane_secrets", "--write"]
@@ -20,13 +22,18 @@ services:
   db:
     image: postgres:16
     environment:
+      PGPORT: "5433"
       POSTGRES_DB: aimm
       POSTGRES_USER: aimm
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-aimm}
+      POSTGRES_PASSWORD_FILE: /run/aimm-secrets/postgres_password
     volumes:
-      - aimm_pgdata:/var/lib/postgresql/data
+      - aimm_pg5433:/var/lib/postgresql/data
+      - ./.secrets:/run/aimm-secrets:ro
+    depends_on:
+      secrets-init:
+        condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U aimm -d aimm"]
+      test: ["CMD-SHELL", "pg_isready -U aimm -d aimm -p 5433"]
       interval: 5s
       timeout: 3s
       retries: 20
@@ -38,10 +45,19 @@ services:
     env_file:
       - .env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://aimm:aimm@db:5432/aimm}
+      DATABASE_URL: ${DATABASE_URL:-}
+      AIMM_SECRETS_DIR: /run/aimm-secrets
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5433"
     depends_on:
       db:
         condition: service_healthy
+      secrets-init:
+        condition: service_completed_successfully
+    entrypoint: ["/app/docker/api-entrypoint.sh"]
+    volumes:
+      - ./.secrets:/run/aimm-secrets:ro
     command: ["alembic", "upgrade", "head"]
     restart: "no"
 
@@ -52,9 +68,12 @@ services:
     env_file:
       - .env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://aimm:aimm@db:5432/aimm}
+      DATABASE_URL: ${DATABASE_URL:-}
       AIMM_DB_AUTOCREATE: "0"
       AIMM_SECRETS_DIR: /run/aimm-secrets
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5433"
       AIMM_AUTH_SECRET: ${AIMM_AUTH_SECRET:-}
       AIMM_API_KEY: ${AIMM_API_KEY:-}
       AIMM_CORS_ORIGINS: ${AIMM_CORS_ORIGINS:-}
@@ -96,7 +115,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://aimm:aimm@db:5432/aimm}
+      DATABASE_URL: ${DATABASE_URL:-}
+      AIMM_SECRETS_DIR: /run/aimm-secrets
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5433"
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       OPENAI_MODEL: ${OPENAI_MODEL:-}
@@ -112,14 +135,18 @@ services:
       PLATFORM_WORKER_CURSOR: ${PLATFORM_WORKER_CURSOR:-default}
       PLATFORM_SYNC_LOCAL_BACKTESTS: ${PLATFORM_SYNC_LOCAL_BACKTESTS:-0}
       PLATFORM_SYNC_LOCAL_BACKTESTS_EVERY_SEC: ${PLATFORM_SYNC_LOCAL_BACKTESTS_EVERY_SEC:-10}
+    entrypoint: ["/app/docker/api-entrypoint.sh"]
     depends_on:
       db:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
+      secrets-init:
+        condition: service_completed_successfully
     volumes:
       - ./.runs:/app/.runs
       - ./config:/app/config:ro
+      - ./.secrets:/run/aimm-secrets:ro
 
   engine:
     profiles: ["engine"]
@@ -171,4 +198,4 @@ services:
     # When this profile is up, set FUTU_OPEND_HOST=futu-opend in .env.
 
 volumes:
-  aimm_pgdata:
+  aimm_pg5433:

--- a/docker/api-entrypoint.sh
+++ b/docker/api-entrypoint.sh
@@ -9,5 +9,9 @@ if [ -z "${AIMM_API_KEY:-}" ] || [ -z "${AIMM_AUTH_SECRET:-}" ]; then
   echo "control-plane: AIMM_API_KEY and AIMM_AUTH_SECRET are required (no defaults)." >&2
   exit 1
 fi
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "control-plane: DATABASE_URL is required (set it or let secrets-init generate POSTGRES_PASSWORD)." >&2
+  exit 1
+fi
 
 exec "$@"

--- a/docker/api-entrypoint.sh
+++ b/docker/api-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+export AIMM_SECRETS_DIR="${AIMM_SECRETS_DIR:-/run/aimm-secrets}"
+
+eval "$(python -m api.control_plane_secrets --export-shell)"
+
+if [ -z "${AIMM_API_KEY:-}" ] || [ -z "${AIMM_AUTH_SECRET:-}" ]; then
+  echo "control-plane: AIMM_API_KEY and AIMM_AUTH_SECRET are required (no defaults)." >&2
+  exit 1
+fi
+
+exec "$@"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,10 +26,11 @@ config/policy.default.json  → trading policy (risk, sizing, rules)
 | `NEXUS_API_KEY`     | Olaxbt Nexus data API key                     |
 | `AIMM_API_KEY`      | Flow control-plane API key (`x-api-key`)      |
 | `AIMM_AUTH_SECRET`  | JWT signing secret for `/auth/*`              |
+| `POSTGRES_PASSWORD` | Compose Postgres password                     |
 
-`AIMM_API_KEY` and `AIMM_AUTH_SECRET` have **no shipped default**. If you set your
-own values in `.env`, those are used on every boot. Leave them empty and run
-`python -m api.control_plane_secrets --write` (or `docker compose up`): unique
+`AIMM_API_KEY`, `AIMM_AUTH_SECRET`, and `POSTGRES_PASSWORD` have **no shipped default**.
+Compose Postgres listens on **5433** (not 5432). If you set your own values in `.env`, those are used on every boot. Leave them empty
+and run `python -m api.control_plane_secrets --write` (or `docker compose up`): unique
 values are written to `.secrets/` (gitignored) once and reused. All Flow HTTP
 routes except `GET /health` require `x-api-key`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,14 @@ config/policy.default.json  → trading policy (risk, sizing, rules)
 | `BINANCE_API_KEY`   | Binance API key for market data               |
 | `BINANCE_API_SECRET`| Binance API secret                            |
 | `NEXUS_API_KEY`     | Olaxbt Nexus data API key                     |
+| `AIMM_API_KEY`      | Flow control-plane API key (`x-api-key`)      |
+| `AIMM_AUTH_SECRET`  | JWT signing secret for `/auth/*`              |
+
+`AIMM_API_KEY` and `AIMM_AUTH_SECRET` have **no shipped default**. If you set your
+own values in `.env`, those are used on every boot. Leave them empty and run
+`python -m api.control_plane_secrets --write` (or `docker compose up`): unique
+values are written to `.secrets/` (gitignored) once and reused. All Flow HTTP
+routes except `GET /health` require `x-api-key`.
 
 Atlas Cloud can be selected without replacing the existing OpenAI variables:
 

--- a/docs/leaderboard-hosting.md
+++ b/docs/leaderboard-hosting.md
@@ -26,9 +26,10 @@ export POSTGRES_PASSWORD=$(openssl rand -hex 20)
 # 3. Start the leaderboard stack
 docker compose -f docker-compose.leaderboard.yml up -d
 
-# 4. Verify
+# 4. Verify (health is unauthenticated; other routes need x-api-key from .secrets/api_key)
 curl http://localhost:8001/health
-# → {"status": "ok", "version": "1.0.0"}
+# → {"ok": true, ...}
+curl -H "x-api-key: $(cat .secrets/api_key)" http://localhost:8001/leadpage/leaderboard
 ```
 
 ## Configuration
@@ -37,15 +38,18 @@ curl http://localhost:8001/health
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LEADERBOARD_PORT` | `8001` | API server port |
+| `LEADERBOARD_PORT` | — | Deprecated; use `AIMM_API_PUBLISH` (default `127.0.0.1:8001`) |
 | `LEADERBOARD_WEB_PORT` | `3000` | Web dashboard port |
+| `AIMM_API_KEY` | (generated) | Required control-plane key (`x-api-key`) |
+| `AIMM_AUTH_SECRET` | (generated) | JWT signing secret |
 | `LEADPAGE_PROVIDER_KEYS` | — | Map of provider IDs to shared secrets |
 | `LEADPAGE_REQUIRE_KEYS` | `1` | Reject unauthenticated submissions |
 | `LEADPAGE_REQUIRE_SIGNED` | `0` | Require HMAC-signed payloads |
 | `LEADPAGE_SIGNED_MAX_SKEW_SEC` | `300` | Max timestamp skew for signed requests |
 | `DATABASE_URL` | auto | PostgreSQL connection string |
-| `POSTGRES_PASSWORD` | `aimm` | DB password |
-| `AIMM_CORS_ORIGINS` | `*` | Allowed CORS origins |
+| `POSTGRES_PASSWORD` | `aimm` | DB password (do not publish Postgres on `0.0.0.0`) |
+| `POSTGRES_HOST_PORT` | — | Deprecated; use `POSTGRES_PUBLISH` (default `127.0.0.1:5432`) |
+| `AIMM_CORS_ORIGINS` | (empty) | Allowed CORS origins; empty disables cross-origin browser access |
 
 ### Provider Key Formats
 

--- a/docs/leaderboard-hosting.md
+++ b/docs/leaderboard-hosting.md
@@ -10,7 +10,7 @@
   │ Agent 2     │────▶│  :8001       │────▶│  :3000       │
   │ (3rd-party) │     │              │     └──────────────┘
   ├─────────────┤     │  PostgreSQL  │
-  │ Agent N     │────▶│  (:5432)     │
+  │ Agent N     │────▶│  (:5433)     │
   └─────────────┘     └──────────────┘
 ```
 
@@ -47,8 +47,8 @@ curl -H "x-api-key: $(cat .secrets/api_key)" http://localhost:8001/leadpage/lead
 | `LEADPAGE_REQUIRE_SIGNED` | `0` | Require HMAC-signed payloads |
 | `LEADPAGE_SIGNED_MAX_SKEW_SEC` | `300` | Max timestamp skew for signed requests |
 | `DATABASE_URL` | auto | PostgreSQL connection string |
-| `POSTGRES_PASSWORD` | `aimm` | DB password (do not publish Postgres on `0.0.0.0`) |
-| `POSTGRES_HOST_PORT` | — | Deprecated; use `POSTGRES_PUBLISH` (default `127.0.0.1:5432`) |
+| `POSTGRES_PASSWORD` | (generated) | DB password (do not publish Postgres on `0.0.0.0`) |
+| `POSTGRES_HOST_PORT` | — | Deprecated; use `POSTGRES_PUBLISH` (default `127.0.0.1:5433`) |
 | `AIMM_CORS_ORIGINS` | (empty) | Allowed CORS origins; empty disables cross-origin browser access |
 
 ### Provider Key Formats

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -135,9 +135,10 @@ The repo exposes a lightweight, mostly read-only HTTP API:
 
 ### Security
 
-- If `AIMM_API_KEY` is not set → API is open (intended for local development only).
-- If `AIMM_API_KEY` is set → All non-local requests require `x-api-key` header.
-- In production, always put the Flow API behind a reverse proxy and configure `AIMM_CORS_ORIGINS` appropriately.
+- `AIMM_API_KEY` and `AIMM_AUTH_SECRET` are always required (no shipped default).
+- Empty values are treated as unset; first boot writes unique keys under `.secrets/`.
+- All Flow API requests except `GET /health` require `x-api-key` (or `Authorization: Bearer` with the same key).
+- In production, put the Flow API behind a reverse proxy and configure `AIMM_CORS_ORIGINS` to your dashboard origin.
 
 ## Key Files for OpenClaw Integration
 

--- a/openclaw/examples/claw_usage.md
+++ b/openclaw/examples/claw_usage.md
@@ -36,8 +36,8 @@ This repo includes a lightweight platform surface:
 ### Local Postgres (optional but recommended)
 
 ```bash
-docker compose up -d
-export DATABASE_URL="postgresql+psycopg://aimm:aimm@127.0.0.1:5432/aimm"
+docker compose -f docker-compose.leaderboard.yml up -d
+export DATABASE_URL="postgresql+psycopg://aimm:$(cat .secrets/postgres_password)@127.0.0.1:5433/aimm"
 ```
 
 ### Publish a provider result (signed)

--- a/openclaw/manifest.json
+++ b/openclaw/manifest.json
@@ -25,7 +25,7 @@
       "transport": "http",
       "method": "GET",
       "path": "/health",
-      "auth": "optional_x_api_key"
+      "auth": "required_x_api_key"
     },
     {
       "name": "flow.latest_run",
@@ -34,7 +34,7 @@
       "transport": "http",
       "method": "GET",
       "path": "/runs/latest",
-      "auth": "optional_x_api_key"
+      "auth": "required_x_api_key"
     },
     {
       "name": "flow.get_payload",
@@ -43,7 +43,7 @@
       "transport": "http",
       "method": "GET",
       "path": "/runs/{run_id}/payload",
-      "auth": "optional_x_api_key"
+      "auth": "required_x_api_key"
     },
     {
       "name": "flow.get_events",
@@ -52,7 +52,7 @@
       "transport": "http",
       "method": "GET",
       "path": "/runs/{run_id}/events",
-      "auth": "optional_x_api_key"
+      "auth": "required_x_api_key"
     },
     {
       "name": "pm.get_portfolio_health",
@@ -61,7 +61,7 @@
       "transport": "http",
       "method": "GET",
       "path": "/pm/portfolio-health",
-      "auth": "optional_x_api_key"
+      "auth": "required_x_api_key"
     },
     {
       "name": "backtest.list_runs",
@@ -70,7 +70,7 @@
       "transport": "http",
       "method": "GET",
       "path": "/backtests",
-      "auth": "optional_x_api_key"
+      "auth": "required_x_api_key"
     }
   ],
   "agents": {

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,11 +16,6 @@ if str(src_dir) not in sys.path:
 os.environ.setdefault("AIMM_DESK_STRATEGY_PRESET", "default")
 os.environ.setdefault("STRATEGY_INTERVAL_SEC", "180")
 
-# Check for Nexus API key - use demo key if not set
-if not os.getenv("NEXUS_API_KEY"):
-    os.environ["NEXUS_API_KEY"] = "4Qbp6biPAKPS1gOksAySOlqK"
-    print("⚠️  Using demo Nexus API key (rate-limited)")
-
 # Export main components for easier imports
 __all__ = ["agents", "backtest", "config", "tools", "workflow", "main"]
 

--- a/src/api/auth_routes.py
+++ b/src/api/auth_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import time
+from collections import defaultdict
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -14,16 +15,30 @@ from storage.leadpage_db import create_user, get_user_by_email, get_user_by_id
 router = APIRouter(tags=["auth"])
 
 _PWD = CryptContext(schemes=["bcrypt"], deprecated="auto")
+_AUTH_HITS: dict[tuple[str, str], list[float]] = defaultdict(list)
+
+
+def _rate_limit(request: Request, *, bucket: str, limit: int = 20, window_sec: int = 60) -> None:
+    host = getattr(getattr(request, "client", None), "host", None) or "unknown"
+    now = time.time()
+    key = (bucket, host)
+    recent = [t for t in _AUTH_HITS[key] if now - t < window_sec]
+    if len(recent) >= limit:
+        _AUTH_HITS[key] = recent
+        raise HTTPException(status_code=429, detail="too many attempts")
+    recent.append(now)
+    _AUTH_HITS[key] = recent
 
 
 def _jwt_secret() -> str:
+    from api.control_plane_secrets import is_usable_secret
+
     sec = (os.getenv("AIMM_AUTH_SECRET") or "").strip()
-    if not sec:
-        env = (os.getenv("AIMM_ENV") or os.getenv("ENV") or "").strip().lower()
-        if env in {"prod", "production"}:
-            raise RuntimeError("AIMM_AUTH_SECRET is required in production")
-        # Dev fallback; for production set AIMM_AUTH_SECRET.
-        sec = "dev-secret-change-me"
+    if not is_usable_secret(sec):
+        raise RuntimeError(
+            "AIMM_AUTH_SECRET is not set. "
+            "Run python -m api.control_plane_secrets --write or set AIMM_AUTH_SECRET."
+        )
     return sec
 
 
@@ -82,7 +97,8 @@ class LoginRequest(BaseModel):
 
 
 @router.post("/auth/register")
-def register(req: RegisterRequest) -> dict[str, Any]:
+def register(request: Request, req: RegisterRequest) -> dict[str, Any]:
+    _rate_limit(request, bucket="register", limit=10, window_sec=60)
     email = req.email.strip().lower()
     if "@" not in email:
         raise HTTPException(status_code=400, detail="invalid email")
@@ -94,7 +110,8 @@ def register(req: RegisterRequest) -> dict[str, Any]:
 
 
 @router.post("/auth/login")
-def login(req: LoginRequest) -> dict[str, Any]:
+def login(request: Request, req: LoginRequest) -> dict[str, Any]:
+    _rate_limit(request, bucket="login", limit=20, window_sec=60)
     email = req.email.strip().lower()
     u = get_user_by_email(email)
     if u is None or not _PWD.verify(req.password, u.password_hash):

--- a/src/api/backtest_routes.py
+++ b/src/api/backtest_routes.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from api.safe_ids import path_under, require_safe_id
 from backtest.bars import (
     align_bars_by_min_length,
     fetch_ccxt_ohlcv_bars,
@@ -64,8 +65,13 @@ def _job_stale_sec() -> int:
     return max(60, int(os.environ.get("BACKTEST_JOB_STALE_SEC", "240")))
 
 
+def _run_dir(run_id: str) -> Path:
+    rid = require_safe_id(str(run_id), name="run_id")
+    return path_under(BACKTESTS_DIR, rid)
+
+
 def _job_path(run_id: str) -> Path:
-    return BACKTESTS_DIR / str(run_id) / "job.json"
+    return _run_dir(run_id) / "job.json"
 
 
 def _write_job(run_id: str, payload: dict[str, Any]) -> None:
@@ -1075,13 +1081,13 @@ def post_backtest_from_file(req: FileBacktestRequest) -> dict[str, Any]:
 
 @router.get("/backtests/{run_id}/summary")
 def get_backtest_summary(run_id: str) -> dict[str, Any]:
-    summary_path = BACKTESTS_DIR / run_id / "summary.json"
+    summary_path = _run_dir(run_id) / "summary.json"
     if not summary_path.is_file():
         raise HTTPException(status_code=404, detail="Unknown backtest run_id")
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     # Backfill start/end time for older runs (added later in engine).
     if isinstance(summary, dict) and ("start_ts" not in summary or "end_ts" not in summary):
-        equity_path = BACKTESTS_DIR / run_id / "equity.jsonl"
+        equity_path = _run_dir(run_id) / "equity.jsonl"
         if equity_path.is_file():
             try:
                 lines = equity_path.read_text(encoding="utf-8").splitlines()
@@ -1119,7 +1125,7 @@ def get_backtest_export_manifest(run_id: str) -> dict[str, Any]:
     Contains schema version, file listing, and metrics summary.
     Returns 404 if the export bundle was not generated.
     """
-    manifest_path = BACKTESTS_DIR / run_id / "export_manifest.json"
+    manifest_path = _run_dir(run_id) / "export_manifest.json"
     if not manifest_path.is_file():
         raise HTTPException(
             status_code=404,
@@ -1137,7 +1143,7 @@ def get_backtest_equity(
     max_points: int = Query(2000, ge=10, le=50_000),
 ) -> dict[str, Any]:
     """Return equity curve points for charting (downsampled for large runs)."""
-    equity_path = BACKTESTS_DIR / run_id / "equity.jsonl"
+    equity_path = _run_dir(run_id) / "equity.jsonl"
     if not equity_path.is_file():
         raise HTTPException(
             status_code=404, detail="Unknown backtest run_id or missing equity.jsonl"
@@ -1145,7 +1151,7 @@ def get_backtest_equity(
     rows = _read_jsonl_all(equity_path)
     # Older runs wrote warmup bars into equity.jsonl; drop them so charts match
     # the scored From→To window (same as buy&hold / bars.json).
-    summary_path = BACKTESTS_DIR / run_id / "summary.json"
+    summary_path = _run_dir(run_id) / "summary.json"
     if summary_path.is_file():
         try:
             summary = json.loads(summary_path.read_text(encoding="utf-8"))
@@ -1184,7 +1190,7 @@ def get_backtest_trades(
     limit: int = Query(2000, ge=1, le=50_000),
 ) -> dict[str, Any]:
     """Return booked trades from ``trades.jsonl`` (newest last; capped by ``limit``)."""
-    trades_path = BACKTESTS_DIR / run_id / "trades.jsonl"
+    trades_path = _run_dir(run_id) / "trades.jsonl"
     if not trades_path.is_file():
         raise HTTPException(
             status_code=404, detail="Unknown backtest run_id or missing trades.jsonl"
@@ -1210,7 +1216,7 @@ def get_backtest_iterations(
 ) -> dict[str, Any]:
     """Return per-bar iteration receipts from ``iterations.jsonl`` (capped)."""
 
-    iterations_path = BACKTESTS_DIR / run_id / "iterations.jsonl"
+    iterations_path = _run_dir(run_id) / "iterations.jsonl"
     if not iterations_path.is_file():
         raise HTTPException(
             status_code=404, detail="Unknown backtest run_id or missing iterations.jsonl"
@@ -1229,7 +1235,7 @@ def get_backtest_bars(
     max_points: int = Query(2000, ge=10, le=50_000),
 ) -> dict[str, Any]:
     """Return OHLCV bars used for the run (primary ticker), downsampled for charting."""
-    bars_path = BACKTESTS_DIR / run_id / "bars.json"
+    bars_path = _run_dir(run_id) / "bars.json"
     if not bars_path.is_file():
         raise HTTPException(status_code=404, detail="Unknown backtest run_id or missing bars.json")
     raw = json.loads(bars_path.read_text(encoding="utf-8"))
@@ -1256,7 +1262,7 @@ def get_backtest_bars(
 
     # Synthesize buy&hold from closes when summary has no benchmark path
     if not benchmark_equity and full_norm:
-        summary_path = BACKTESTS_DIR / run_id / "summary.json"
+        summary_path = _run_dir(run_id) / "summary.json"
         initial = 10_000.0
         if summary_path.is_file():
             try:

--- a/src/api/control_plane_secrets.py
+++ b/src/api/control_plane_secrets.py
@@ -1,0 +1,206 @@
+"""AIMM_API_KEY / AIMM_AUTH_SECRET: env, then .secrets/, else generate once."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shlex
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+API_KEY_ENV = "AIMM_API_KEY"
+AUTH_SECRET_ENV = "AIMM_AUTH_SECRET"
+SECRETS_DIR_ENV = "AIMM_SECRETS_DIR"
+DISABLE_GENERATE_ENV = "AIMM_DISABLE_SECRET_GENERATE"
+
+API_KEY_FILENAME = "api_key"
+AUTH_SECRET_FILENAME = "auth_secret"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def generate_secret() -> str:
+    import secrets
+
+    return secrets.token_urlsafe(32)
+
+
+def is_usable_secret(value: str | None) -> bool:
+    return bool((value or "").strip())
+
+
+def secrets_dir() -> Path:
+    raw = (os.getenv(SECRETS_DIR_ENV) or "").strip()
+    if raw:
+        return Path(raw)
+    return _REPO_ROOT / ".secrets"
+
+
+def _generate_disabled() -> bool:
+    raw = (os.getenv(DISABLE_GENERATE_ENV) or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _read_secret_file(path: Path) -> str | None:
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        logger.warning("control-plane: could not read %s", path)
+        return None
+    return text if is_usable_secret(text) else None
+
+
+def _write_secret_file(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        os.write(fd, value.encode("utf-8"))
+    finally:
+        os.close(fd)
+
+
+def _replace_secret_file(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    fd = os.open(str(tmp), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, value.encode("utf-8"))
+    finally:
+        os.close(fd)
+    os.replace(tmp, path)
+
+
+def persist_secrets(api_key: str, auth_secret: str) -> None:
+    dest = secrets_dir()
+    for name, value in ((API_KEY_FILENAME, api_key), (AUTH_SECRET_FILENAME, auth_secret)):
+        path = dest / name
+        existing = None
+        try:
+            existing = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            existing = None
+        if existing == value:
+            continue
+        _replace_secret_file(path, value)
+
+
+def _load_or_create_file(path: Path, *, generate: bool) -> str | None:
+    existing = _read_secret_file(path)
+    if existing:
+        return existing
+    if not generate:
+        return None
+    created = generate_secret()
+    try:
+        _write_secret_file(path, created)
+        return created
+    except FileExistsError:
+        existing = _read_secret_file(path)
+        if existing:
+            return existing
+        path.unlink(missing_ok=True)
+        try:
+            _write_secret_file(path, created)
+            return created
+        except FileExistsError:
+            return _read_secret_file(path)
+
+
+def _from_env(name: str) -> str | None:
+    raw = (os.getenv(name) or "").strip()
+    return raw or None
+
+
+def resolve_secret(env_name: str, filename: str, *, generate: bool) -> str | None:
+    from_env = _from_env(env_name)
+    if from_env:
+        return from_env
+    path = secrets_dir() / filename
+    loaded = _load_or_create_file(path, generate=generate and not _generate_disabled())
+    if loaded:
+        return loaded
+    return None
+
+
+def resolve_api_key(*, generate: bool = False) -> str | None:
+    return resolve_secret(API_KEY_ENV, API_KEY_FILENAME, generate=generate)
+
+
+def resolve_auth_secret(*, generate: bool = False) -> str | None:
+    return resolve_secret(AUTH_SECRET_ENV, AUTH_SECRET_FILENAME, generate=generate)
+
+
+def ensure_control_plane_secrets(*, generate: bool = True) -> tuple[str, str]:
+    do_generate = generate and not _generate_disabled()
+    api_key = resolve_api_key(generate=do_generate)
+    auth_secret = resolve_auth_secret(generate=do_generate)
+    missing: list[str] = []
+    if not api_key:
+        missing.append(API_KEY_ENV)
+    if not auth_secret:
+        missing.append(AUTH_SECRET_ENV)
+    if missing:
+        dest = secrets_dir()
+        raise RuntimeError(
+            f"Missing {', '.join(missing)}. Set them in the environment or run "
+            f"python -m api.control_plane_secrets --write (writes under {dest})."
+        )
+    os.environ[API_KEY_ENV] = api_key
+    os.environ[AUTH_SECRET_ENV] = auth_secret
+    return api_key, auth_secret
+
+
+def presented_matches(presented: str | None, expected: str) -> bool:
+    import secrets as _secrets
+
+    if not presented or not expected:
+        return False
+    try:
+        return _secrets.compare_digest(presented, expected)
+    except (TypeError, ValueError):
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate or load AIMM_API_KEY and AIMM_AUTH_SECRET."
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Persist secrets under AIMM_SECRETS_DIR (or <repo>/.secrets).",
+    )
+    parser.add_argument(
+        "--export-shell",
+        action="store_true",
+        help="Print `export VAR=...` lines for eval in an entrypoint.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        api_key, auth_secret = ensure_control_plane_secrets(generate=True)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    dest = secrets_dir()
+    if args.write:
+        persist_secrets(api_key, auth_secret)
+    if args.write or not args.export_shell:
+        print(f"secrets ready under {dest}/ ({API_KEY_FILENAME}, {AUTH_SECRET_FILENAME})")
+
+    if args.export_shell:
+        print(f"export {API_KEY_ENV}={shlex.quote(api_key)}")
+        print(f"export {AUTH_SECRET_ENV}={shlex.quote(auth_secret)}")
+        print(f"export {SECRETS_DIR_ENV}={shlex.quote(str(dest))}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/control_plane_secrets.py
+++ b/src/api/control_plane_secrets.py
@@ -1,4 +1,4 @@
-"""AIMM_API_KEY / AIMM_AUTH_SECRET: env, then .secrets/, else generate once."""
+"""AIMM_API_KEY / AIMM_AUTH_SECRET / POSTGRES_PASSWORD: env, then .secrets/, else generate once."""
 
 from __future__ import annotations
 
@@ -18,6 +18,9 @@ DISABLE_GENERATE_ENV = "AIMM_DISABLE_SECRET_GENERATE"
 
 API_KEY_FILENAME = "api_key"
 AUTH_SECRET_FILENAME = "auth_secret"
+POSTGRES_PASSWORD_ENV = "POSTGRES_PASSWORD"
+POSTGRES_PASSWORD_FILENAME = "postgres_password"
+DATABASE_URL_ENV = "DATABASE_URL"
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -75,9 +78,16 @@ def _replace_secret_file(path: Path, value: str) -> None:
     os.replace(tmp, path)
 
 
-def persist_secrets(api_key: str, auth_secret: str) -> None:
+def persist_secrets(
+    api_key: str,
+    auth_secret: str,
+    postgres_password: str | None = None,
+) -> None:
     dest = secrets_dir()
-    for name, value in ((API_KEY_FILENAME, api_key), (AUTH_SECRET_FILENAME, auth_secret)):
+    pairs = [(API_KEY_FILENAME, api_key), (AUTH_SECRET_FILENAME, auth_secret)]
+    if postgres_password:
+        pairs.append((POSTGRES_PASSWORD_FILENAME, postgres_password))
+    for name, value in pairs:
         path = dest / name
         existing = None
         try:
@@ -135,6 +145,73 @@ def resolve_auth_secret(*, generate: bool = False) -> str | None:
     return resolve_secret(AUTH_SECRET_ENV, AUTH_SECRET_FILENAME, generate=generate)
 
 
+def _database_url_from_env() -> str | None:
+    return (os.getenv(DATABASE_URL_ENV) or "").strip() or None
+
+
+DEFAULT_POSTGRES_PORT = "5433"
+
+
+def _parse_database_url(url: str):
+    from urllib.parse import urlparse
+
+    normalized = url
+    for prefix in ("postgresql+psycopg://", "postgresql+asyncpg://"):
+        if normalized.startswith(prefix):
+            normalized = "postgresql://" + normalized[len(prefix) :]
+            break
+    return urlparse(normalized)
+
+
+def _should_build_database_url(url: str | None) -> bool:
+    if not url:
+        return True
+    return (_parse_database_url(url).hostname or "").lower() == "db"
+
+
+def build_database_url(password: str) -> str:
+    from urllib.parse import quote
+
+    user = (os.getenv("POSTGRES_USER") or "aimm").strip() or "aimm"
+    host = (os.getenv("POSTGRES_HOST") or "db").strip() or "db"
+    name = (os.getenv("POSTGRES_DB") or "aimm").strip() or "aimm"
+    port = (os.getenv("POSTGRES_PORT") or DEFAULT_POSTGRES_PORT).strip() or DEFAULT_POSTGRES_PORT
+    return (
+        f"postgresql+psycopg://{quote(user, safe='')}:{quote(password, safe='')}"
+        f"@{host}:{port}/{quote(name, safe='')}"
+    )
+
+
+def _apply_postgres_password(password: str) -> None:
+    os.environ[POSTGRES_PASSWORD_ENV] = password
+    if _should_build_database_url(_database_url_from_env()):
+        os.environ[DATABASE_URL_ENV] = build_database_url(password)
+
+
+def ensure_postgres_password(*, generate: bool = True) -> str | None:
+    from_env = _from_env(POSTGRES_PASSWORD_ENV)
+    if from_env:
+        _apply_postgres_password(from_env)
+        return from_env
+    path = secrets_dir() / POSTGRES_PASSWORD_FILENAME
+    loaded = _read_secret_file(path)
+    if loaded:
+        _apply_postgres_password(loaded)
+        return loaded
+    if not (generate and not _generate_disabled()):
+        return None
+    created = generate_secret()
+    try:
+        _write_secret_file(path, created)
+        loaded = created
+    except FileExistsError:
+        loaded = _read_secret_file(path)
+    if not loaded:
+        return None
+    _apply_postgres_password(loaded)
+    return loaded
+
+
 def ensure_control_plane_secrets(*, generate: bool = True) -> tuple[str, str]:
     do_generate = generate and not _generate_disabled()
     api_key = resolve_api_key(generate=do_generate)
@@ -184,20 +261,29 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         api_key, auth_secret = ensure_control_plane_secrets(generate=True)
+        postgres_password = ensure_postgres_password(generate=True)
     except RuntimeError as exc:
         print(str(exc), file=sys.stderr)
         return 1
 
     dest = secrets_dir()
     if args.write:
-        persist_secrets(api_key, auth_secret)
+        persist_secrets(api_key, auth_secret, postgres_password=postgres_password)
     if args.write or not args.export_shell:
-        print(f"secrets ready under {dest}/ ({API_KEY_FILENAME}, {AUTH_SECRET_FILENAME})")
+        names = f"{API_KEY_FILENAME}, {AUTH_SECRET_FILENAME}"
+        if postgres_password:
+            names += f", {POSTGRES_PASSWORD_FILENAME}"
+        print(f"secrets ready under {dest}/ ({names})")
 
     if args.export_shell:
         print(f"export {API_KEY_ENV}={shlex.quote(api_key)}")
         print(f"export {AUTH_SECRET_ENV}={shlex.quote(auth_secret)}")
         print(f"export {SECRETS_DIR_ENV}={shlex.quote(str(dest))}")
+        if postgres_password:
+            print(f"export {POSTGRES_PASSWORD_ENV}={shlex.quote(postgres_password)}")
+            db_url = _database_url_from_env() or os.getenv(DATABASE_URL_ENV) or ""
+            if db_url:
+                print(f"export {DATABASE_URL_ENV}={shlex.quote(db_url)}")
 
     return 0
 

--- a/src/api/engine_routes.py
+++ b/src/api/engine_routes.py
@@ -26,7 +26,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class PaperStartRequest(BaseModel):
-    ticker: str = Field("BTC/USDT", min_length=3, max_length=64)
+    ticker: str = Field(
+        "BTC/USDT", min_length=3, max_length=64, pattern=r"^[A-Za-z0-9][A-Za-z0-9/._-]{1,62}$"
+    )
     interval_sec: int = Field(900, ge=300, le=3600)
 
 

--- a/src/api/flow_stream_server.py
+++ b/src/api/flow_stream_server.py
@@ -26,6 +26,7 @@ from .capabilities_routes import router as capabilities_router
 from .config_designer_routes import router as config_designer_router
 from .control_plane_secrets import (
     ensure_control_plane_secrets,
+    ensure_postgres_password,
     is_usable_secret,
     presented_matches,
 )
@@ -66,6 +67,7 @@ DEFAULT_TAIL_MESSAGE_LOG = int((os.getenv("AIMM_UI_TAIL_MESSAGES") or "600").str
 @asynccontextmanager
 async def _lifespan(_app: FastAPI):
     ensure_control_plane_secrets(generate=True)
+    ensure_postgres_password(generate=True)
     # Daemon backtest threads die on restart; flip orphaned job.json out of "running".
     try:
         recover_stale_backtest_jobs(reason="api_startup")

--- a/src/api/flow_stream_server.py
+++ b/src/api/flow_stream_server.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, Query, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
@@ -24,6 +24,11 @@ from .backtest_routes import recover_stale_backtest_jobs
 from .backtest_routes import router as backtest_router
 from .capabilities_routes import router as capabilities_router
 from .config_designer_routes import router as config_designer_router
+from .control_plane_secrets import (
+    ensure_control_plane_secrets,
+    is_usable_secret,
+    presented_matches,
+)
 from .copy_routes import router as copy_router
 from .deploy_routes import router as deploy_router
 from .engine_routes import router as engine_router
@@ -37,6 +42,7 @@ from .profile_routes import router as profile_router
 from .provider_admin_routes import router as provider_admin_router
 from .public_provider_routes import router as public_provider_router
 from .runtime_settings_routes import router as runtime_settings_router
+from .safe_ids import path_under, require_safe_id
 from .schema_validation import validate_nexus_payload
 from .signal_routes import router as signal_router
 from .studio_routes import router as studio_router
@@ -59,6 +65,7 @@ DEFAULT_TAIL_MESSAGE_LOG = int((os.getenv("AIMM_UI_TAIL_MESSAGES") or "600").str
 
 @asynccontextmanager
 async def _lifespan(_app: FastAPI):
+    ensure_control_plane_secrets(generate=True)
     # Daemon backtest threads die on restart; flip orphaned job.json out of "running".
     try:
         recover_stale_backtest_jobs(reason="api_startup")
@@ -67,65 +74,95 @@ async def _lifespan(_app: FastAPI):
     yield
 
 
-app = FastAPI(title="AI Market Maker Flow Stream", version="0.1.0", lifespan=_lifespan)
+_enable_docs = (os.getenv("AIMM_ENABLE_DOCS") or "").strip().lower() in {"1", "true", "yes", "on"}
+app = FastAPI(
+    title="AI Market Maker Flow Stream",
+    version="0.1.0",
+    lifespan=_lifespan,
+    docs_url="/docs" if _enable_docs else None,
+    redoc_url="/redoc" if _enable_docs else None,
+    openapi_url="/openapi.json" if _enable_docs else None,
+)
 
 
 def _expected_api_key() -> str | None:
     v = (os.getenv("AIMM_API_KEY") or "").strip()
-    return v or None
+    return v if is_usable_secret(v) else None
 
 
 def _extract_presented_key(request: Request) -> str | None:
-    # Prefer explicit X-API-Key; allow Authorization: Bearer for common gateways.
+    # Bearer is also used for user JWTs, so only accept it when it is the API key.
     x = (request.headers.get("x-api-key") or "").strip()
     if x:
         return x
     auth = (request.headers.get("authorization") or "").strip()
     if auth.lower().startswith("bearer "):
         token = auth.split(" ", 1)[1].strip()
-        return token or None
+        expected = _expected_api_key()
+        if token and expected and presented_matches(token, expected):
+            return token
     return None
+
+
+def _is_public_http_path(path: str) -> bool:
+    return path == "/health"
+
+
+def _with_security_headers(response):
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+    response.headers.setdefault("Cache-Control", "no-store")
+    return response
 
 
 @app.middleware("http")
 async def api_key_middleware(request: Request, call_next):
+    if _is_public_http_path(request.url.path):
+        return _with_security_headers(await call_next(request))
+
     expected = _expected_api_key()
     if expected is None:
-        return await call_next(request)
-
-    # Always allow unauthenticated health checks.
-    if request.url.path == "/health":
-        return await call_next(request)
-
-    # Allow same-host calls (e.g. Next.js proxy running on the same machine/container).
-    # This keeps the web UI functional without leaking the key to browsers.
-    client_host = getattr(getattr(request, "client", None), "host", None)
-    if client_host in {"127.0.0.1", "::1"}:
-        return await call_next(request)
-
-    presented = _extract_presented_key(request)
-    if presented != expected:
-        return JSONResponse(
-            {"error": "unauthorized", "hint": "Set x-api-key (or Authorization: Bearer)"},
-            status_code=HTTP_401_UNAUTHORIZED,
+        return _with_security_headers(
+            JSONResponse(
+                {
+                    "error": "api_key_not_configured",
+                    "hint": "Set AIMM_API_KEY or run python -m api.control_plane_secrets --write",
+                },
+                status_code=503,
+            )
         )
 
-    return await call_next(request)
+    presented = _extract_presented_key(request)
+    if not presented_matches(presented, expected):
+        return _with_security_headers(
+            JSONResponse(
+                {
+                    "error": "unauthorized",
+                    "hint": "Set x-api-key (or Authorization: Bearer with the API key)",
+                },
+                status_code=HTTP_401_UNAUTHORIZED,
+            )
+        )
+
+    return _with_security_headers(await call_next(request))
 
 
-_cors_origins_raw = (os.getenv("AIMM_CORS_ORIGINS") or "*").strip()
+_cors_origins_raw = (os.getenv("AIMM_CORS_ORIGINS") or "").strip()
 _cors_allow_origins = (
     ["*"]
     if _cors_origins_raw == "*"
     else [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
 )
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_cors_allow_origins or ["*"],
-    allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+if _cors_allow_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_cors_allow_origins,
+        allow_credentials=False,
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "x-api-key", "x-aimm-dashboard"],
+    )
 app.include_router(backtest_router)
 app.include_router(agent_prompt_router)
 app.include_router(runtime_settings_router)
@@ -155,23 +192,30 @@ def _resolve_run_log(run_id: str) -> Path:
 
         resolved = resolve_alias(run_id)
         if resolved:
-            return RUNS_DIR / f"{resolved}.events.jsonl"
+            rid = require_safe_id(resolved, name="run_id")
+            return path_under(RUNS_DIR, f"{rid}.events.jsonl")
+    except HTTPException:
+        raise
     except Exception:
         pass
-    rid = (run_id or "").strip()
+    rid = require_safe_id((run_id or "").strip(), name="run_id")
     if rid == "latest" and LATEST_RUN_FILE.exists():
-        latest = LATEST_RUN_FILE.read_text().strip()
-        if latest and not latest.lower().startswith("bt"):
-            return RUNS_DIR / f"{latest}.events.jsonl"
+        latest_raw = LATEST_RUN_FILE.read_text().strip()
+        if latest_raw:
+            latest = require_safe_id(latest_raw, name="run_id")
+            if latest and not latest.lower().startswith("bt"):
+                return path_under(RUNS_DIR, f"{latest}.events.jsonl")
     if rid in ("latest-paper", "latest_paper", "paper") and LATEST_PAPER_FILE.exists():
-        latest = LATEST_PAPER_FILE.read_text().strip()
-        if latest:
-            return RUNS_DIR / f"{latest}.events.jsonl"
+        latest_raw = LATEST_PAPER_FILE.read_text().strip()
+        if latest_raw:
+            latest = require_safe_id(latest_raw, name="run_id")
+            return path_under(RUNS_DIR, f"{latest}.events.jsonl")
     if rid in ("latest-backtest", "latest_backtest", "backtest") and LATEST_BACKTEST_FILE.exists():
-        latest = LATEST_BACKTEST_FILE.read_text().strip()
-        if latest:
-            return RUNS_DIR / f"{latest}.events.jsonl"
-    return RUNS_DIR / f"{rid}.events.jsonl"
+        latest_raw = LATEST_BACKTEST_FILE.read_text().strip()
+        if latest_raw:
+            latest = require_safe_id(latest_raw, name="run_id")
+            return path_under(RUNS_DIR, f"{latest}.events.jsonl")
+    return path_under(RUNS_DIR, f"{rid}.events.jsonl")
 
 
 @app.get("/health")
@@ -294,24 +338,18 @@ def run_payload(
 @app.websocket("/ws/runs/{run_id}")
 async def ws_run_payload(websocket: WebSocket, run_id: str) -> None:
     expected = _expected_api_key()
-    if expected is not None:
-        client_host = getattr(getattr(websocket, "client", None), "host", None)
-        if client_host in {"127.0.0.1", "::1"}:
-            await websocket.accept()
-        else:
-            presented = (websocket.headers.get("x-api-key") or "").strip()
-            if not presented:
-                auth = (websocket.headers.get("authorization") or "").strip()
-                if auth.lower().startswith("bearer "):
-                    presented = auth.split(" ", 1)[1].strip()
-            if not presented:
-                presented = (websocket.query_params.get("api_key") or "").strip()
-            if presented != expected:
-                await websocket.close(code=1008)
-                return
-            await websocket.accept()
-    else:
-        await websocket.accept()
+    if expected is None:
+        await websocket.close(code=1011)
+        return
+    presented = (websocket.headers.get("x-api-key") or "").strip()
+    if not presented:
+        auth = (websocket.headers.get("authorization") or "").strip()
+        if auth.lower().startswith("bearer "):
+            presented = auth.split(" ", 1)[1].strip()
+    if not presented_matches(presented, expected):
+        await websocket.close(code=1008)
+        return
+    await websocket.accept()
     try:
         while True:
             log_path = _resolve_run_log(run_id)

--- a/src/api/leadpage_routes.py
+++ b/src/api/leadpage_routes.py
@@ -25,7 +25,9 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 
+from api.control_plane_secrets import presented_matches
 from api.leadpage_validation import validate_result
+from api.safe_ids import path_under, require_safe_id
 from api.wallet_auth import (
     generate_provider_key,
     make_challenge,
@@ -255,7 +257,7 @@ def _auth_provider_or_401(request: Request, provider: str) -> None:
     if not expected:
         raise HTTPException(status_code=401, detail=f"unknown provider: {provider}")
     presented = _presented_provider_key(request)
-    if presented != expected:
+    if not presented_matches(presented, expected):
         raise HTTPException(
             status_code=401,
             detail="unauthorized (set x-leadpage-provider-key or x-api-key)",
@@ -428,7 +430,11 @@ def _append_jsonl(path: Path, row: dict[str, Any]) -> None:
 
 
 def _load_local_summary(run_id: str) -> dict[str, Any] | None:
-    p = BACKTESTS_DIR / run_id / "summary.json"
+    try:
+        rid = require_safe_id(run_id, name="run_id")
+        p = path_under(BACKTESTS_DIR, rid, "summary.json")
+    except HTTPException:
+        return None
     if not p.is_file():
         return None
     try:

--- a/src/api/pm_routes.py
+++ b/src/api/pm_routes.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 
 from adapters.nexus_adapter import get_nexus_adapter
 from api.payload_adapter import build_nexus_payload
+from api.safe_ids import path_under, require_safe_id
 from backtest.exchange_trade_format import (
     trade_row_fee_usd,
     trade_row_side,
@@ -99,7 +100,7 @@ def _extract_first_json_object(text: str) -> dict[str, Any] | None:
 
 
 def _resolve_backtest_dir(run_id: str) -> Path:
-    rid = (run_id or "").strip()
+    rid = require_safe_id((run_id or "").strip(), name="run_id")
     if rid == "latest":
         # Prefer newest *completed* bt-* (must have summary.json). Orphaned
         # mid-run folders get fresh mtimes when job.json is updated on restart.
@@ -114,24 +115,28 @@ def _resolve_backtest_dir(run_id: str) -> Path:
                 reverse=True,
             )
             if candidates:
-                rid = candidates[0].name
+                rid = require_safe_id(candidates[0].name, name="run_id")
         if rid == "latest" and LATEST_RUN_FILE.exists():
-            latest = LATEST_RUN_FILE.read_text().strip()
-            if latest.startswith("bt") and (BACKTESTS_DIR / latest / "summary.json").is_file():
-                rid = latest
-    d = BACKTESTS_DIR / rid
+            latest_raw = LATEST_RUN_FILE.read_text().strip()
+            if (
+                latest_raw
+                and latest_raw.startswith("bt")
+                and (BACKTESTS_DIR / latest_raw / "summary.json").is_file()
+            ):
+                rid = require_safe_id(latest_raw, name="run_id")
+    d = path_under(BACKTESTS_DIR, rid)
     if not d.exists():
         raise HTTPException(status_code=404, detail=f"run not found: {rid}")
     return d
 
 
 def _resolve_run_log(run_id: str) -> Path:
-    rid = run_id
+    rid = require_safe_id(run_id, name="run_id")
     if rid == "latest" and LATEST_RUN_FILE.exists():
-        latest = LATEST_RUN_FILE.read_text().strip()
-        if latest:
-            rid = latest
-    return RUNS_DIR / f"{rid}.events.jsonl"
+        latest_raw = LATEST_RUN_FILE.read_text().strip()
+        if latest_raw:
+            rid = require_safe_id(latest_raw, name="run_id")
+    return path_under(RUNS_DIR, f"{rid}.events.jsonl")
 
 
 def _is_stable_pair(sym: str) -> bool:

--- a/src/api/safe_ids.py
+++ b/src/api/safe_ids.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from fastapi import HTTPException
+
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_RUN_ALIASES = frozenset(
+    {
+        "latest",
+        "latest-paper",
+        "latest_paper",
+        "paper",
+        "latest-backtest",
+        "latest_backtest",
+        "backtest",
+    }
+)
+
+
+def require_safe_id(value: str, *, name: str = "id") -> str:
+    v = (value or "").strip()
+    if v in _RUN_ALIASES:
+        return v
+    if not _SAFE_ID_RE.fullmatch(v):
+        raise HTTPException(status_code=400, detail=f"invalid {name}")
+    return v
+
+
+def path_under(root: Path, *parts: str) -> Path:
+    root_r = root.resolve()
+    candidate = root_r.joinpath(*parts).resolve()
+    try:
+        candidate.relative_to(root_r)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid path") from exc
+    return candidate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+TEST_AIMM_API_KEY = "pytest-aimm-api-key-not-for-production-use"
+TEST_AIMM_AUTH_SECRET = "pytest-aimm-auth-secret-not-for-production"
+
+
+@pytest.fixture(autouse=True)
+def _control_plane_test_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIMM_API_KEY", TEST_AIMM_API_KEY)
+    monkeypatch.setenv("AIMM_AUTH_SECRET", TEST_AIMM_AUTH_SECRET)
+    monkeypatch.setenv("AIMM_DISABLE_SECRET_GENERATE", "1")
+
+
+def flow_auth_headers() -> dict[str, str]:
+    return {"x-api-key": os.environ["AIMM_API_KEY"]}

--- a/tests/test_agent_prompt_routes.py
+++ b/tests/test_agent_prompt_routes.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+from conftest import flow_auth_headers
 from fastapi.testclient import TestClient
 
 from api.flow_stream_server import app
@@ -14,7 +15,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     # Use an isolated prompts file per test run.
     prompts_path = tmp_path / "agent_prompts.json"
     monkeypatch.setenv("AIMM_AGENT_PROMPTS_PATH", str(prompts_path))
-    return TestClient(app)
+    return TestClient(app, headers=flow_auth_headers())
 
 
 def test_put_creates_row_then_get_roundtrip(client: TestClient, tmp_path: Path) -> None:

--- a/tests/test_control_plane_auth.py
+++ b/tests/test_control_plane_auth.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conftest import TEST_AIMM_API_KEY, flow_auth_headers
+from fastapi.testclient import TestClient
+
+from api.control_plane_secrets import (
+    generate_secret,
+    is_usable_secret,
+    presented_matches,
+)
+
+
+def test_empty_secret_is_not_usable() -> None:
+    assert not is_usable_secret("")
+    assert not is_usable_secret(None)
+    assert not is_usable_secret("   ")
+    assert is_usable_secret("any-user-set-value")
+    assert is_usable_secret(generate_secret())
+    assert is_usable_secret(TEST_AIMM_API_KEY)
+
+
+def test_generated_secrets_are_unique() -> None:
+    a = generate_secret()
+    b = generate_secret()
+    assert a != b
+    assert is_usable_secret(a) and is_usable_secret(b)
+
+
+def test_ensure_writes_unique_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AIMM_API_KEY", raising=False)
+    monkeypatch.delenv("AIMM_AUTH_SECRET", raising=False)
+    monkeypatch.delenv("AIMM_DISABLE_SECRET_GENERATE", raising=False)
+    monkeypatch.setenv("AIMM_SECRETS_DIR", str(tmp_path))
+    from api.control_plane_secrets import ensure_control_plane_secrets
+
+    k1, s1 = ensure_control_plane_secrets(generate=True)
+    k2, s2 = ensure_control_plane_secrets(generate=True)
+    assert k1 == k2 and s1 == s2
+    assert (tmp_path / "api_key").read_text(encoding="utf-8") == k1
+    assert (tmp_path / "auth_secret").read_text(encoding="utf-8") == s1
+    assert is_usable_secret(k1) and is_usable_secret(s1)
+
+
+def test_user_env_secrets_are_used_not_regenerated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_key = "my-own-key"
+    user_secret = "my-own-secret"
+    leftover_key = "leftover-generated-api-key-not-used-xx"
+    leftover_secret = "leftover-generated-auth-secret-not-used"
+    (tmp_path / "api_key").write_text(leftover_key, encoding="utf-8")
+    (tmp_path / "auth_secret").write_text(leftover_secret, encoding="utf-8")
+    monkeypatch.setenv("AIMM_API_KEY", user_key)
+    monkeypatch.setenv("AIMM_AUTH_SECRET", user_secret)
+    monkeypatch.delenv("AIMM_DISABLE_SECRET_GENERATE", raising=False)
+    monkeypatch.setenv("AIMM_SECRETS_DIR", str(tmp_path))
+    from api.control_plane_secrets import ensure_control_plane_secrets, persist_secrets
+
+    k1, s1 = ensure_control_plane_secrets(generate=True)
+    k2, s2 = ensure_control_plane_secrets(generate=True)
+    assert k1 == user_key == k2
+    assert s1 == user_secret == s2
+    persist_secrets(k1, s1)
+    assert (tmp_path / "api_key").read_text(encoding="utf-8") == user_key
+    assert (tmp_path / "auth_secret").read_text(encoding="utf-8") == user_secret
+
+
+def test_disable_generate_refuses_missing_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AIMM_API_KEY", raising=False)
+    monkeypatch.delenv("AIMM_AUTH_SECRET", raising=False)
+    monkeypatch.setenv("AIMM_DISABLE_SECRET_GENERATE", "1")
+    monkeypatch.setenv("AIMM_SECRETS_DIR", str(tmp_path))
+    from api.control_plane_secrets import ensure_control_plane_secrets
+
+    with pytest.raises(RuntimeError, match="Missing"):
+        ensure_control_plane_secrets(generate=True)
+
+
+def test_health_is_public() -> None:
+    from api.flow_stream_server import app
+
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json().get("ok") is True
+
+
+def test_control_plane_rejects_missing_api_key() -> None:
+    from api.flow_stream_server import app
+
+    client = TestClient(app)
+    for method, path in (
+        ("get", "/deploy-config"),
+        ("get", "/runtime-settings"),
+        ("get", "/engine/paper/status"),
+        ("post", "/engine/paper/stop"),
+        ("put", "/agent-prompts/n13"),
+    ):
+        r = getattr(client, method)(path)
+        assert r.status_code == 401, (path, r.status_code, r.text)
+
+
+def test_control_plane_rejects_wrong_key() -> None:
+    from api.flow_stream_server import app
+
+    client = TestClient(app)
+    for bad in ("wrong-key-not-matching", ""):
+        r = client.get("/deploy-config", headers={"x-api-key": bad})
+        assert r.status_code == 401, bad
+
+
+def test_control_plane_accepts_configured_key() -> None:
+    from api.flow_stream_server import app
+
+    client = TestClient(app, headers=flow_auth_headers())
+    r = client.get("/health")
+    assert r.status_code == 200
+    r = client.get("/deploy-config")
+    assert r.status_code != 401
+
+
+def test_loopback_does_not_bypass_auth() -> None:
+    from api.flow_stream_server import app
+
+    client = TestClient(app)
+    r = client.get("/runtime-settings")
+    assert r.status_code == 401
+
+
+def test_compare_digest_rejects_mismatch() -> None:
+    key = generate_secret()
+    assert presented_matches(key, key)
+    assert not presented_matches("nope", key)
+    assert not presented_matches(None, key)
+    assert not presented_matches(key, "")
+
+
+def test_path_traversal_run_id_rejected() -> None:
+    from api.flow_stream_server import app
+
+    client = TestClient(app, headers=flow_auth_headers())
+    r = client.get("/runs/../etc/passwd/events")
+    assert r.status_code in {400, 404}
+    r2 = client.get("/runs/%2e%2e%2fetc%2fpasswd/payload")
+    assert r2.status_code in {400, 404}
+
+
+def test_openapi_disabled_by_default() -> None:
+    from api.flow_stream_server import app
+
+    client = TestClient(app, headers=flow_auth_headers())
+    r = client.get("/openapi.json")
+    assert r.status_code in {404, 405}
+
+
+def test_security_headers_present() -> None:
+    from api.flow_stream_server import app
+
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.headers.get("x-content-type-options") == "nosniff"
+    assert r.headers.get("x-frame-options") == "DENY"
+
+
+def test_jwt_secret_requires_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIMM_AUTH_SECRET", "")
+    from api.auth_routes import _jwt_secret
+
+    with pytest.raises(RuntimeError, match="AIMM_AUTH_SECRET"):
+        _jwt_secret()
+    monkeypatch.setenv("AIMM_AUTH_SECRET", "any-user-secret")
+    assert _jwt_secret() == "any-user-secret"
+
+
+def test_require_safe_id_rejects_traversal() -> None:
+    from fastapi import HTTPException
+
+    from api.safe_ids import require_safe_id
+
+    with pytest.raises(HTTPException) as ei:
+        require_safe_id("../etc/passwd", name="run_id")
+    assert ei.value.status_code == 400
+    assert require_safe_id("bt_abc-1", name="run_id") == "bt_abc-1"

--- a/tests/test_flow_futu_price_route.py
+++ b/tests/test_flow_futu_price_route.py
@@ -25,9 +25,11 @@ def test_futu_price_endpoint_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(futu_mod, "FutuAdapter", StubAdapter)
 
+    from conftest import flow_auth_headers
+
     from api.flow_stream_server import app
 
-    client = TestClient(app)
+    client = TestClient(app, headers=flow_auth_headers())
     r = client.get("/futu/price?symbol=HK.09999&interval=1d&limit=200")
     assert r.status_code == 200
     body = r.json()
@@ -50,9 +52,11 @@ def test_futu_status_endpoint_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(futu_mod, "FutuAdapter", StubAdapter)
 
+    from conftest import flow_auth_headers
+
     from api.flow_stream_server import app
 
-    client = TestClient(app)
+    client = TestClient(app, headers=flow_auth_headers())
     r = client.get("/futu/status")
     assert r.status_code == 200
     body = r.json()
@@ -69,9 +73,11 @@ def test_futu_status_endpoint_returns_body_when_adapter_raises(
 
     monkeypatch.setattr(futu_mod, "FutuAdapter", BadAdapter)
 
+    from conftest import flow_auth_headers
+
     from api.flow_stream_server import app
 
-    client = TestClient(app)
+    client = TestClient(app, headers=flow_auth_headers())
     r = client.get("/futu/status")
     assert r.status_code == 200
     body = r.json()
@@ -92,9 +98,11 @@ def test_futu_price_endpoint_502_when_adapter_raises(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(futu_mod, "FutuAdapter", BadAdapter)
 
+    from conftest import flow_auth_headers
+
     from api.flow_stream_server import app
 
-    client = TestClient(app)
+    client = TestClient(app, headers=flow_auth_headers())
     r = client.get("/futu/price")
     assert r.status_code == 502
     assert "OpenD" in r.json().get("detail", "")

--- a/web/.env.example
+++ b/web/.env.example
@@ -5,8 +5,5 @@ NEXT_PUBLIC_FLOW_API_BASE_URL=http://127.0.0.1:8001
 NEXT_PUBLIC_FLOW_WS_URL=ws://127.0.0.1:8001/ws/runs/latest
 NEXT_PUBLIC_FLOW_ALLOW_MOCK_FALLBACK=0
 
-# If Flow has AIMM_API_KEY set, Next must send the same key (non-loopback clients get 401 otherwise).
-# AIMM_API_KEY=
-
 # Dockerized Next: docker-compose.prod.yml pins FLOW_API_BASE_URL=http://api:8001 for the web
 # container (do not use host 127.0.0.1 there — server routes would call the wrong host).

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,7 +20,10 @@ COPY --from=builder /app/package.json /app/package.json
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/.next /app/.next
 COPY --from=builder /app/public /app/public
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 EXPOSE 3000
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["npm", "run", "start"]
 

--- a/web/docker-entrypoint.sh
+++ b/web/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+SECRETS_DIR="${AIMM_SECRETS_DIR:-/run/aimm-secrets}"
+
+if [ -z "${AIMM_API_KEY:-}" ] && [ -f "${SECRETS_DIR}/api_key" ]; then
+  AIMM_API_KEY="$(tr -d '\n\r' < "${SECRETS_DIR}/api_key")"
+  export AIMM_API_KEY
+fi
+
+if [ -z "${AIMM_API_KEY:-}" ]; then
+  echo "web: AIMM_API_KEY is required (no default). Wait for secrets-init or set AIMM_API_KEY." >&2
+  exit 1
+fi
+
+exec "$@"

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,8 +1,40 @@
 /** @type {import('next').NextConfig} */
+const fs = require("fs");
+const path = require("path");
+
+// next dev only — Docker sets AIMM_API_KEY in the entrypoint from the shared volume.
+if (process.env.NODE_ENV !== "production" && !process.env.AIMM_API_KEY) {
+  try {
+    const fromFile = fs
+      .readFileSync(path.join(__dirname, "..", ".secrets", "api_key"), "utf8")
+      .trim();
+    if (fromFile) process.env.AIMM_API_KEY = fromFile;
+  } catch {}
+}
+
 const nextConfig = {
   // We use Next route handlers (`app/api/*`) as lightweight proxies to the Python backend,
   // so we cannot use `output: "export"` (static export forbids dynamic routes).
   output: "standalone",
   trailingSlash: false,
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "no-referrer" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+          {
+            key: "Content-Security-Policy",
+            value:
+              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+          },
+        ],
+      },
+    ];
+  },
 };
 module.exports = nextConfig;

--- a/web/src/app/api/_flowAuth.ts
+++ b/web/src/app/api/_flowAuth.ts
@@ -1,5 +1,0 @@
-/** Server-only: optional `x-api-key` for Flow API when `AIMM_API_KEY` is set (same name as Python). */
-export function flowAuthHeaders(): Record<string, string> {
-  const key = (process.env["AIMM_API_KEY"] ?? process.env["FLOW_API_KEY"] ?? "").trim();
-  return key ? { "x-api-key": key } : {};
-}

--- a/web/src/app/api/agent-prompts/[nodeId]/route.ts
+++ b/web/src/app/api/agent-prompts/[nodeId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { flowAuthHeaders } from "../../_flowAuth";
+import { flowAuthHeaders } from "@/server/flowProxy";
 
 function flowBase(): string {
   return process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";

--- a/web/src/app/api/backtests/preset/route.ts
+++ b/web/src/app/api/backtests/preset/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { flowAuthHeaders } from "../../_flowAuth";
+import { flowAuthHeaders } from "@/server/flowProxy";
 
 /** Proxy to Flow API: POST /backtests/preset (named Quant strategy preset). */
 export async function POST(req: Request) {

--- a/web/src/app/api/backtests/route.ts
+++ b/web/src/app/api/backtests/route.ts
@@ -1,5 +1,4 @@
-import { flowAuthHeaders } from "../_flowAuth";
-import { flowApiBase, proxyJson } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase, proxyJson } from "@/server/flowProxy";
 
 /** Proxy: GET /backtests — list run_ids under .runs/backtests/ */
 export async function GET() {

--- a/web/src/app/api/copy/executions/route.ts
+++ b/web/src/app/api/copy/executions/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
+import { flowAuthHeaders } from "@/server/flowProxy";
 import { getPlatformAuthHeader } from "../../platform/_session";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const params = url.searchParams.toString();
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";
-  const headers = { ...(await getPlatformAuthHeader()) };
+  const headers = { ...flowAuthHeaders(), ...(await getPlatformAuthHeader()) };
   const res = await fetch(`${flowApiBase}/copy/executions${params ? `?${params}` : ""}`, {
     cache: "no-store",
     headers,

--- a/web/src/app/api/flow/[...path]/route.ts
+++ b/web/src/app/api/flow/[...path]/route.ts
@@ -1,0 +1,132 @@
+import { flowApiBase, flowAuthHeaders } from "@/server/flowProxy";
+
+export const dynamic = "force-dynamic";
+
+const DASHBOARD_HEADER = "x-aimm-dashboard";
+
+const ALLOWED_PREFIXES = [
+  "runs/",
+  "backtests",
+  "engine/",
+  "capabilities",
+  "ops/",
+  "runtime-settings",
+  "signals/",
+  "deploy-config",
+  "agent-prompts",
+  "pm/",
+  "studio/",
+  "futu/",
+  "tools",
+  "strategies",
+];
+
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+]);
+
+function pathAllowed(parts: string[]): boolean {
+  if (parts.some((p) => p.includes("..") || p.includes("/") || p.includes("\\"))) {
+    return false;
+  }
+  const joined = parts.join("/");
+  return ALLOWED_PREFIXES.some(
+    (prefix) => joined === prefix.replace(/\/$/, "") || joined.startsWith(prefix),
+  );
+}
+
+function isSameOrigin(request: Request): boolean {
+  const reqUrl = new URL(request.url);
+  const origin = request.headers.get("origin");
+  if (origin) {
+    try {
+      return new URL(origin).host === reqUrl.host;
+    } catch {
+      return false;
+    }
+  }
+  const referer = request.headers.get("referer");
+  if (referer) {
+    try {
+      return new URL(referer).host === reqUrl.host;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+async function proxyToFlow(request: Request, path: string[]): Promise<Response> {
+  if (!pathAllowed(path)) {
+    return Response.json({ error: "forbidden", hint: "path is not dashboard-proxied" }, { status: 403 });
+  }
+  const dashboardClient = request.headers.get(DASHBOARD_HEADER) === "1";
+  if (!isSameOrigin(request) && !dashboardClient) {
+    return Response.json(
+      { error: "forbidden", hint: "dashboard proxy is same-origin only" },
+      { status: 403 },
+    );
+  }
+
+  const search = new URL(request.url).search;
+  const upstream = `${flowApiBase()}/${path.map(encodeURIComponent).join("/")}${search}`;
+
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+  for (const [key, value] of Object.entries(flowAuthHeaders())) {
+    headers.set(key, value);
+  }
+
+  const method = request.method.toUpperCase();
+  const init: RequestInit = {
+    method,
+    headers,
+    cache: "no-store",
+    redirect: "manual",
+  };
+  if (!["GET", "HEAD"].includes(method)) {
+    init.body = await request.arrayBuffer();
+  }
+
+  const res = await fetch(upstream, init);
+  const outHeaders = new Headers();
+  const contentType = res.headers.get("content-type");
+  if (contentType) outHeaders.set("content-type", contentType);
+
+  return new Response(res.body, { status: res.status, headers: outHeaders });
+}
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+export async function GET(request: Request, ctx: Ctx) {
+  return proxyToFlow(request, (await ctx.params).path ?? []);
+}
+
+export async function POST(request: Request, ctx: Ctx) {
+  return proxyToFlow(request, (await ctx.params).path ?? []);
+}
+
+export async function PUT(request: Request, ctx: Ctx) {
+  return proxyToFlow(request, (await ctx.params).path ?? []);
+}
+
+export async function PATCH(request: Request, ctx: Ctx) {
+  return proxyToFlow(request, (await ctx.params).path ?? []);
+}
+
+export async function DELETE(request: Request, ctx: Ctx) {
+  return proxyToFlow(request, (await ctx.params).path ?? []);
+}

--- a/web/src/app/api/futu/place-order/route.ts
+++ b/web/src/app/api/futu/place-order/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { flowApiBase } from "@/server/flowProxy";
-import { flowAuthHeaders } from "@/app/api/_flowAuth";
+import { flowApiBase, flowAuthHeaders } from "@/server/flowProxy";
 
 /**
  * POST /api/futu/place-order

--- a/web/src/app/api/futu/price/route.ts
+++ b/web/src/app/api/futu/price/route.ts
@@ -1,13 +1,9 @@
 import { NextResponse } from "next/server";
-import { flowApiBase } from "@/server/flowProxy";
-import { flowAuthHeaders } from "@/app/api/_flowAuth";
+import { flowApiBase, flowAuthHeaders } from "@/server/flowProxy";
 
 /**
  * GET /api/futu/price?symbol=HK.00700&interval=1d&limit=200
- *
- * Proxies to Flow `/futu/price` (Futu OpenD). Forwards HTTP errors instead of hiding them
- * behind synthetic bars. Sends `x-api-key` when `AIMM_API_KEY` is set (Flow may require it
- * for non-loopback clients, e.g. Next on host → Flow in Docker).
+ * Proxies Flow `/futu/price`; forwards upstream errors instead of fake bars.
  */
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -32,7 +28,7 @@ export async function GET(request: Request) {
 
     const hint401 =
       flowRes.status === 401
-        ? "Flow has AIMM_API_KEY set; add the same AIMM_API_KEY to web/.env.local (or unset AIMM_API_KEY on the Flow process for local-only dev)."
+        ? "Flow rejected the request. Check AIMM_API_KEY on the API."
         : undefined;
 
     return NextResponse.json(

--- a/web/src/app/api/futu/status/route.ts
+++ b/web/src/app/api/futu/status/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { flowApiBase } from "@/server/flowProxy";
-import { flowAuthHeaders } from "@/app/api/_flowAuth";
+import { flowApiBase, flowAuthHeaders } from "@/server/flowProxy";
 
 /**
  * GET /api/futu/status
@@ -23,7 +22,7 @@ export async function GET() {
 
     const hint401 =
       flowRes.status === 401
-        ? "Flow has AIMM_API_KEY set; add the same AIMM_API_KEY to web/.env.local (or unset AIMM_API_KEY on the Flow process for local-only dev)."
+        ? "Flow rejected the request. Check AIMM_API_KEY on the API."
         : undefined;
 
     return NextResponse.json(

--- a/web/src/app/api/leadpage/providers/[provider]/rows/route.ts
+++ b/web/src/app/api/leadpage/providers/[provider]/rows/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { flowAuthHeaders } from "../../../../_flowAuth";
+import { flowAuthHeaders } from "@/server/flowProxy";
 
 export async function GET(request: Request, context: { params: Promise<{ provider: string }> }) {
   const { provider } = await context.params;

--- a/web/src/app/api/leadpage/providers/route.ts
+++ b/web/src/app/api/leadpage/providers/route.ts
@@ -1,5 +1,4 @@
-import { flowAuthHeaders } from "../../_flowAuth";
-import { flowApiBase, proxyJson } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase, proxyJson } from "@/server/flowProxy";
 
 export async function GET() {
   return proxyJson(`${flowApiBase()}/leadpage/providers`, {

--- a/web/src/app/api/paper/trades/route.ts
+++ b/web/src/app/api/paper/trades/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
+import { flowAuthHeaders } from "@/server/flowProxy";
 import { getPlatformAuthHeader } from "../../platform/_session";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const params = url.searchParams.toString();
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";
-  const headers = { ...(await getPlatformAuthHeader()) };
+  const headers = { ...flowAuthHeaders(), ...(await getPlatformAuthHeader()) };
   const res = await fetch(`${flowApiBase}/paper/trades${params ? `?${params}` : ""}`, {
     cache: "no-store",
     headers,

--- a/web/src/app/api/platform/login/route.ts
+++ b/web/src/app/api/platform/login/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { flowAuthHeaders } from "@/server/flowProxy";
 import { setPlatformToken } from "../_session";
 
 export async function POST(request: Request) {
@@ -6,7 +7,7 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => ({}));
   const res = await fetch(`${flowApiBase}/auth/login`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...flowAuthHeaders() },
     body: JSON.stringify(body),
   });
   const json = await res.json().catch(() => ({}));

--- a/web/src/app/api/platform/providers/[provider]/rotate-secret/route.ts
+++ b/web/src/app/api/platform/providers/[provider]/rotate-secret/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
+import { flowAuthHeaders } from "@/server/flowProxy";
 import { getPlatformAuthHeader } from "../../../_session";
 
 export async function POST(_request: Request, context: { params: Promise<{ provider: string }> }) {
   const { provider } = await context.params;
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";
-  const headers = { ...(await getPlatformAuthHeader()) };
+  const headers = { ...flowAuthHeaders(), ...(await getPlatformAuthHeader()) };
   const res = await fetch(
     `${flowApiBase}/admin/providers/${encodeURIComponent(provider)}/rotate-secret`,
     {

--- a/web/src/app/api/platform/providers/route.ts
+++ b/web/src/app/api/platform/providers/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
+import { flowAuthHeaders } from "@/server/flowProxy";
 import { getPlatformAuthHeader } from "../_session";
 
 export async function GET() {
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";
-  const headers = { ...(await getPlatformAuthHeader()) };
+  const headers = { ...flowAuthHeaders(), ...(await getPlatformAuthHeader()) };
   const res = await fetch(`${flowApiBase}/admin/providers`, {
     cache: "no-store",
     headers,
@@ -15,7 +16,11 @@ export async function GET() {
 export async function POST(request: Request) {
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";
   const body = await request.json().catch(() => ({}));
-  const headers = { "content-type": "application/json", ...(await getPlatformAuthHeader()) };
+  const headers = {
+    "content-type": "application/json",
+    ...flowAuthHeaders(),
+    ...(await getPlatformAuthHeader()),
+  };
   const res = await fetch(`${flowApiBase}/admin/providers`, {
     method: "POST",
     headers,

--- a/web/src/app/api/platform/register/route.ts
+++ b/web/src/app/api/platform/register/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { flowAuthHeaders } from "@/server/flowProxy";
 import { setPlatformToken } from "../_session";
 
 export async function POST(request: Request) {
@@ -6,7 +7,7 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => ({}));
   const res = await fetch(`${flowApiBase}/auth/register`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...flowAuthHeaders() },
     body: JSON.stringify(body),
   });
   const json = await res.json().catch(() => ({}));

--- a/web/src/app/api/pm/backtests/[runId]/ask/route.ts
+++ b/web/src/app/api/pm/backtests/[runId]/ask/route.ts
@@ -1,5 +1,4 @@
-import { flowAuthHeaders } from "../../../../_flowAuth";
-import { flowApiBase, proxyJson } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase, proxyJson } from "@/server/flowProxy";
 import { NextRequest } from "next/server";
 
 export async function POST(req: NextRequest, ctx: { params: Promise<{ runId: string }> }) {

--- a/web/src/app/api/pm/backtests/[runId]/snapshot/route.ts
+++ b/web/src/app/api/pm/backtests/[runId]/snapshot/route.ts
@@ -1,5 +1,4 @@
-import { flowAuthHeaders } from "../../../../_flowAuth";
-import { flowApiBase, proxyJson } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase, proxyJson } from "@/server/flowProxy";
 import { NextRequest } from "next/server";
 
 export async function GET(req: NextRequest, ctx: { params: Promise<{ runId: string }> }) {

--- a/web/src/app/api/pm/portfolio-health/route.ts
+++ b/web/src/app/api/pm/portfolio-health/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { flowAuthHeaders } from "../../_flowAuth";
+import { flowAuthHeaders } from "@/server/flowProxy";
 
 export async function GET() {
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";

--- a/web/src/app/api/public/providers/[provider]/profile/route.ts
+++ b/web/src/app/api/public/providers/[provider]/profile/route.ts
@@ -1,5 +1,4 @@
-import { flowAuthHeaders } from "../../../../_flowAuth";
-import { flowApiBase, proxyJson } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase, proxyJson } from "@/server/flowProxy";
 
 export async function GET(_request: Request, context: { params: Promise<{ provider: string }> }) {
   const { provider } = await context.params;

--- a/web/src/app/api/signals/feed/route.ts
+++ b/web/src/app/api/signals/feed/route.ts
@@ -1,5 +1,4 @@
-import { flowAuthHeaders } from "../../_flowAuth";
-import { flowApiBase, proxyJson, withSearchParams } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase, proxyJson, withSearchParams } from "@/server/flowProxy";
 
 export async function GET(request: Request) {
   const target = withSearchParams(`${flowApiBase()}/signals/feed`, request);

--- a/web/src/app/api/signals/following/route.ts
+++ b/web/src/app/api/signals/following/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { getPlatformAuthHeader } from "../../platform/_session";
+import { flowAuthHeaders } from "@/server/flowProxy";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const params = url.searchParams.toString();
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";
-  const headers = { ...(await getPlatformAuthHeader()) };
+  const headers = { ...flowAuthHeaders(), ...(await getPlatformAuthHeader()) };
   const res = await fetch(`${flowApiBase}/signals/following${params ? `?${params}` : ""}`, {
     cache: "no-store",
     headers,

--- a/web/src/app/api/signals/publish/route.ts
+++ b/web/src/app/api/signals/publish/route.ts
@@ -1,5 +1,4 @@
-import { flowAuthHeaders } from "../../_flowAuth";
-import { flowApiBase, proxyJson } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase, proxyJson } from "@/server/flowProxy";
 
 export async function POST(request: Request) {
   const bodyText = await request.text();

--- a/web/src/app/api/social/following/route.ts
+++ b/web/src/app/api/social/following/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
 import { getPlatformAuthHeader } from "../../platform/_session";
+import { flowAuthHeaders } from "@/server/flowProxy";
 
 export async function GET() {
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";
-  const headers = { ...(await getPlatformAuthHeader()) };
+  const headers = { ...flowAuthHeaders(), ...(await getPlatformAuthHeader()) };
   const res = await fetch(`${flowApiBase}/social/following`, { cache: "no-store", headers });
   const json = await res.json().catch(() => ({}));
   return NextResponse.json(json, { status: res.status });

--- a/web/src/app/api/social/unfollow/route.ts
+++ b/web/src/app/api/social/unfollow/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { getPlatformAuthHeader } from "../../platform/_session";
+import { flowAuthHeaders } from "@/server/flowProxy";
 
 export async function POST(request: Request) {
   const flowApiBase = process.env.FLOW_API_BASE_URL ?? "http://127.0.0.1:8001";
   const bodyText = await request.text();
-  const headers = { "content-type": "application/json", ...(await getPlatformAuthHeader()) };
+  const headers = { "content-type": "application/json", ...flowAuthHeaders(), ...(await getPlatformAuthHeader()) };
   const res = await fetch(`${flowApiBase}/social/unfollow`, {
     method: "POST",
     headers,

--- a/web/src/app/api/strategies/route.ts
+++ b/web/src/app/api/strategies/route.ts
@@ -1,5 +1,4 @@
-import { flowAuthHeaders } from "../_flowAuth";
-import { flowApiBase, proxyJson } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase, proxyJson } from "@/server/flowProxy";
 
 /** Proxy: GET /strategies — list Quant strategy presets from the Flow API. */
 export async function GET() {

--- a/web/src/app/api/studio/price/route.ts
+++ b/web/src/app/api/studio/price/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { flowApiBase } from "@/server/flowProxy";
+import { flowAuthHeaders, flowApiBase } from "@/server/flowProxy";
 
 /**
  * GET /api/studio/price?symbol=BTC/USDT&interval=1h&limit=200
@@ -19,7 +19,7 @@ export async function GET(request: Request) {
     const flowBase = flowApiBase();
     const flowRes = await fetch(
       `${flowBase}/studio/price?symbol=${encodeURIComponent(symbol)}&interval=${interval}&limit=${limit}`,
-      { cache: "no-store", signal: AbortSignal.timeout(3000) },
+      { cache: "no-store", signal: AbortSignal.timeout(3000), headers: { ...flowAuthHeaders() } },
     );
     if (flowRes.ok) {
       const data = await flowRes.json();

--- a/web/src/app/api/traces/route.ts
+++ b/web/src/app/api/traces/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import mockTraces from "@/data/mock-traces.json";
-import { flowApiBase } from "@/server/flowProxy";
-import { flowAuthHeaders } from "../_flowAuth";
+import { flowApiBase, flowAuthHeaders } from "@/server/flowProxy";
 
 /** Live Flow by default. Set USE_MOCK=1 or NEXT_PUBLIC_USE_MOCK=1 to serve bundled demo JSON from /api/traces. */
 function useMockTraces(): boolean {

--- a/web/src/app/control/page.tsx
+++ b/web/src/app/control/page.tsx
@@ -3,10 +3,10 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { NexusSectionHeader } from "@/components/NexusSectionHeader";
+import { dashboardFlowHeaders, getFlowApiOrigin } from "@/lib/flowApiOrigin";
 
 function flowOrigin(): string {
-  const raw = process.env.NEXT_PUBLIC_FLOW_API_BASE_URL?.trim() || "http://127.0.0.1:8001";
-  return raw.replace(/\/$/, "");
+  return getFlowApiOrigin();
 }
 
 type Selftest = {
@@ -93,9 +93,9 @@ export default function ControlCenterPage() {
   function refresh() {
     setError(null);
     Promise.all([
-      fetch(`${base}/capabilities`, { cache: "no-store" }).then((r) => r.json()),
-      fetch(`${base}/ops/selftest`, { cache: "no-store" }).then((r) => r.json()),
-      fetch(`${base}/runtime-settings`, { cache: "no-store" }).then((r) => r.json()),
+      fetch(`${base}/capabilities`, { cache: "no-store", headers: dashboardFlowHeaders() }).then((r) => r.json()),
+      fetch(`${base}/ops/selftest`, { cache: "no-store", headers: dashboardFlowHeaders() }).then((r) => r.json()),
+      fetch(`${base}/runtime-settings`, { cache: "no-store", headers: dashboardFlowHeaders() }).then((r) => r.json()),
     ])
       .then(([c, s, r]) => {
         setCaps(c ?? null);
@@ -125,7 +125,7 @@ export default function ControlCenterPage() {
     try {
       const res = await fetch(`${base}/ops/backtests/quick`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardFlowHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({
           ticker: btTicker,
           n_bars: Number(btBars),
@@ -154,7 +154,7 @@ export default function ControlCenterPage() {
     try {
       const res = await fetch(`${base}/ops/publish/backtest`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardFlowHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({ run_id: publishRunId, confirm: true }),
       });
       const json = await res.json().catch(() => ({}));
@@ -177,7 +177,10 @@ export default function ControlCenterPage() {
     setReceiptsLoading(true);
     setReceipts(null);
     try {
-      const res = await fetch(`${base}/backtests/${encodeURIComponent(rid)}/iterations?limit=300`, { cache: "no-store" });
+      const res = await fetch(`${base}/backtests/${encodeURIComponent(rid)}/iterations?limit=300`, {
+        cache: "no-store",
+        headers: dashboardFlowHeaders(),
+      });
       const json = await res.json().catch(() => ({}));
       if (!res.ok) {
         throw new Error(json?.detail || json?.error || `Failed to load receipts (${res.status})`);
@@ -196,7 +199,7 @@ export default function ControlCenterPage() {
     try {
       const res = await fetch(`${base}/runtime-settings/harness-memory`, {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardFlowHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({
           harness_memory: {
             recent_views_max: Number(hmViews),

--- a/web/src/app/p/[provider]/page.tsx
+++ b/web/src/app/p/[provider]/page.tsx
@@ -53,11 +53,7 @@ export default function PublicProviderPage({ params }: { params: { provider: str
   }, [provider]);
 
   const sseUrl = useMemo(() => {
-    const base = (process.env.NEXT_PUBLIC_FLOW_API_BASE_URL || "http://127.0.0.1:8001").replace(
-      /\/$/,
-      "",
-    );
-    return `${base}/signals/stream?provider=${encodeURIComponent(provider)}&poll_sec=1&limit=30`;
+    return `/api/flow/signals/stream?provider=${encodeURIComponent(provider)}&poll_sec=1&limit=30`;
   }, [provider]);
 
   useEffect(() => {

--- a/web/src/components/LivePaperControls.tsx
+++ b/web/src/components/LivePaperControls.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { getFlowApiOrigin } from "@/lib/flowApiOrigin";
+import { dashboardFlowHeaders, getFlowApiOrigin } from "@/lib/flowApiOrigin";
 import { useNowSec } from "@/hooks/useNowSec";
 import {
   formatCountdown,
@@ -84,7 +84,10 @@ export function LivePaperControls({
 
   const refreshBook = useCallback(async () => {
     try {
-      const res = await fetch(`${getFlowApiOrigin()}/engine/paper/book`, { cache: "no-store" });
+      const res = await fetch(`${getFlowApiOrigin()}/engine/paper/book`, {
+        cache: "no-store",
+        headers: dashboardFlowHeaders(),
+      });
       if (!res.ok) return;
       setBook((await res.json()) as PaperBook);
     } catch {
@@ -94,7 +97,10 @@ export function LivePaperControls({
 
   const refresh = useCallback(async () => {
     try {
-      const res = await fetch(`${getFlowApiOrigin()}/engine/paper/status`, { cache: "no-store" });
+      const res = await fetch(`${getFlowApiOrigin()}/engine/paper/status`, {
+        cache: "no-store",
+        headers: dashboardFlowHeaders(),
+      });
       const data = (await res.json().catch(() => ({}))) as PaperStatus;
       if (!res.ok) {
         setErr(typeof data.detail === "string" ? data.detail : "Status failed");
@@ -142,7 +148,7 @@ export function LivePaperControls({
     try {
       const res = await fetch(`${getFlowApiOrigin()}/engine/paper/start`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: dashboardFlowHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({ ticker, interval_sec: intervalSec }),
       });
       const data = (await res.json().catch(() => ({}))) as PaperStatus;
@@ -170,7 +176,10 @@ export function LivePaperControls({
     setBusy(true);
     setErr(null);
     try {
-      const res = await fetch(`${getFlowApiOrigin()}/engine/paper/stop`, { method: "POST" });
+      const res = await fetch(`${getFlowApiOrigin()}/engine/paper/stop`, {
+        method: "POST",
+        headers: dashboardFlowHeaders(),
+      });
       const data = (await res.json().catch(() => ({}))) as PaperStatus;
       if (!res.ok) {
         setErr(data.detail || "Stop failed");

--- a/web/src/features/monitor/components/LiveMonitorPanel.tsx
+++ b/web/src/features/monitor/components/LiveMonitorPanel.tsx
@@ -255,7 +255,7 @@ export function LiveMonitorPanel({
     try {
       const res = await fetch(`${getFlowApiOrigin()}/engine/paper/book/reset`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-aimm-dashboard": "1" },
         body: JSON.stringify({}),
       });
       const data = (await res.json().catch(() => ({}))) as { detail?: string };

--- a/web/src/hooks/useNexusPayload.ts
+++ b/web/src/hooks/useNexusPayload.ts
@@ -6,27 +6,9 @@ import type { NexusPayload } from "@/types/nexus-payload";
 import mockTraces from "@/data/mock-traces.json";
 import { getFlowApiOrigin } from "@/lib/flowApiOrigin";
 
-function resolveFlowWsUrl(runId: string): string {
-  const rid = (runId || "latest").trim() || "latest";
-  const explicit = process.env.NEXT_PUBLIC_FLOW_WS_URL?.trim();
-  if (explicit) {
-    if (explicit.includes("/ws/runs/")) {
-      return explicit.replace(/\/ws\/runs\/[^/?#]+/, `/ws/runs/${encodeURIComponent(rid)}`);
-    }
-    if (explicit.includes("/ws/")) {
-      const base = explicit.replace(/\/$/, "");
-      return `${base.replace(/\/ws\/.*$/, "")}/ws/runs/${encodeURIComponent(rid)}`;
-    }
-    return `${explicit.replace(/\/$/, "")}/ws/runs/${encodeURIComponent(rid)}`;
-  }
-
-  const apiBase = process.env.NEXT_PUBLIC_FLOW_API_BASE_URL?.trim();
-  if (apiBase) {
-    const wsBase = apiBase.replace(/^http:\/\//, "ws://").replace(/^https:\/\//, "wss://");
-    return `${wsBase.replace(/\/$/, "")}/ws/runs/${encodeURIComponent(rid)}`;
-  }
-
-  return `ws://127.0.0.1:8001/ws/runs/${encodeURIComponent(rid)}`;
+function livePayloadUrl(followId: string): string {
+  if (followId === "latest") return "/api/traces";
+  return `${getFlowApiOrigin()}/runs/${encodeURIComponent(followId)}/payload?soft=true`;
 }
 
 /**
@@ -58,10 +40,7 @@ export function useNexusPayload(runId: string = "latest") {
     }
 
     setLoading(true);
-    const httpUrl =
-      followId === "latest"
-        ? "/api/traces"
-        : `${getFlowApiOrigin()}/runs/${encodeURIComponent(followId)}/payload?soft=true`;
+    const httpUrl = livePayloadUrl(followId);
 
     fetchNexusPayloadWithSource(httpUrl)
       .then(({ payload: data, dataSource }) => {
@@ -92,66 +71,29 @@ export function useNexusPayload(runId: string = "latest") {
     if (useMock) return;
 
     let closed = false;
-    let socket: WebSocket | null = null;
-    let reconnectTimer: number | null = null;
-    const wsEndpoint = resolveFlowWsUrl(followId);
-    let attempt = 0;
+    const httpUrl = livePayloadUrl(followId);
 
-    const cleanup = () => {
-      if (reconnectTimer) {
-        window.clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
-      if (socket) socket.close();
-      socket = null;
-    };
-
-    const connect = () => {
+    const tick = () => {
       if (closed) return;
-      cleanup();
-      socket = new WebSocket(wsEndpoint);
-
-      socket.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data) as {
-            type?: string;
-            payload?: NexusPayload;
-          };
-          if (data.type === "payload" && data.payload) {
-            setPayload(data.payload);
-            setTraceDataSource("live");
-            setLoading(false);
-            setError(null);
-          }
-        } catch (e) {
-          setError(e instanceof Error ? e : new Error(String(e)));
-        }
-      };
-
-      socket.onopen = () => {
-        attempt = 0;
-        setWsConnected(true);
-      };
-
-      socket.onclose = () => {
-        setWsConnected(false);
-        if (closed) return;
-        const delay = Math.min(8000, 400 * 2 ** attempt);
-        attempt = Math.min(attempt + 1, 6);
-        reconnectTimer = window.setTimeout(connect, delay);
-      };
-
-      socket.onerror = () => {
-        // Reconnect via onclose
-      };
+      fetchNexusPayloadWithSource(httpUrl)
+        .then(({ payload: data, dataSource }) => {
+          if (closed) return;
+          setPayload(data);
+          setTraceDataSource(dataSource ?? "live");
+          setError(null);
+          setWsConnected(true);
+          setLoading(false);
+        })
+        .catch(() => {
+          if (!closed) setWsConnected(false);
+        });
     };
 
-    connect();
-
+    const interval = window.setInterval(tick, 1000);
     return () => {
       closed = true;
       setWsConnected(false);
-      cleanup();
+      window.clearInterval(interval);
     };
   }, [followId]);
 

--- a/web/src/lib/api/traces.ts
+++ b/web/src/lib/api/traces.ts
@@ -33,7 +33,10 @@ export async function fetchNexusPayloadWithSource(
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      const res = await fetch(url, { cache: "no-store" });
+      const res = await fetch(url, {
+        cache: "no-store",
+        headers: url.includes("/api/flow") ? { "x-aimm-dashboard": "1" } : undefined,
+      });
       if (res.ok) {
         const dataSource = res.headers.get("x-flow-data-source");
         const payload = (await res.json()) as NexusPayload;

--- a/web/src/lib/flowApiOrigin.ts
+++ b/web/src/lib/flowApiOrigin.ts
@@ -1,9 +1,14 @@
-/**
- * Origin for direct browser → Flow API calls (backtests, equity series, etc.).
- * FastAPI enables CORS in `flow_stream_server.py`. Static export cannot ship
- * dynamic Next API routes; set `NEXT_PUBLIC_FLOW_API_BASE_URL` when the UI and API differ.
- */
 export function getFlowApiOrigin(): string {
-  const raw = process.env.NEXT_PUBLIC_FLOW_API_BASE_URL?.trim() || "http://127.0.0.1:8001";
+  if (typeof window !== "undefined") {
+    return "/api/flow";
+  }
+  const raw =
+    process.env.FLOW_API_BASE_URL?.trim() ||
+    process.env.NEXT_PUBLIC_FLOW_API_BASE_URL?.trim() ||
+    "http://127.0.0.1:8001";
   return raw.replace(/\/$/, "");
+}
+
+export function dashboardFlowHeaders(extra?: HeadersInit): HeadersInit {
+  return { "x-aimm-dashboard": "1", ...(extra ?? {}) };
 }

--- a/web/src/server/flowProxy.ts
+++ b/web/src/server/flowProxy.ts
@@ -8,19 +8,17 @@ type ProxyOptions = {
   fallbackJson?: Record<string, unknown>;
 };
 
-/**
- * Base URL for Next.js **server** routes when proxying to Flow (FastAPI).
- *
- * Prefer `FLOW_API_BASE_URL` (e.g. `http://api:8001` in Docker). If unset, use
- * `NEXT_PUBLIC_FLOW_API_BASE_URL` so local `npm run dev` works when only the public
- * var is set in `web/.env.local`.
- */
 export function flowApiBase(): string {
   const raw =
     process.env.FLOW_API_BASE_URL?.trim() ||
     process.env.NEXT_PUBLIC_FLOW_API_BASE_URL?.trim() ||
     "http://127.0.0.1:8001";
   return raw.replace(/\/$/, "");
+}
+
+export function flowAuthHeaders(): Record<string, string> {
+  const key = (process.env["AIMM_API_KEY"] ?? "").trim();
+  return key ? { "x-api-key": key } : {};
 }
 
 export function proxyUnreachable(fallbackJson: Record<string, unknown>) {
@@ -34,7 +32,7 @@ export async function proxyJson(targetUrl: string, opts: ProxyOptions = {}) {
   try {
     const res = await fetch(targetUrl, {
       method: opts.method,
-      headers: opts.headers,
+      headers: { ...flowAuthHeaders(), ...opts.headers },
       body: opts.body,
       cache: opts.cache ?? "no-store",
     });


### PR DESCRIPTION
## Summary

Enforce Flow API auth and generate unique keys on first boot

## Motivation

Enforce the key for endpoints to secure the app locally or hosting.

## How to Test

uv run pre-commit run --all-files
uv run ruff format --check .
uv run ruff check .

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (add `--runslow` if you touched slow tests)
- [x] Documentation updated if behavior or public API changed
- [x] No API keys or secrets committed